### PR TITLE
fix(seed): fail silently if an external service raises an internal exception

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1864,32 +1864,32 @@
         },
         {
             "name": "doctrine/dbal",
-            "version": "2.12.1",
+            "version": "2.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "adce7a954a1c2f14f85e94aed90c8489af204086"
+                "reference": "67d56d3203b33db29834e6b2fcdbfdc50535d796"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/adce7a954a1c2f14f85e94aed90c8489af204086",
-                "reference": "adce7a954a1c2f14f85e94aed90c8489af204086",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/67d56d3203b33db29834e6b2fcdbfdc50535d796",
+                "reference": "67d56d3203b33db29834e6b2fcdbfdc50535d796",
                 "shasum": ""
             },
             "require": {
                 "doctrine/cache": "^1.0",
+                "doctrine/deprecations": "^0.5.3",
                 "doctrine/event-manager": "^1.0",
                 "ext-pdo": "*",
-                "php": "^7.3 || ^8"
+                "php": "^7.1 || ^8"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^8.1",
-                "jetbrains/phpstorm-stubs": "^2019.1",
-                "phpstan/phpstan": "^0.12.40",
-                "phpunit/phpunit": "^9.4",
-                "psalm/plugin-phpunit": "^0.10.0",
+                "doctrine/coding-standard": "8.2.0",
+                "jetbrains/phpstorm-stubs": "2020.2",
+                "phpstan/phpstan": "0.12.81",
+                "phpunit/phpunit": "^7.5.20|^8.5|9.5.0",
                 "symfony/console": "^2.0.5|^3.0|^4.0|^5.0",
-                "vimeo/psalm": "^3.17.2"
+                "vimeo/psalm": "4.6.4"
             },
             "suggest": {
                 "symfony/console": "For helpful console commands such as SQL execution and import of files."
@@ -1898,11 +1898,6 @@
                 "bin/doctrine-dbal"
             ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.0.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Doctrine\\DBAL\\": "lib/Doctrine/DBAL"
@@ -1955,7 +1950,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/dbal/issues",
-                "source": "https://github.com/doctrine/dbal/tree/2.12.1"
+                "source": "https://github.com/doctrine/dbal/tree/2.13.0"
             },
             "funding": [
                 {
@@ -1971,7 +1966,50 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-14T20:26:58+00:00"
+            "time": "2021-03-28T18:10:53+00:00"
+        },
+        {
+            "name": "doctrine/deprecations",
+            "version": "v0.5.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/deprecations.git",
+                "reference": "9504165960a1f83cc1480e2be1dd0a0478561314"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/9504165960a1f83cc1480e2be1dd0a0478561314",
+                "reference": "9504165960a1f83cc1480e2be1dd0a0478561314",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1|^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^6.0|^7.0|^8.0",
+                "phpunit/phpunit": "^7.0|^8.0|^9.0",
+                "psr/log": "^1.0"
+            },
+            "suggest": {
+                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Deprecations\\": "lib/Doctrine/Deprecations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
+            "homepage": "https://www.doctrine-project.org/",
+            "support": {
+                "issues": "https://github.com/doctrine/deprecations/issues",
+                "source": "https://github.com/doctrine/deprecations/tree/v0.5.3"
+            },
+            "time": "2021-03-21T12:59:47+00:00"
         },
         {
             "name": "doctrine/event-manager",
@@ -2782,16 +2820,16 @@
         },
         {
             "name": "fakerphp/faker",
-            "version": "v1.14.0",
+            "version": "v1.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FakerPHP/Faker.git",
-                "reference": "cd46398f42c2ab191ffb0b57c07e911c7c28eb25"
+                "reference": "ed22aee8d17c7b396f74a58b1e7fefa4f90d5ef1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/cd46398f42c2ab191ffb0b57c07e911c7c28eb25",
-                "reference": "cd46398f42c2ab191ffb0b57c07e911c7c28eb25",
+                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/ed22aee8d17c7b396f74a58b1e7fefa4f90d5ef1",
+                "reference": "ed22aee8d17c7b396f74a58b1e7fefa4f90d5ef1",
                 "shasum": ""
             },
             "require": {
@@ -2814,6 +2852,11 @@
                 "ext-mbstring": "Required for multibyte Unicode string functionality."
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "v1.15-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Faker\\": "src/Faker/"
@@ -2836,9 +2879,9 @@
             ],
             "support": {
                 "issues": "https://github.com/FakerPHP/Faker/issues",
-                "source": "https://github.com/FakerPHP/Faker/tree/v1.14.0"
+                "source": "https://github.com/FakerPHP/Faker/tree/v.1.14.1"
             },
-            "time": "2021-03-29T08:56:34+00:00"
+            "time": "2021-03-30T06:27:33+00:00"
         },
         {
             "name": "fideloper/proxy",
@@ -4102,16 +4145,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v8.34.0",
+            "version": "v8.35.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "81892ca110795a9c46c7e198cba7763bfd2af0bf"
+                "reference": "476d06a41d109a355cb3a376bd09f21b7d83ebda"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/81892ca110795a9c46c7e198cba7763bfd2af0bf",
-                "reference": "81892ca110795a9c46c7e198cba7763bfd2af0bf",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/476d06a41d109a355cb3a376bd09f21b7d83ebda",
+                "reference": "476d06a41d109a355cb3a376bd09f21b7d83ebda",
                 "shasum": ""
             },
             "require": {
@@ -4266,7 +4309,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2021-03-23T15:12:51+00:00"
+            "time": "2021-03-30T14:09:34+00:00"
         },
         {
             "name": "laravel/horizon",
@@ -10894,16 +10937,16 @@
         },
         {
             "name": "facade/ignition",
-            "version": "2.6.0",
+            "version": "2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/facade/ignition.git",
-                "reference": "4be10a998815f77952b9eb983fb0b64c8a4defbb"
+                "reference": "bdc8b0b32c888f6edc838ca641358322b3d9506d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/facade/ignition/zipball/4be10a998815f77952b9eb983fb0b64c8a4defbb",
-                "reference": "4be10a998815f77952b9eb983fb0b64c8a4defbb",
+                "url": "https://api.github.com/repos/facade/ignition/zipball/bdc8b0b32c888f6edc838ca641358322b3d9506d",
+                "reference": "bdc8b0b32c888f6edc838ca641358322b3d9506d",
                 "shasum": ""
             },
             "require": {
@@ -10967,7 +11010,7 @@
                 "issues": "https://github.com/facade/ignition/issues",
                 "source": "https://github.com/facade/ignition"
             },
