### PR TITLE
#126 fix(discord): do not raise events on restore save operation

### DIFF
--- a/app/Models/BaseModel.php
+++ b/app/Models/BaseModel.php
@@ -34,4 +34,37 @@ abstract class BaseModel extends Model implements Auditable, Nameable
             ->withoutGlobalScope(SoftDeletingScope::class)
             ->first();
     }
+
+    /**
+     * Restore a soft-deleted model instance.
+     *
+     * @return bool|null
+     */
+    public function restore()
+    {
+        // If the restoring event does not return false, we will proceed with this
+        // restore operation. Otherwise, we bail out so the developer will stop
+        // the restore totally. We will clear the deleted timestamp and save.
+        if ($this->fireModelEvent('restoring') === false) {
+            return false;
+        }
+
+        $this->{$this->getDeletedAtColumn()} = null;
+
+        // Once we have saved the model, we will fire the "restored" event so this
+        // developer will do anything they need to after a restore operation is
+        // totally finished. Then we will return the result of the save call.
+        $this->exists = true;
+
+        // Save quietly so that we do not fire an updated event on restore
+        $result = self::withoutEvents(
+            function () {
+                return $this->save();
+            }
+        );
+
+        $this->fireModelEvent('restored', false);
+
+        return $result;
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -83,6 +83,39 @@ class User extends Authenticatable implements MustVerifyEmail, Nameable
         return $this->name;
     }
 
