### PR TITLE
fix(seed): use guzzle client to retrieve contents of external pages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
-name: tests
+name: Tests
 
-on:
-  push:
-    branches: [ '**' ]
+on: push
 
 jobs:
   laravel-tests:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Tests
 on: push
 
 jobs:
-  laravel-tests:
+  test:
 
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-<a href="https://github.com/AnimeThemes/animethemes-server/actions"><img src="https://github.com/AnimeThemes/animethemes-server/workflows/tests/badge.svg?branch=wiki" alt="tests"></a>
+<a href="https://github.com/AnimeThemes/animethemes-server/actions"><img src="https://github.com/AnimeThemes/animethemes-server/workflows/test/badge.svg?branch=wiki" alt="tests"></a>
 <a href="https://github.styleci.io/repos/111264405?branch=wiki"><img src="https://github.styleci.io/repos/111264405/shield?branch=wiki" alt="StyleCI"></a>
 <a href="https://discordapp.com/invite/m9zbVyQ"><img src="https://img.shields.io/discord/354388306580078594.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2"></a>
 <a href="https://github.com/AnimeThemes/animethemes-server/blob/wiki/LICENSE"><img src="https://img.shields.io/github/license/AnimeThemes/animethemes-server"></a>

--- a/composer.lock
+++ b/composer.lock
@@ -64,16 +64,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.175.3",
+            "version": "3.176.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "836564a2cef648e60fee63d3f9c5a74757aa3217"
+                "reference": "0713d48ba190cf49486e1cd95cd2def25ef4c80e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/836564a2cef648e60fee63d3f9c5a74757aa3217",
-                "reference": "836564a2cef648e60fee63d3f9c5a74757aa3217",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/0713d48ba190cf49486e1cd95cd2def25ef4c80e",
+                "reference": "0713d48ba190cf49486e1cd95cd2def25ef4c80e",
                 "shasum": ""
             },
             "require": {
@@ -148,9 +148,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.175.3"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.176.0"
             },