-            "time": "2021-03-24T18:58:31+00:00"
+            "time": "2021-03-30T15:55:38+00:00"
         },
         {
             "name": "facade/ignition-contracts",
@@ -11024,16 +11067,16 @@
         },
         {
             "name": "filp/whoops",
-            "version": "2.11.0",
+            "version": "2.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filp/whoops.git",
-                "reference": "f6e14679f948d8a5cfb866fa7065a30c66bd64d3"
+                "reference": "d501fd2658d55491a2295ff600ae5978eaad7403"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filp/whoops/zipball/f6e14679f948d8a5cfb866fa7065a30c66bd64d3",
-                "reference": "f6e14679f948d8a5cfb866fa7065a30c66bd64d3",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/d501fd2658d55491a2295ff600ae5978eaad7403",
+                "reference": "d501fd2658d55491a2295ff600ae5978eaad7403",
                 "shasum": ""
             },
             "require": {
@@ -11083,7 +11126,7 @@
             ],
             "support": {
                 "issues": "https://github.com/filp/whoops/issues",
-                "source": "https://github.com/filp/whoops/tree/2.11.0"
+                "source": "https://github.com/filp/whoops/tree/2.12.0"
             },
             "funding": [
                 {
@@ -11091,7 +11134,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-03-19T12:00:00+00:00"
+            "time": "2021-03-30T12:00:00+00:00"
         },
         {
             "name": "joshgaber/novaunit",

--- a/database/seeders/AniDbResourceSeeder.php
+++ b/database/seeders/AniDbResourceSeeder.php
@@ -69,9 +69,10 @@ class AniDbResourceSeeder extends Seeder
                     // We may not have a match for this MAL resource
                     Log::info($e->getMessage());
                 } catch (ServerException $e) {
-                    // We may have upset Yuna
+                    // We may have upset Yuna, try again later
                     Log::info($e->getMessage());
-                    abort(500);
+
+                    return;
                 }
             }
         }

--- a/database/seeders/AnilistAnimeResourceSeeder.php
+++ b/database/seeders/AnilistAnimeResourceSeeder.php
@@ -83,9 +83,10 @@ class AnilistAnimeResourceSeeder extends Seeder
                     // We may not have a match for this MAL resource
                     Log::info($e->getMessage());
                 } catch (ServerException $e) {
-                    // We may have upset Anilist
+                    // We may have upset Anilist, try again later
                     Log::info($e->getMessage());
-                    abort(500);
+
+                    return;
                 }
             }
         }

