### PR TITLE
fix(redis): named rate limiters expect a specific number of arguments

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -20,6 +20,9 @@ parameters:
         - '#Call to an undefined method Illuminate\\Database\\Eloquent\\Factories\\Factory::jsonApiResource\(\).#'
         - '#Call to an undefined method Illuminate\\Database\\Eloquent\\Factories\\Factory::withCurrentTeam\(\).#'
         - '#Call to an undefined method Illuminate\\Database\\Eloquent\\Factories\\Factory::withPersonalTeam\(\).#'
+        -
+            message: '#Unreachable statement - code above always terminates.#'
+            path: app/Http/Middleware/ThrottleRequestsWithService.php
 
     excludes_analyse:
 


### PR DESCRIPTION
Laravel won't use the valid named rate limiter if we don't pass exactly 3 arguments to the middleware handle method. If we have a valid named rate limiter, only pass in the needed arguments to the throttling middleware.