-            "time": "2021-03-24T18:14:18+00:00"
+            "time": "2021-03-25T18:17:15+00:00"
         },
         {
             "name": "babenkoivan/elastic-adapter",
@@ -1287,16 +1287,16 @@
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "1.4.5",
+            "version": "1.4.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "f28d44c286812c714741478d968104c5e604a1d4"
+                "reference": "f27e06cd9675801df441b3656569b328e04aa37c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/f28d44c286812c714741478d968104c5e604a1d4",
-                "reference": "f28d44c286812c714741478d968104c5e604a1d4",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/f27e06cd9675801df441b3656569b328e04aa37c",
+                "reference": "f27e06cd9675801df441b3656569b328e04aa37c",
                 "shasum": ""
             },
             "require": {
@@ -1304,7 +1304,8 @@
                 "psr/log": "^1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || 6.5 - 8"
+                "phpstan/phpstan": "^0.12.55",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
             },
             "type": "library",
             "autoload": {
@@ -1330,7 +1331,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/xdebug-handler/issues",
-                "source": "https://github.com/composer/xdebug-handler/tree/1.4.5"
+                "source": "https://github.com/composer/xdebug-handler/tree/1.4.6"
             },
             "funding": [
                 {
@@ -1346,7 +1347,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-13T08:04:11+00:00"
+            "time": "2021-03-25T17:01:18+00:00"
         },
         {
             "name": "cyrildewit/eloquent-viewable",
@@ -4338,16 +4339,16 @@
         },
         {
             "name": "laravel/jetstream",
-            "version": "v2.2.4",
+            "version": "v2.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/jetstream.git",
-                "reference": "d20cd9bf3267aaffa0359ad97be03b2f43532adf"
+                "reference": "e05018b39d7f5ef7ef19af6ba8244e89c2402aab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/jetstream/zipball/d20cd9bf3267aaffa0359ad97be03b2f43532adf",
-                "reference": "d20cd9bf3267aaffa0359ad97be03b2f43532adf",
+                "url": "https://api.github.com/repos/laravel/jetstream/zipball/e05018b39d7f5ef7ef19af6ba8244e89c2402aab",
+                "reference": "e05018b39d7f5ef7ef19af6ba8244e89c2402aab",
                 "shasum": ""
             },
             "require": {
@@ -4401,7 +4402,7 @@
                 "issues": "https://github.com/laravel/jetstream/issues",
                 "source": "https://github.com/laravel/jetstream"
             },
-            "time": "2021-03-23T17:23:07+00:00"
+            "time": "2021-03-25T10:42:54+00:00"
         },
         {
             "name": "laravel/nova",

--- a/database/seeders/AnimeResourceSeeder.php
+++ b/database/seeders/AnimeResourceSeeder.php
@@ -23,13 +23,11 @@ class AnimeResourceSeeder extends Seeder
             sleep(rand(5, 15));
 
             // Get JSON of Year page content
-            $year_wiki_contents = file_get_contents($year_page);
-            $year_wiki_json = json_decode($year_wiki_contents);
-            $year_wiki_content_md = $year_wiki_json->data->content_md;
+            $year_wiki_contents = WikiPages::getPageContents($year_page);
 
             // Match headers of Anime and links of Resources
             // Format: "###[{Anime Name}]({Resource Link})"
-            preg_match_all('/###\[(.*)\]\((https\:\/\/.*)\)/m', $year_wiki_content_md, $anime_resource_wiki_entries, PREG_SET_ORDER);
+            preg_match_all('/###\[(.*)\]\((https\:\/\/.*)\)/m', $year_wiki_contents, $anime_resource_wiki_entries, PREG_SET_ORDER);
 
             foreach ($anime_resource_wiki_entries as $anime_resource_wiki_entry) {
                 $anime_name = html_entity_decode($anime_resource_wiki_entry[1]);

--- a/database/seeders/AnimeSeasonSeeder.php
+++ b/database/seeders/AnimeSeasonSeeder.php
@@ -23,12 +23,10 @@ class AnimeSeasonSeeder extends Seeder
             sleep(rand(5, 15));
 
             // Get JSON of Year page content
-            $year_wiki_contents = file_get_contents($year_page);
-            $year_wiki_json = json_decode($year_wiki_contents);
-            $year_wiki_content_md = $year_wiki_json->data->content_md;
+            $year_wiki_contents = WikiPages::getPageContents($year_page);
 
             // We want to proceed line by line
-            preg_match_all('/^(.*)$/m', $year_wiki_content_md, $anime_season_wiki_entries, PREG_SET_ORDER);
+            preg_match_all('/^(.*)$/m', $year_wiki_contents, $anime_season_wiki_entries, PREG_SET_ORDER);
 
             // The current year and season
             $year = $years[0];

--- a/database/seeders/AnimeSeeder.php
+++ b/database/seeders/AnimeSeeder.php
@@ -17,13 +17,11 @@ class AnimeSeeder extends Seeder
     public function run()
     {
         // Get JSON of Anime Index page content
-        $anime_wiki_contents = file_get_contents(WikiPages::ANIME_INDEX);
-        $anime_wiki_json = json_decode($anime_wiki_contents);
-        $anime_wiki_content_md = $anime_wiki_json->data->content_md;
+        $anime_wiki_contents = WikiPages::getPageContents(WikiPages::ANIME_INDEX);
 
         // Match Anime Entries
         // Format: "[{Anime Name} ({Year})](/r/AnimeThemes/wiki/{year}#{anchor link})"
-        preg_match_all('/\[(.*)\s\((.*)\)\]\(\/r\/AnimeThemes\/wiki\/.*\)/m', $anime_wiki_content_md, $anime_wiki_entries, PREG_SET_ORDER);
+        preg_match_all('/\[(.*)\s\((.*)\)\]\(\/r\/AnimeThemes\/wiki\/.*\)/m', $anime_wiki_contents, $anime_wiki_entries, PREG_SET_ORDER);
 
         foreach ($anime_wiki_entries as $anime_wiki_entry) {
             $anime_name = html_entity_decode($anime_wiki_entry[1]);

--- a/database/seeders/AnimeThemeSeeder.php
+++ b/database/seeders/AnimeThemeSeeder.php
@@ -29,12 +29,10 @@ class AnimeThemeSeeder extends Seeder
             sleep(rand(5, 15));
 
             // Get JSON of Year page content
-            $year_wiki_contents = file_get_contents($year_page);
-            $year_wiki_json = json_decode($year_wiki_contents);
-            $year_wiki_content_md = $year_wiki_json->data->content_md;
+            $year_wiki_contents = WikiPages::getPageContents($year_page);
 
             // We want to proceed line by line
-            preg_match_all('/^(.*)$/m', $year_wiki_content_md, $anime_theme_wiki_entries, PREG_SET_ORDER);
+            preg_match_all('/^(.*)$/m', $year_wiki_contents, $anime_theme_wiki_entries, PREG_SET_ORDER);
 
             // The current Anime & Group
             $season = null;

--- a/database/seeders/ArtistCoverSeeder.php
+++ b/database/seeders/ArtistCoverSeeder.php
@@ -13,7 +13,6 @@ use Illuminate\Database\Seeder;
 use Illuminate\Http\Testing\File;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
-use Illuminate\Support\Str;
 
 class ArtistCoverSeeder extends Seeder
 {

--- a/database/seeders/ArtistCoverSeeder.php
+++ b/database/seeders/ArtistCoverSeeder.php
@@ -75,8 +75,9 @@ class ArtistCoverSeeder extends Seeder
 
                     // Create large cover image
                     if (! is_null($anilist_cover_large) && is_null($artist_cover_large)) {
-                        $cover_image = file_get_contents($anilist_cover_large);
-                        $cover_file = File::createWithContent(Str::random(40).'.png', $cover_image);
+                        $cover_image_response = $client->get($anilist_cover_large);
+                        $cover_image = $cover_image_response->getBody()->getContents();
+                        $cover_file = File::createWithContent(basename($anilist_cover_large), $cover_image);
                         $cover_large = $fs->putFile('', $cover_file);
 
                         $cover_large_image = Image::create([
@@ -91,8 +92,9 @@ class ArtistCoverSeeder extends Seeder
 
                     // Create small cover image
                     if (! is_null($anilist_cover_small) && is_null($artist_cover_small)) {
-                        $cover_image = file_get_contents($anilist_cover_small);
-                        $cover_file = File::createWithContent(Str::random(40).'.png', $cover_image);
+                        $cover_image_response = $client->get($anilist_cover_small);
+                        $cover_image = $cover_image_response->getBody()->getContents();
+                        $cover_file = File::createWithContent(basename($anilist_cover_small), $cover_image);
                         $cover_small = $fs->putFile('', $cover_file);
 
                         $cover_small_image = Image::create([

--- a/database/seeders/ArtistSeeder.php
+++ b/database/seeders/ArtistSeeder.php
@@ -18,13 +18,11 @@ class ArtistSeeder extends Seeder
     public function run()
     {
         // Get JSON of Artist Index page content
-        $artist_wiki_contents = file_get_contents(WikiPages::ARTIST_INDEX);
-        $artist_wiki_json = json_decode($artist_wiki_contents);
-        $artist_wiki_content_md = $artist_wiki_json->data->content_md;
+        $artist_wiki_contents = WikiPages::getPageContents(WikiPages::ARTIST_INDEX);
 
         // Match Artist Entries
         // Format: "[{Artist Name}](/r/AnimeThemes/wiki/artist/{Artist Slug}/)"
-        preg_match_all('/\[(.*)\]\(\/r\/AnimeThemes\/wiki\/artist\/(.*)\)/m', $artist_wiki_content_md, $artist_wiki_entries, PREG_SET_ORDER);
+        preg_match_all('/\[(.*)\]\(\/r\/AnimeThemes\/wiki\/artist\/(.*)\)/m', $artist_wiki_contents, $artist_wiki_entries, PREG_SET_ORDER);
 
         foreach ($artist_wiki_entries as $artist_wiki_entry) {
             $artist_name = html_entity_decode($artist_wiki_entry[1]);
@@ -45,13 +43,11 @@ class ArtistSeeder extends Seeder
 
             // Get JSON of Artist Entry page content
             $artist_link = WikiPages::getArtistPage($artist_slug);
-            $artist_resource_wiki_contents = file_get_contents($artist_link);
-            $artist_resource_wiki_json = json_decode($artist_resource_wiki_contents);
-            $artist_resource_wiki_content_md = $artist_resource_wiki_json->data->content_md;
+            $artist_resource_wiki_contents = WikiPages::getPageContents($artist_link);
 
             // Match headers of Resource in Artist Entry page
             // Format: "##[{Artist Name}]({Resource Link})"
-            preg_match('/##\[.*\]\((https\:\/\/.*)\)/m', $artist_resource_wiki_content_md, $artist_resource_entry);
+            preg_match('/##\[.*\]\((https\:\/\/.*)\)/m', $artist_resource_wiki_contents, $artist_resource_entry);
             $artist_resource_link = html_entity_decode($artist_resource_entry[1]);
             preg_match('/([0-9]+)/', $artist_resource_link, $external_id);
             $resource_site = ResourceSite::valueOf($artist_resource_link);

--- a/database/seeders/ArtistSongSeeder.php
+++ b/database/seeders/ArtistSongSeeder.php
@@ -20,13 +20,11 @@ class ArtistSongSeeder extends Seeder
     public function run()
     {
         // Get JSON of Artist Index page content
-        $artist_wiki_contents = file_get_contents(WikiPages::ARTIST_INDEX);
-        $artist_wiki_json = json_decode($artist_wiki_contents);
-        $artist_wiki_content_md = $artist_wiki_json->data->content_md;
+        $artist_wiki_contents = WikiPages::getPageContents(WikiPages::ARTIST_INDEX);
 
         // Match Artist Entries
         // Format: "[{Artist Name}](/r/AnimeThemes/wiki/artist/{Artist Slug}/)"
-        preg_match_all('/\[(.*)\]\(\/r\/AnimeThemes\/wiki\/artist\/(.*)\)/m', $artist_wiki_content_md, $artist_wiki_entries, PREG_SET_ORDER);
+        preg_match_all('/\[(.*)\]\(\/r\/AnimeThemes\/wiki\/artist\/(.*)\)/m', $artist_wiki_contents, $artist_wiki_entries, PREG_SET_ORDER);
 
         foreach ($artist_wiki_entries as $artist_wiki_entry) {
             $artist_name = html_entity_decode($artist_wiki_entry[1]);
@@ -42,12 +40,10 @@ class ArtistSongSeeder extends Seeder
 
             // Get JSON of Artist Entry page content
             $artist_link = WikiPages::getArtistPage($artist_slug);
-            $artist_song_wiki_contents = file_get_contents($artist_link);
-            $artist_song_wiki_json = json_decode($artist_song_wiki_contents);
-            $artist_song_wiki_content_md = $artist_song_wiki_json->data->content_md;
+            $artist_song_wiki_contents = WikiPages::getPageContents($artist_link);
 
             // We want to proceed line by line
-            preg_match_all('/^(.*)$/m', $artist_song_wiki_content_md, $artist_song_wiki_entries, PREG_SET_ORDER);
+            preg_match_all('/^(.*)$/m', $artist_song_wiki_contents, $artist_song_wiki_entries, PREG_SET_ORDER);
 
             // The current Anime
             $anime = null;

--- a/database/seeders/SeriesSeeder.php
+++ b/database/seeders/SeriesSeeder.php
@@ -17,13 +17,11 @@ class SeriesSeeder extends Seeder
     public function run()
     {
         // Get JSON of Series Index page content
-        $series_wiki_contents = file_get_contents(WikiPages::SERIES_INDEX);
-        $series_wiki_json = json_decode($series_wiki_contents);
-        $series_wiki_content_md = $series_wiki_json->data->content_md;
+        $series_wiki_contents = WikiPages::getPageContents(WikiPages::SERIES_INDEX);
 
         // Match Series Entries
         // Format: "[{Series Name}](/r/AnimeThemes/wiki/series/{Series Slug}/)
-        preg_match_all('/\[(.*)\]\(\/r\/AnimeThemes\/wiki\/series\/(.*)\)/m', $series_wiki_content_md, $series_wiki_entries, PREG_SET_ORDER);
+        preg_match_all('/\[(.*)\]\(\/r\/AnimeThemes\/wiki\/series\/(.*)\)/m', $series_wiki_contents, $series_wiki_entries, PREG_SET_ORDER);
 
         foreach ($series_wiki_entries as $series_wiki_entry) {
             $series_name = html_entity_decode($series_wiki_entry[1]);
@@ -44,13 +42,11 @@ class SeriesSeeder extends Seeder
 
             // Get JSON of Series Entry page content
             $series_link = WikiPages::getSeriesPage($series_slug);
-            $series_anime_wiki_contents = file_get_contents($series_link);
-            $series_anime_wiki_json = json_decode($series_anime_wiki_contents);
-            $series_anime_wiki_content_md = $series_anime_wiki_json->data->content_md;
+            $series_anime_wiki_contents = WikiPages::getPageContents($series_link);
 
             // Match headers of Anime in Series Entry page
             // Format: "###[{Anime Name}]({Resource Link})"
-            preg_match_all('/###\[(.*)\]\(https\:\/\/.*\)/m', $series_anime_wiki_content_md, $series_anime_wiki_entries, PREG_PATTERN_ORDER);
+            preg_match_all('/###\[(.*)\]\(https\:\/\/.*\)/m', $series_anime_wiki_contents, $series_anime_wiki_entries, PREG_PATTERN_ORDER);
             $series_anime_names = array_map(function ($series_anime_wiki_entry) {
                 return html_entity_decode($series_anime_wiki_entry);
             }, $series_anime_wiki_entries[1]);

--- a/database/seeders/SynopsisCoverSeeder.php
+++ b/database/seeders/SynopsisCoverSeeder.php
@@ -84,13 +84,15 @@ class SynopsisCoverSeeder extends Seeder
 
                     // Create large cover image
                     if (! is_null($anilist_cover_large) && is_null($anime_cover_large)) {
-                        $cover_image = file_get_contents($anilist_cover_large);
-                        $cover_file = File::createWithContent(Str::random(40).'.png', $cover_image);
+                        $cover_image_response = $client->get($anilist_cover_large);
+                        $cover_image = $cover_image_response->getBody()->getContents();
+                        $cover_file = File::createWithContent(basename($anilist_cover_large), $cover_image);
                         $cover_large = $fs->putFile('', $cover_file);
 
                         $cover_large_image = Image::create([
                             'facet' => ImageFacet::COVER_LARGE,
                             'path' => $cover_large,
+                            //'contentType =>
                         ]);
 
                         // Attach large cover to anime
@@ -100,8 +102,9 @@ class SynopsisCoverSeeder extends Seeder
 
                     // Create small cover image
                     if (! is_null($anilist_cover_small) && is_null($anime_cover_small)) {
-                        $cover_image = file_get_contents($anilist_cover_small);
-                        $cover_file = File::createWithContent(Str::random(40).'.png', $cover_image);
+                        $cover_image_response = $client->get($anilist_cover_small);
+                        $cover_image = $cover_image_response->getBody()->getContents();
+                        $cover_file = File::createWithContent(basename($anilist_cover_small), $cover_image);
                         $cover_small = $fs->putFile('', $cover_file);
 
                         $cover_small_image = Image::create([

--- a/database/seeders/SynopsisCoverSeeder.php
+++ b/database/seeders/SynopsisCoverSeeder.php
@@ -13,7 +13,6 @@ use Illuminate\Database\Seeder;
 use Illuminate\Http\Testing\File;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
-use Illuminate\Support\Str;
 
 class SynopsisCoverSeeder extends Seeder
 {

--- a/database/seeders/VideoSeeder.php
+++ b/database/seeders/VideoSeeder.php
@@ -82,7 +82,7 @@ class VideoSeeder extends Seeder
      */
     protected function handleFailedDeletion(Video $video)
     {
-        Log::error("Video '{$delete_video->basename}' was not deleted");
+        Log::error("Video '{$video->basename}' was not deleted");
     }
 
     /**

--- a/database/seeders/VideoTagsSeeder.php
+++ b/database/seeders/VideoTagsSeeder.php
@@ -25,13 +25,11 @@ class VideoTagsSeeder extends Seeder
             sleep(rand(5, 15));
 
             // Get JSON of Year page content
-            $year_wiki_contents = file_get_contents($video_page);
-            $year_wiki_json = json_decode($year_wiki_contents);
-            $year_wiki_content_md = $year_wiki_json->data->content_md;
+            $year_wiki_contents = WikiPages::getPageContents($video_page);
 
             // Match Tags and basename of Videos
             // Format: "[Webm ({Tag 1, Tag 2, Tag 3...})]({Video Link})
-            preg_match_all('/\[Webm.*\((.*)\)\]\(https\:\/\/animethemes\.moe\/video\/(.*)\)|\[Webm\]\(https\:\/\/animethemes\.moe\/video\/(.*)\)/m', $year_wiki_content_md, $video_wiki_entries, PREG_SET_ORDER);
+            preg_match_all('/\[Webm.*\((.*)\)\]\(https\:\/\/animethemes\.moe\/video\/(.*)\)|\[Webm\]\(https\:\/\/animethemes\.moe\/video\/(.*)\)/m', $year_wiki_contents, $video_wiki_entries, PREG_SET_ORDER);
 
             foreach ($video_wiki_entries as $video_wiki_entry) {
                 // Video tags are potentially inconsistent so we make an effort for uniformity

--- a/database/seeders/WikiPages.php
+++ b/database/seeders/WikiPages.php
@@ -2,7 +2,11 @@
 
 namespace Database\Seeders;
 
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ServerException;
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Log;
 
 class WikiPages
 {
@@ -86,5 +90,31 @@ class WikiPages
             ->append($slug)
             ->append('.json')
             ->__toString();
+    }
+
+    /**
+     * Get contents of reddit wiki page.
+     *
+     * @param string $page
+     * @return mixed
+     */
+    public static function getPageContents(string $page)
+    {
+        try {
+            $client = new Client;
+
+            $response = $client->post($page);
+
+            $contents = json_decode($response->getBody()->getContents());
+
+            return $contents->data->content_md;
+        } catch (ClientException $e) {
+            // We may be requesting an invalid Reddit page
+            Log::info($e->getMessage());
+        } catch (ServerException $e) {
+            // We may have upset Reddit
+            Log::info($e->getMessage());
+            abort(500);
+        }
     }
 }

--- a/database/seeders/WikiPages.php
+++ b/database/seeders/WikiPages.php
@@ -5,8 +5,8 @@ namespace Database\Seeders;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\ServerException;
-use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 
 class WikiPages
 {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2045,9 +2045,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "14.14.35",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.35.tgz",
-            "integrity": "sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==",
+            "version": "14.14.36",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.36.tgz",
+            "integrity": "sha512-kjivUwDJfIjngzbhooRnOLhGYz6oRFi+L+EpMjxroDYXwDw9lHrJJ43E+dJ6KAd3V3WxWAJ/qZE9XKYHhjPOFQ==",
             "dev": true
         },
         "node_modules/@types/parse-glob": {
@@ -5112,9 +5112,9 @@
             "dev": true
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.3.699",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.699.tgz",
-            "integrity": "sha512-fjt43CPXdPYwD9ybmKbNeLwZBmCVdLY2J5fGZub7/eMPuiqQznOGNXv/wurnpXIlE7ScHnvG9Zi+H4/i6uMKmw==",
+            "version": "1.3.700",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.700.tgz",
+            "integrity": "sha512-wQtaxVZzpOeCjW1CGuC5W3bYjE2jglvk076LcTautBOB9UtHztty7wNzjVsndiMcSsdUsdMy5w76w5J1U7OPTQ==",
             "dev": true
         },
         "node_modules/elliptic": {
@@ -13858,9 +13858,9 @@
             }
         },
         "node_modules/sockjs-client": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.5.0.tgz",
-            "integrity": "sha512-8Dt3BDi4FYNrCFGTL/HtwVzkARrENdwOUf1ZoW/9p3M8lZdFT35jVdrHza+qgxuG9H3/shR4cuX/X9umUrjP8Q==",
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.5.1.tgz",
+            "integrity": "sha512-VnVAb663fosipI/m6pqRXakEOw7nvd7TUgdr3PlR/8V2I95QIdwT8L4nMxhyU8SmDBHYXU1TOElaKOmKLfYzeQ==",
             "dev": true,
             "dependencies": {
                 "debug": "^3.2.6",
@@ -13868,7 +13868,7 @@
                 "faye-websocket": "^0.11.3",
                 "inherits": "^2.0.4",
                 "json3": "^3.3.3",
-                "url-parse": "^1.4.7"
+                "url-parse": "^1.5.1"
             }
         },
         "node_modules/sockjs-client/node_modules/debug": {
@@ -17406,9 +17406,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "14.14.35",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.35.tgz",
-            "integrity": "sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==",
+            "version": "14.14.36",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.36.tgz",
+            "integrity": "sha512-kjivUwDJfIjngzbhooRnOLhGYz6oRFi+L+EpMjxroDYXwDw9lHrJJ43E+dJ6KAd3V3WxWAJ/qZE9XKYHhjPOFQ==",
             "dev": true
         },
         "@types/parse-glob": {
@@ -19917,9 +19917,9 @@
             "dev": true
         },
         "electron-to-chromium": {
-            "version": "1.3.699",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.699.tgz",
-            "integrity": "sha512-fjt43CPXdPYwD9ybmKbNeLwZBmCVdLY2J5fGZub7/eMPuiqQznOGNXv/wurnpXIlE7ScHnvG9Zi+H4/i6uMKmw==",
+            "version": "1.3.700",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.700.tgz",
+            "integrity": "sha512-wQtaxVZzpOeCjW1CGuC5W3bYjE2jglvk076LcTautBOB9UtHztty7wNzjVsndiMcSsdUsdMy5w76w5J1U7OPTQ==",
             "dev": true
         },
         "elliptic": {
@@ -26782,9 +26782,9 @@
             }
         },
         "sockjs-client": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.5.0.tgz",
-            "integrity": "sha512-8Dt3BDi4FYNrCFGTL/HtwVzkARrENdwOUf1ZoW/9p3M8lZdFT35jVdrHza+qgxuG9H3/shR4cuX/X9umUrjP8Q==",
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.5.1.tgz",
+            "integrity": "sha512-VnVAb663fosipI/m6pqRXakEOw7nvd7TUgdr3PlR/8V2I95QIdwT8L4nMxhyU8SmDBHYXU1TOElaKOmKLfYzeQ==",
             "dev": true,
             "requires": {
                 "debug": "^3.2.6",
@@ -26792,7 +26792,7 @@
                 "faye-websocket": "^0.11.3",
                 "inherits": "^2.0.4",
                 "json3": "^3.3.3",
-                "url-parse": "^1.4.7"
+                "url-parse": "^1.5.1"
             },
             "dependencies": {
                 "debug": {

--- a/tests/Feature/Http/Api/FallbackTest.php
+++ b/tests/Feature/Http/Api/FallbackTest.php
@@ -2,13 +2,11 @@
 
 namespace Tests\Feature\Http\Api;
 
-use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Str;
 use Tests\TestCase;
 
 class FallbackTest extends TestCase
 {
-    use WithFaker;
-
     /**
      * The API shall return an errors object when requests are made to an
      * unregistered route.
@@ -17,7 +15,7 @@ class FallbackTest extends TestCase
      */
     public function testAbortJson()
     {
-        $response = $this->get(url('api/'.$this->faker->word));
+        $response = $this->get(url('api/'.Str::random()));
 
         $response->assertJsonStructure([
             'errors',


### PR DESCRIPTION
Addressing a security item in php config prevented the seeders from retrieving external pages, so now we use a guzzle client. This also provides bridging changes needed in #152. 