+    /**
+     * Restore a soft-deleted model instance.
+     *
+     * @return bool|null
+     */
+    public function restore()
+    {
+        // If the restoring event does not return false, we will proceed with this
+        // restore operation. Otherwise, we bail out so the developer will stop
+        // the restore totally. We will clear the deleted timestamp and save.
+        if ($this->fireModelEvent('restoring') === false) {
+            return false;
+        }
+
+        $this->{$this->getDeletedAtColumn()} = null;
+
+        // Once we have saved the model, we will fire the "restored" event so this
+        // developer will do anything they need to after a restore operation is
+        // totally finished. Then we will return the result of the save call.
+        $this->exists = true;
+
+        // Save quietly so that we do not fire an updated event on restore
+        $result = self::withoutEvents(
+            function () {
+                return $this->save();
+            }
+        );
+
+        $this->fireModelEvent('restored', false);
+
+        return $result;
+    }
+
     // Make HasTeams more null safe
 
     /**

--- a/composer.lock
+++ b/composer.lock
@@ -5145,16 +5145,16 @@
         },
         {
             "name": "livewire/livewire",
-            "version": "v2.4.2",
+            "version": "v2.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/livewire/livewire.git",
-                "reference": "2495387841a3eb03ac62b2c984ccd2574303285b"
+                "reference": "69575f50bb7f8a49a41f9bd6bd16c73a6ef4fda3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/livewire/livewire/zipball/2495387841a3eb03ac62b2c984ccd2574303285b",
-                "reference": "2495387841a3eb03ac62b2c984ccd2574303285b",
+                "url": "https://api.github.com/repos/livewire/livewire/zipball/69575f50bb7f8a49a41f9bd6bd16c73a6ef4fda3",
+                "reference": "69575f50bb7f8a49a41f9bd6bd16c73a6ef4fda3",
                 "shasum": ""
             },
             "require": {
@@ -5205,7 +5205,7 @@
             "description": "A front-end framework for Laravel.",
             "support": {
                 "issues": "https://github.com/livewire/livewire/issues",
-                "source": "https://github.com/livewire/livewire/tree/v2.4.2"
+                "source": "https://github.com/livewire/livewire/tree/v2.4.3"
             },
             "funding": [
                 {
@@ -5213,7 +5213,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-04-04T15:46:50+00:00"
+            "time": "2021-04-16T14:27:45+00:00"
         },
         {
             "name": "mobiledetect/mobiledetectlib",
@@ -5712,16 +5712,16 @@
         },
         {
             "name": "nunomaduro/larastan",
-            "version": "v0.7.3",
+            "version": "v0.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/larastan.git",
-                "reference": "9c515d46851dca5a99fc82c0a69392c362b7affd"
+                "reference": "0ceef2a39b45be9d7f7dd96192a1721ba5112278"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/larastan/zipball/9c515d46851dca5a99fc82c0a69392c362b7affd",
-                "reference": "9c515d46851dca5a99fc82c0a69392c362b7affd",
+                "url": "https://api.github.com/repos/nunomaduro/larastan/zipball/0ceef2a39b45be9d7f7dd96192a1721ba5112278",
+                "reference": "0ceef2a39b45be9d7f7dd96192a1721ba5112278",
                 "shasum": ""
             },
             "require": {
@@ -5785,7 +5785,7 @@
             ],
             "support": {
                 "issues": "https://github.com/nunomaduro/larastan/issues",
-                "source": "https://github.com/nunomaduro/larastan/tree/v0.7.3"
+                "source": "https://github.com/nunomaduro/larastan/tree/v0.7.4"
             },
             "funding": [
                 {
@@ -5805,7 +5805,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2021-04-12T11:01:46+00:00"
+            "time": "2021-04-16T08:25:31+00:00"
         },
         {
             "name": "olssonm/l5-zxcvbn",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3245,9 +3245,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001208",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001208.tgz",
-            "integrity": "sha512-OE5UE4+nBOro8Dyvv0lfx+SRtfVIOM9uhKqFmJeUbGriqhhStgp1A0OyBpgy3OUF8AhYCT+PVwPC1gMl2ZcQMA==",
+            "version": "1.0.30001209",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001209.tgz",
+            "integrity": "sha512-2Ktt4OeRM7EM/JaOZjuLzPYAIqmbwQMNnYbgooT+icoRGrKOyAxA1xhlnotBD1KArRSPsuJp3TdYcZYrL7qNxA==",
             "dev": true
         },
         "node_modules/chalk": {
@@ -4049,23 +4049,22 @@
             }
         },
         "node_modules/css-loader": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.1.tgz",
-            "integrity": "sha512-YCyRzlt/jgG1xanXZDG/DHqAueOtXFHeusP9TS478oP1J++JSKOyEgGW1GHVoCj/rkS+GWOlBwqQJBr9yajQ9w==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.2.tgz",
+            "integrity": "sha512-IS722y7Lh2Yq+acMR74tdf3faMOLRP2RfLwS0VzSS7T98IHtacMWJLku3A0OBTFHB07zAa4nWBhA8gfxwQVWGQ==",
             "dev": true,
             "dependencies": {
                 "camelcase": "^6.2.0",
-                "cssesc": "^3.0.0",
                 "icss-utils": "^5.1.0",
                 "loader-utils": "^2.0.0",
-                "postcss": "^8.2.8",
+                "postcss": "^8.2.10",
                 "postcss-modules-extract-imports": "^3.0.0",
                 "postcss-modules-local-by-default": "^4.0.0",
                 "postcss-modules-scope": "^3.0.0",
                 "postcss-modules-values": "^4.0.0",
                 "postcss-value-parser": "^4.1.0",
                 "schema-utils": "^3.0.0",
-                "semver": "^7.3.4"
+                "semver": "^7.3.5"
             },
             "engines": {
                 "node": ">= 10.13.0"
@@ -4925,9 +4924,9 @@
             }
         },
         "node_modules/dom-serializer/node_modules/domhandler": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.1.0.tgz",
-            "integrity": "sha512-/6/kmsGlMY4Tup/nGVutdrK9yQi4YjWVcVeoQmixpzjOUK1U7pQkvAPHBJeUxOgxF0J8f8lwCJSlCfD0V4CMGQ==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
+            "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
             "dev": true,
             "dependencies": {
                 "domelementtype": "^2.2.0"
@@ -4977,23 +4976,23 @@
             }
         },
         "node_modules/domutils": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.5.2.tgz",
-            "integrity": "sha512-MHTthCb1zj8f1GVfRpeZUbohQf/HdBos0oX5gZcQFepOZPLLRyj6Wn7XS7EMnY7CVpwv8863u2vyE83Hfu28HQ==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.6.0.tgz",
+            "integrity": "sha512-y0BezHuy4MDYxh6OvolXYsH+1EMGmFbwv5FKW7ovwMG6zTPWqNPq3WF9ayZssFq+UlKdffGLbOEaghNdaOm1WA==",
             "dev": true,
             "dependencies": {
                 "dom-serializer": "^1.0.1",
                 "domelementtype": "^2.2.0",
-                "domhandler": "^4.1.0"
+                "domhandler": "^4.2.0"
             },
             "funding": {
                 "url": "https://github.com/fb55/domutils?sponsor=1"
             }
         },
         "node_modules/domutils/node_modules/domhandler": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.1.0.tgz",
-            "integrity": "sha512-/6/kmsGlMY4Tup/nGVutdrK9yQi4YjWVcVeoQmixpzjOUK1U7pQkvAPHBJeUxOgxF0J8f8lwCJSlCfD0V4CMGQ==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
+            "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
             "dev": true,
             "dependencies": {
                 "domelementtype": "^2.2.0"
@@ -13340,12 +13339,12 @@
             "dev": true
         },
         "node_modules/sass": {
-            "version": "1.32.8",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.8.tgz",
-            "integrity": "sha512-Sl6mIeGpzjIUZqvKnKETfMf0iDAswD9TNlv13A7aAF3XZlRPMq4VvJWBC2N2DXbp94MQVdNSFG6LfF/iOXrPHQ==",
+            "version": "1.32.9",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.9.tgz",
+            "integrity": "sha512-DGXRkoCF5w+WnlcfolMiNsZ/D0UfmOi4CW2ORMgrXg1eMF6Aoq7kj5qlMrkiXhXdRufTYclMsJUtxYozQT65Ig==",
             "dev": true,
             "dependencies": {
-                "chokidar": ">=2.0.0 <4.0.0"
+                "chokidar": ">=3.0.0 <4.0.0"
             },
             "bin": {
                 "sass": "sass.js"
@@ -18302,9 +18301,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001208",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001208.tgz",
-            "integrity": "sha512-OE5UE4+nBOro8Dyvv0lfx+SRtfVIOM9uhKqFmJeUbGriqhhStgp1A0OyBpgy3OUF8AhYCT+PVwPC1gMl2ZcQMA==",
+            "version": "1.0.30001209",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001209.tgz",
+            "integrity": "sha512-2Ktt4OeRM7EM/JaOZjuLzPYAIqmbwQMNnYbgooT+icoRGrKOyAxA1xhlnotBD1KArRSPsuJp3TdYcZYrL7qNxA==",
             "dev": true
         },
         "chalk": {
@@ -18979,23 +18978,22 @@
             }
         },
         "css-loader": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.1.tgz",
-            "integrity": "sha512-YCyRzlt/jgG1xanXZDG/DHqAueOtXFHeusP9TS478oP1J++JSKOyEgGW1GHVoCj/rkS+GWOlBwqQJBr9yajQ9w==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.2.tgz",
+            "integrity": "sha512-IS722y7Lh2Yq+acMR74tdf3faMOLRP2RfLwS0VzSS7T98IHtacMWJLku3A0OBTFHB07zAa4nWBhA8gfxwQVWGQ==",
             "dev": true,
             "requires": {
                 "camelcase": "^6.2.0",
-                "cssesc": "^3.0.0",
                 "icss-utils": "^5.1.0",
                 "loader-utils": "^2.0.0",
-                "postcss": "^8.2.8",
+                "postcss": "^8.2.10",
                 "postcss-modules-extract-imports": "^3.0.0",
                 "postcss-modules-local-by-default": "^4.0.0",
                 "postcss-modules-scope": "^3.0.0",
                 "postcss-modules-values": "^4.0.0",
                 "postcss-value-parser": "^4.1.0",
                 "schema-utils": "^3.0.0",
-                "semver": "^7.3.4"
+                "semver": "^7.3.5"
             },
             "dependencies": {
                 "loader-utils": {
@@ -19682,9 +19680,9 @@
             },
             "dependencies": {
                 "domhandler": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.1.0.tgz",
-                    "integrity": "sha512-/6/kmsGlMY4Tup/nGVutdrK9yQi4YjWVcVeoQmixpzjOUK1U7pQkvAPHBJeUxOgxF0J8f8lwCJSlCfD0V4CMGQ==",
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
+                    "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
                     "dev": true,
                     "requires": {
                         "domelementtype": "^2.2.0"
@@ -19714,20 +19712,20 @@
             }
         },
         "domutils": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.5.2.tgz",
-            "integrity": "sha512-MHTthCb1zj8f1GVfRpeZUbohQf/HdBos0oX5gZcQFepOZPLLRyj6Wn7XS7EMnY7CVpwv8863u2vyE83Hfu28HQ==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.6.0.tgz",
+            "integrity": "sha512-y0BezHuy4MDYxh6OvolXYsH+1EMGmFbwv5FKW7ovwMG6zTPWqNPq3WF9ayZssFq+UlKdffGLbOEaghNdaOm1WA==",
             "dev": true,
             "requires": {
                 "dom-serializer": "^1.0.1",
                 "domelementtype": "^2.2.0",
-                "domhandler": "^4.1.0"
+                "domhandler": "^4.2.0"
             },
             "dependencies": {
                 "domhandler": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.1.0.tgz",
-                    "integrity": "sha512-/6/kmsGlMY4Tup/nGVutdrK9yQi4YjWVcVeoQmixpzjOUK1U7pQkvAPHBJeUxOgxF0J8f8lwCJSlCfD0V4CMGQ==",
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
+                    "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
                     "dev": true,
                     "requires": {
                         "domelementtype": "^2.2.0"
@@ -26266,12 +26264,12 @@
             "dev": true
         },
         "sass": {
-            "version": "1.32.8",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.8.tgz",
-            "integrity": "sha512-Sl6mIeGpzjIUZqvKnKETfMf0iDAswD9TNlv13A7aAF3XZlRPMq4VvJWBC2N2DXbp94MQVdNSFG6LfF/iOXrPHQ==",
+            "version": "1.32.9",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.9.tgz",
+            "integrity": "sha512-DGXRkoCF5w+WnlcfolMiNsZ/D0UfmOi4CW2ORMgrXg1eMF6Aoq7kj5qlMrkiXhXdRufTYclMsJUtxYozQT65Ig==",
             "dev": true,
             "requires": {
-                "chokidar": ">=2.0.0 <4.0.0"
+                "chokidar": ">=3.0.0 <4.0.0"
             }
         },
         "sass-loader": {


### PR DESCRIPTION
This is an incremental commit that fixes discord notifications for restored actions. We don't want to fire update events on restore as is the default behavior of the framework, so we override the soft delete trait to quietly save the restore changes without events.