--- a/database/seeders/AnilistArtistResourceSeeder.php
+++ b/database/seeders/AnilistArtistResourceSeeder.php
@@ -78,9 +78,10 @@ class AnilistArtistResourceSeeder extends Seeder
                 // We may not have a match for this MAL resource
                 Log::info($e->getMessage());
             } catch (ServerException $e) {
-                // We may have upset Anilist
+                // We may have upset Anilist, try again later
                 Log::info($e->getMessage());
-                abort(500);
+
+                return;
             }
         }
     }

--- a/database/seeders/AnimeResourceSeeder.php
+++ b/database/seeders/AnimeResourceSeeder.php
@@ -24,6 +24,9 @@ class AnimeResourceSeeder extends Seeder
 
             // Get JSON of Year page content
             $year_wiki_contents = WikiPages::getPageContents($year_page);
+            if ($year_wiki_contents === null) {
+                continue;
+            }
 
             // Match headers of Anime and links of Resources
             // Format: "###[{Anime Name}]({Resource Link})"

--- a/database/seeders/AnimeSeasonSeeder.php
+++ b/database/seeders/AnimeSeasonSeeder.php
@@ -24,6 +24,9 @@ class AnimeSeasonSeeder extends Seeder
 
             // Get JSON of Year page content
             $year_wiki_contents = WikiPages::getPageContents($year_page);
+            if ($year_wiki_contents === null) {
+                continue;
+            }
 
             // We want to proceed line by line
             preg_match_all('/^(.*)$/m', $year_wiki_contents, $anime_season_wiki_entries, PREG_SET_ORDER);

--- a/database/seeders/AnimeSeeder.php
+++ b/database/seeders/AnimeSeeder.php
@@ -18,6 +18,9 @@ class AnimeSeeder extends Seeder
     {
         // Get JSON of Anime Index page content
         $anime_wiki_contents = WikiPages::getPageContents(WikiPages::ANIME_INDEX);
+        if ($anime_wiki_contents === null) {
+            return;
+        }
 
         // Match Anime Entries
         // Format: "[{Anime Name} ({Year})](/r/AnimeThemes/wiki/{year}#{anchor link})"

--- a/database/seeders/AnimeThemeSeeder.php
+++ b/database/seeders/AnimeThemeSeeder.php
@@ -30,6 +30,9 @@ class AnimeThemeSeeder extends Seeder
 
             // Get JSON of Year page content
             $year_wiki_contents = WikiPages::getPageContents($year_page);
+            if ($year_wiki_contents === null) {
+                continue;
+            }
 
             // We want to proceed line by line
             preg_match_all('/^(.*)$/m', $year_wiki_contents, $anime_theme_wiki_entries, PREG_SET_ORDER);

--- a/database/seeders/ArtistCoverSeeder.php
+++ b/database/seeders/ArtistCoverSeeder.php
@@ -113,9 +113,10 @@ class ArtistCoverSeeder extends Seeder
                     // We may not have a match for this MAL resource
                     Log::info($e->getMessage());
                 } catch (ServerException $e) {
-                    // We may have upset Anilist
+                    // We may have upset Anilist, try again later
                     Log::info($e->getMessage());
-                    abort(500);
+
+                    return;
                 }
             }
         }

--- a/database/seeders/ArtistSeeder.php
+++ b/database/seeders/ArtistSeeder.php
@@ -19,6 +19,9 @@ class ArtistSeeder extends Seeder
     {
         // Get JSON of Artist Index page content
         $artist_wiki_contents = WikiPages::getPageContents(WikiPages::ARTIST_INDEX);
+        if ($artist_wiki_contents === null) {
+            return;
+        }
 
         // Match Artist Entries
         // Format: "[{Artist Name}](/r/AnimeThemes/wiki/artist/{Artist Slug}/)"
@@ -44,6 +47,9 @@ class ArtistSeeder extends Seeder
             // Get JSON of Artist Entry page content
             $artist_link = WikiPages::getArtistPage($artist_slug);
             $artist_resource_wiki_contents = WikiPages::getPageContents($artist_link);
+            if ($artist_resource_wiki_contents === null) {
+                continue;
+            }
 
             // Match headers of Resource in Artist Entry page
             // Format: "##[{Artist Name}]({Resource Link})"

--- a/database/seeders/ArtistSongSeeder.php
+++ b/database/seeders/ArtistSongSeeder.php
@@ -21,6 +21,9 @@ class ArtistSongSeeder extends Seeder
     {
         // Get JSON of Artist Index page content
         $artist_wiki_contents = WikiPages::getPageContents(WikiPages::ARTIST_INDEX);
+        if ($artist_wiki_contents === null) {
+            return;
+        }
 
         // Match Artist Entries
         // Format: "[{Artist Name}](/r/AnimeThemes/wiki/artist/{Artist Slug}/)"
@@ -41,6 +44,9 @@ class ArtistSongSeeder extends Seeder
             // Get JSON of Artist Entry page content
             $artist_link = WikiPages::getArtistPage($artist_slug);
             $artist_song_wiki_contents = WikiPages::getPageContents($artist_link);
+            if ($artist_song_wiki_contents === null) {
+                continue;
+            }
 
             // We want to proceed line by line
             preg_match_all('/^(.*)$/m', $artist_song_wiki_contents, $artist_song_wiki_entries, PREG_SET_ORDER);

--- a/database/seeders/KitsuResourceSeeder.php
+++ b/database/seeders/KitsuResourceSeeder.php
@@ -81,9 +81,10 @@ class KitsuResourceSeeder extends Seeder
                     // We may not have a match for this MAL resource
                     Log::info($e->getMessage());
                 } catch (ServerException $e) {
-                    // We may have upset Kitsu
+                    // We may have upset Kitsu, try again later
                     Log::info($e->getMessage());
-                    abort(500);
+
+                    return;
                 }
             }
         }

--- a/database/seeders/SeriesSeeder.php
+++ b/database/seeders/SeriesSeeder.php
@@ -18,6 +18,9 @@ class SeriesSeeder extends Seeder
     {
         // Get JSON of Series Index page content
         $series_wiki_contents = WikiPages::getPageContents(WikiPages::SERIES_INDEX);
+        if ($series_wiki_contents === null) {
+            return;
+        }
 
         // Match Series Entries
         // Format: "[{Series Name}](/r/AnimeThemes/wiki/series/{Series Slug}/)
@@ -43,6 +46,9 @@ class SeriesSeeder extends Seeder
             // Get JSON of Series Entry page content
             $series_link = WikiPages::getSeriesPage($series_slug);
             $series_anime_wiki_contents = WikiPages::getPageContents($series_link);
+            if ($series_anime_wiki_contents === null) {
+                continue;
+            }
 
             // Match headers of Anime in Series Entry page
             // Format: "###[{Anime Name}]({Resource Link})"

--- a/database/seeders/SynopsisCoverSeeder.php
+++ b/database/seeders/SynopsisCoverSeeder.php
@@ -122,9 +122,10 @@ class SynopsisCoverSeeder extends Seeder
                     // We may not have a match for this MAL resource
                     Log::info($e->getMessage());
                 } catch (ServerException $e) {
-                    // We may have upset Anilist
+                    // We may have upset Anilist, try again later
                     Log::info($e->getMessage());
-                    abort(500);
+
+                    return;
                 }
             }
         }

--- a/database/seeders/VideoTagsSeeder.php
+++ b/database/seeders/VideoTagsSeeder.php
@@ -26,6 +26,9 @@ class VideoTagsSeeder extends Seeder
 
             // Get JSON of Year page content
             $year_wiki_contents = WikiPages::getPageContents($video_page);
+            if ($year_wiki_contents === null) {
+                return;
+            }
 
             // Match Tags and basename of Videos
             // Format: "[Webm ({Tag 1, Tag 2, Tag 3...})]({Video Link})

--- a/database/seeders/WikiPages.php
+++ b/database/seeders/WikiPages.php
@@ -112,9 +112,10 @@ class WikiPages
             // We may be requesting an invalid Reddit page
             Log::info($e->getMessage());
         } catch (ServerException $e) {
-            // We may have upset Reddit
+            // We may have upset Reddit, try again later
             Log::info($e->getMessage());
-            abort(500);
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
Addressing another issue found in staging log review: If one external service responds with an internal exception, the seeders raise an exception and abort execution altogether. This couples the uptime of each external service that we query, which is not desirable. Instead, we shall silently fail and move on to the next seeder.