### PR TITLE
#155 fix(api): changing resource inclusion strategy defaults

### DIFF
--- a/app/JsonApi/QueryParser.php
+++ b/app/JsonApi/QueryParser.php
@@ -353,13 +353,8 @@ class QueryParser
      */
     public function getIncludePaths($allowedIncludePaths)
     {
-        // If include paths are not specified, return full list of allowed include paths
-        if (is_null($this->includes)) {
-            return $allowedIncludePaths;
-        }
-
         // Return list of include paths that are contained in the list of allowed include paths
-        return array_values(array_intersect($this->includes, $allowedIncludePaths));
+        return collect($this->includes)->intersect($allowedIncludePaths)->all();
     }
 
     /**
@@ -371,14 +366,9 @@ class QueryParser
      */
     public function getResourceIncludePaths($allowedResourceIncludePaths, $type)
     {
-        // If we are not specifying include paths for this type, include all default relations
-        if (! Arr::exists($this->resourceIncludes, $type)) {
-            return $allowedResourceIncludePaths;
-        }
-
         // Return list of include paths that are contained in the list of allowed include paths for this type
         $resourceTypeIncludes = Arr::get($this->resourceIncludes, $type);
 
-        return array_values(array_intersect($resourceTypeIncludes, $allowedResourceIncludePaths));
+        return collect($resourceTypeIncludes)->intersect($allowedResourceIncludePaths)->all();
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -64,16 +64,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.178.5",
+            "version": "3.178.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "5a268a20272c0c9171570ed57f68b629e966deab"
+                "reference": "9443aecbf56eb43e0c7a409494ae4c09f4cebf5f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/5a268a20272c0c9171570ed57f68b629e966deab",
-                "reference": "5a268a20272c0c9171570ed57f68b629e966deab",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/9443aecbf56eb43e0c7a409494ae4c09f4cebf5f",
+                "reference": "9443aecbf56eb43e0c7a409494ae4c09f4cebf5f",
                 "shasum": ""
             },
             "require": {
@@ -148,9 +148,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.178.5"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.178.7"
             },
-            "time": "2021-04-15T18:12:46+00:00"
+            "time": "2021-04-21T18:37:31+00:00"
         },
         {
             "name": "babenkoivan/elastic-adapter",
@@ -1831,16 +1831,16 @@
         },
         {
             "name": "doctrine/dbal",
-            "version": "2.13.0",
+            "version": "2.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "67d56d3203b33db29834e6b2fcdbfdc50535d796"
+                "reference": "c800380457948e65bbd30ba92cc17cda108bf8c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/67d56d3203b33db29834e6b2fcdbfdc50535d796",
-                "reference": "67d56d3203b33db29834e6b2fcdbfdc50535d796",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/c800380457948e65bbd30ba92cc17cda108bf8c9",
+                "reference": "c800380457948e65bbd30ba92cc17cda108bf8c9",
                 "shasum": ""
             },
             "require": {
@@ -1855,6 +1855,7 @@
                 "jetbrains/phpstorm-stubs": "2020.2",
                 "phpstan/phpstan": "0.12.81",
                 "phpunit/phpunit": "^7.5.20|^8.5|9.5.0",
+                "squizlabs/php_codesniffer": "3.6.0",
                 "symfony/console": "^2.0.5|^3.0|^4.0|^5.0",
                 "vimeo/psalm": "4.6.4"
             },
@@ -1917,7 +1918,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/dbal/issues",
-                "source": "https://github.com/doctrine/dbal/tree/2.13.0"
+                "source": "https://github.com/doctrine/dbal/tree/2.13.1"
             },
             "funding": [
                 {
@@ -1933,7 +1934,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-03-28T18:10:53+00:00"
+            "time": "2021-04-17T17:30:19+00:00"
         },
         {
             "name": "doctrine/deprecations",
@@ -2615,28 +2616,29 @@
         },
         {
             "name": "enlightn/security-checker",
-            "version": "v1.7.0",
+            "version": "v1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/enlightn/security-checker.git",
-                "reference": "1ac108ba278ba0c2e71d2ce2ac4fac07ed6e8a29"
+                "reference": "2054fbce2f8df681c8f71b36656222bcd241b77f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/enlightn/security-checker/zipball/1ac108ba278ba0c2e71d2ce2ac4fac07ed6e8a29",
-                "reference": "1ac108ba278ba0c2e71d2ce2ac4fac07ed6e8a29",
+                "url": "https://api.github.com/repos/enlightn/security-checker/zipball/2054fbce2f8df681c8f71b36656222bcd241b77f",
+                "reference": "2054fbce2f8df681c8f71b36656222bcd241b77f",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "ext-zip": "*",
                 "guzzlehttp/guzzle": "^6.3|^7.0",
                 "php": ">=5.6",
                 "symfony/console": "^3.4|^4|^5",
                 "symfony/finder": "^3|^4|^5",
+                "symfony/process": "^3.4|^4|^5",
                 "symfony/yaml": "^3.4|^4|^5"
             },
             "require-dev": {
+                "ext-zip": "*",
                 "friendsofphp/php-cs-fixer": "^2.18",
                 "phpunit/phpunit": "^5.5|^6|^7|^8|^9"
             },
@@ -2674,9 +2676,9 @@
             ],
             "support": {
                 "issues": "https://github.com/enlightn/security-checker/issues",
-                "source": "https://github.com/enlightn/security-checker/tree/v1.7.0"
+                "source": "https://github.com/enlightn/security-checker/tree/v1.8.0"
             },
-            "time": "2021-03-03T11:56:26+00:00"
+            "time": "2021-04-19T07:13:16+00:00"
         },
         {
             "name": "ezimuel/guzzlestreams",
@@ -4049,16 +4051,16 @@
         },
         {
             "name": "laravel/fortify",
-            "version": "v1.7.10",
+            "version": "v1.7.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/fortify.git",
-                "reference": "82c99b6999f7e89f402cfd7eb4074e619382b3b7"
+                "reference": "db984992eea2286a81429c73a800c784e24e99ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/fortify/zipball/82c99b6999f7e89f402cfd7eb4074e619382b3b7",
-                "reference": "82c99b6999f7e89f402cfd7eb4074e619382b3b7",
+                "url": "https://api.github.com/repos/laravel/fortify/zipball/db984992eea2286a81429c73a800c784e24e99ff",
+                "reference": "db984992eea2286a81429c73a800c784e24e99ff",
                 "shasum": ""
             },
             "require": {
@@ -4108,20 +4110,20 @@
                 "issues": "https://github.com/laravel/fortify/issues",
                 "source": "https://github.com/laravel/fortify"
             },
-            "time": "2021-04-13T15:05:45+00:00"
+            "time": "2021-04-20T15:54:43+00:00"
         },
         {
             "name": "laravel/framework",
-            "version": "v8.37.0",
+            "version": "v8.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "cf4082973abc796ec285190f0603380021f6d26f"
+                "reference": "26a73532c54d2c090692bf2e3e64e449669053ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/cf4082973abc796ec285190f0603380021f6d26f",
-                "reference": "cf4082973abc796ec285190f0603380021f6d26f",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/26a73532c54d2c090692bf2e3e64e449669053ba",
+                "reference": "26a73532c54d2c090692bf2e3e64e449669053ba",
                 "shasum": ""
             },
             "require": {
@@ -4276,7 +4278,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2021-04-13T13:49:49+00:00"
+            "time": "2021-04-20T13:50:21+00:00"
         },
         {
             "name": "laravel/horizon",
@@ -4357,16 +4359,16 @@
         },
         {
             "name": "laravel/jetstream",
-            "version": "v2.3.2",
+            "version": "v2.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/jetstream.git",
-                "reference": "cf7a8eb8b3b7ea219b9503df87d3ebefa36f335b"
+                "reference": "fea3aa721de859b156c7b570b0a39d16e087d055"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/jetstream/zipball/cf7a8eb8b3b7ea219b9503df87d3ebefa36f335b",
-                "reference": "cf7a8eb8b3b7ea219b9503df87d3ebefa36f335b",
+                "url": "https://api.github.com/repos/laravel/jetstream/zipball/fea3aa721de859b156c7b570b0a39d16e087d055",
+                "reference": "fea3aa721de859b156c7b570b0a39d16e087d055",
                 "shasum": ""
             },
             "require": {
@@ -4420,7 +4422,7 @@
                 "issues": "https://github.com/laravel/jetstream/issues",
                 "source": "https://github.com/laravel/jetstream"
             },
-            "time": "2021-04-13T15:08:13+00:00"
+            "time": "2021-04-20T16:03:43+00:00"
         },
         {
             "name": "laravel/nova",
@@ -4519,16 +4521,16 @@
         },
         {
             "name": "laravel/sanctum",
-            "version": "v2.9.4",
+            "version": "v2.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/sanctum.git",
-                "reference": "dd84a9141012c5509922df0c72866110f45026cb"
+                "reference": "a08cfee365c6b6df3e91c8f43b92f7163ffc8a94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/sanctum/zipball/dd84a9141012c5509922df0c72866110f45026cb",
-                "reference": "dd84a9141012c5509922df0c72866110f45026cb",
+                "url": "https://api.github.com/repos/laravel/sanctum/zipball/a08cfee365c6b6df3e91c8f43b92f7163ffc8a94",
+                "reference": "a08cfee365c6b6df3e91c8f43b92f7163ffc8a94",
                 "shasum": ""
             },
             "require": {
@@ -4579,7 +4581,7 @@
                 "issues": "https://github.com/laravel/sanctum/issues",
                 "source": "https://github.com/laravel/sanctum"
             },
-            "time": "2021-04-06T14:32:48+00:00"
+            "time": "2021-04-20T16:20:46+00:00"
         },
         {
             "name": "laravel/scout",
@@ -6276,16 +6278,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.7",
+            "version": "3.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "d369510df0ebd5e1a5d0fe3d4d23c55fa87a403d"
+                "reference": "d9615a6fb970d9933866ca8b4036ec3407b020b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/d369510df0ebd5e1a5d0fe3d4d23c55fa87a403d",
-                "reference": "d369510df0ebd5e1a5d0fe3d4d23c55fa87a403d",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/d9615a6fb970d9933866ca8b4036ec3407b020b6",
+                "reference": "d9615a6fb970d9933866ca8b4036ec3407b020b6",
                 "shasum": ""
             },
             "require": {
@@ -6367,7 +6369,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.7"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.8"
             },
             "funding": [
                 {
@@ -6383,20 +6385,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-04-06T14:00:11+00:00"
+            "time": "2021-04-19T03:20:48+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.83",
+            "version": "0.12.84",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "4a967cec6efb46b500dd6d768657336a3ffe699f"
+                "reference": "9c43f15da8798c8f30a4b099e6a94530a558cfd5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/4a967cec6efb46b500dd6d768657336a3ffe699f",
-                "reference": "4a967cec6efb46b500dd6d768657336a3ffe699f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9c43f15da8798c8f30a4b099e6a94530a558cfd5",
+                "reference": "9c43f15da8798c8f30a4b099e6a94530a558cfd5",
                 "shasum": ""
             },
             "require": {
@@ -6427,7 +6429,7 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/0.12.83"
+                "source": "https://github.com/phpstan/phpstan/tree/0.12.84"
             },
             "funding": [
                 {
@@ -6443,7 +6445,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-04-03T15:35:45+00:00"
+            "time": "2021-04-19T17:10:54+00:00"
         },
         {
             "name": "pragmarx/google2fa",
@@ -7985,16 +7987,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v2.2.0",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "5fa56b4074d1ae755beb55617ddafe6f5d78f665"
+                "reference": "5f38c8804a9e97d23e0c8d63341088cd8a22d627"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/5fa56b4074d1ae755beb55617ddafe6f5d78f665",
-                "reference": "5fa56b4074d1ae755beb55617ddafe6f5d78f665",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/5f38c8804a9e97d23e0c8d63341088cd8a22d627",
+                "reference": "5f38c8804a9e97d23e0c8d63341088cd8a22d627",
                 "shasum": ""
             },
             "require": {
@@ -8003,7 +8005,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev"
+                    "dev-main": "2.4-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -8032,7 +8034,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/master"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.4.0"
             },
             "funding": [
                 {
@@ -8048,7 +8050,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-07T11:33:47+00:00"
+            "time": "2021-03-23T23:28:01+00:00"
         },
         {
             "name": "symfony/error-handler",
@@ -8206,16 +8208,16 @@
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v2.2.0",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "0ba7d54483095a198fa51781bc608d17e84dffa2"
+                "reference": "69fee1ad2332a7cbab3aca13591953da9cdb7a11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/0ba7d54483095a198fa51781bc608d17e84dffa2",
-                "reference": "0ba7d54483095a198fa51781bc608d17e84dffa2",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/69fee1ad2332a7cbab3aca13591953da9cdb7a11",
+                "reference": "69fee1ad2332a7cbab3aca13591953da9cdb7a11",
                 "shasum": ""
             },
             "require": {
@@ -8228,7 +8230,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev"
+                    "dev-main": "2.4-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -8265,7 +8267,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v2.2.0"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v2.4.0"
             },
             "funding": [
                 {
@@ -8281,7 +8283,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-07T11:33:47+00:00"
+            "time": "2021-03-23T23:28:01+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -8408,16 +8410,16 @@
         },
         {
             "name": "symfony/http-client-contracts",
-            "version": "v2.3.1",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client-contracts.git",
-                "reference": "41db680a15018f9c1d4b23516059633ce280ca33"
+                "reference": "7e82f6084d7cae521a75ef2cb5c9457bbda785f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/41db680a15018f9c1d4b23516059633ce280ca33",
-                "reference": "41db680a15018f9c1d4b23516059633ce280ca33",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/7e82f6084d7cae521a75ef2cb5c9457bbda785f4",
+                "reference": "7e82f6084d7cae521a75ef2cb5c9457bbda785f4",
                 "shasum": ""
             },
             "require": {
@@ -8428,9 +8430,8 @@
             },
             "type": "library",
             "extra": {
-                "branch-version": "2.3",
                 "branch-alias": {
-                    "dev-main": "2.3-dev"
+                    "dev-main": "2.4-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -8467,7 +8468,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client-contracts/tree/v2.3.1"
+                "source": "https://github.com/symfony/http-client-contracts/tree/v2.4.0"
             },
             "funding": [
                 {
@@ -8483,7 +8484,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-14T17:08:19+00:00"
+            "time": "2021-04-11T23:07:08+00:00"
         },
         {
             "name": "symfony/http-foundation",
@@ -9811,21 +9812,21 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v2.2.0",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "d15da7ba4957ffb8f1747218be9e1a121fd298a1"
+                "reference": "f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d15da7ba4957ffb8f1747218be9e1a121fd298a1",
-                "reference": "d15da7ba4957ffb8f1747218be9e1a121fd298a1",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb",
+                "reference": "f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
-                "psr/container": "^1.0"
+                "psr/container": "^1.1"
             },
             "suggest": {
                 "symfony/service-implementation": ""
@@ -9833,7 +9834,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev"
+                    "dev-main": "2.4-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -9870,7 +9871,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/master"
+                "source": "https://github.com/symfony/service-contracts/tree/v2.4.0"
             },
             "funding": [
                 {
@@ -9886,7 +9887,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-07T11:33:47+00:00"
+            "time": "2021-04-01T10:43:52+00:00"
         },
         {
             "name": "symfony/string",
@@ -10066,16 +10067,16 @@
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v2.3.0",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "e2eaa60b558f26a4b0354e1bbb25636efaaad105"
+                "reference": "95c812666f3e91db75385749fe219c5e494c7f95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/e2eaa60b558f26a4b0354e1bbb25636efaaad105",
-                "reference": "e2eaa60b558f26a4b0354e1bbb25636efaaad105",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/95c812666f3e91db75385749fe219c5e494c7f95",
+                "reference": "95c812666f3e91db75385749fe219c5e494c7f95",
                 "shasum": ""
             },
             "require": {
@@ -10087,7 +10088,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3-dev"
+                    "dev-main": "2.4-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -10124,7 +10125,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/v2.3.0"
+                "source": "https://github.com/symfony/translation-contracts/tree/v2.4.0"
             },
             "funding": [
                 {
@@ -10140,7 +10141,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-09-28T13:05:58+00:00"
+            "time": "2021-03-23T23:28:01+00:00"
         },
         {
             "name": "symfony/var-dumper",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,20 +40,20 @@
             "dev": true
         },
         "node_modules/@babel/core": {
-            "version": "7.13.15",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.15.tgz",
-            "integrity": "sha512-6GXmNYeNjS2Uz+uls5jalOemgIhnTMeaXo+yBUA72kC2uX/8VW6XyhVIo2L8/q0goKQA3EVKx0KOQpVKSeWadQ==",
+            "version": "7.13.16",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.16.tgz",
+            "integrity": "sha512-sXHpixBiWWFti0AV2Zq7avpTasr6sIAu7Y396c608541qAU2ui4a193m0KSQmfPSKFZLnQ3cvlKDOm3XkuXm3Q==",
             "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.12.13",
-                "@babel/generator": "^7.13.9",
-                "@babel/helper-compilation-targets": "^7.13.13",
+                "@babel/generator": "^7.13.16",
+                "@babel/helper-compilation-targets": "^7.13.16",
                 "@babel/helper-module-transforms": "^7.13.14",
-                "@babel/helpers": "^7.13.10",
-                "@babel/parser": "^7.13.15",
+                "@babel/helpers": "^7.13.16",
+                "@babel/parser": "^7.13.16",
                 "@babel/template": "^7.12.13",
                 "@babel/traverse": "^7.13.15",
-                "@babel/types": "^7.13.14",
+                "@babel/types": "^7.13.16",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -79,12 +79,12 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.13.9",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
-            "integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
+            "version": "7.13.16",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.16.tgz",
+            "integrity": "sha512-grBBR75UnKOcUWMp8WoDxNsWCFl//XCK6HWTrBQKTr5SV9f5g0pNOjdyzi/DTBv12S9GnYPInIXQBTky7OXEMg==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.13.0",
+                "@babel/types": "^7.13.16",
                 "jsesc": "^2.5.1",
                 "source-map": "^0.5.0"
             }
@@ -109,12 +109,12 @@
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.13.13",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.13.tgz",
-            "integrity": "sha512-q1kcdHNZehBwD9jYPh3WyXcsFERi39X4I59I3NadciWtNDyZ6x+GboOxncFK0kXlKIv6BJm5acncehXWUjWQMQ==",
+            "version": "7.13.16",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.16.tgz",
+            "integrity": "sha512-3gmkYIrpqsLlieFwjkGgLaSHmhnvlAYzZLlYVjlW+QwI+1zE17kGxuJGmIqDQdYp56XdmGeD+Bswx0UTyG18xA==",
             "dev": true,
             "dependencies": {
-                "@babel/compat-data": "^7.13.12",
+                "@babel/compat-data": "^7.13.15",
                 "@babel/helper-validator-option": "^7.12.17",
                 "browserslist": "^4.14.5",
                 "semver": "^6.3.0"
@@ -219,13 +219,13 @@
             }
         },
         "node_modules/@babel/helper-hoist-variables": {
-            "version": "7.13.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.13.0.tgz",
-            "integrity": "sha512-0kBzvXiIKfsCA0y6cFEIJf4OdzfpRuNk4+YTeHZpGGc666SATFKTz6sRncwFnQk7/ugJ4dSrCj6iJuvW4Qwr2g==",
+            "version": "7.13.16",
+            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.13.16.tgz",
+            "integrity": "sha512-1eMtTrXtrwscjcAeO4BVK+vvkxaLJSPFz1w1KLawz6HLNi9bPFGBNwwDyVfiu1Tv/vRRFYfoGaKhmAQPGPn5Wg==",
             "dev": true,
             "dependencies": {
-                "@babel/traverse": "^7.13.0",
-                "@babel/types": "^7.13.0"
+                "@babel/traverse": "^7.13.15",
+                "@babel/types": "^7.13.16"
             }
         },
         "node_modules/@babel/helper-member-expression-to-functions": {
@@ -352,14 +352,14 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.13.10",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.10.tgz",
-            "integrity": "sha512-4VO883+MWPDUVRF3PhiLBUFHoX/bsLTGFpFK/HqvvfBZz2D57u9XzPVNFVBTc0PW/CWR9BXTOKt8NF4DInUHcQ==",
+            "version": "7.13.17",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.17.tgz",
+            "integrity": "sha512-Eal4Gce4kGijo1/TGJdqp3WuhllaMLSrW6XcL0ulyUAQOuxHcCafZE8KHg9857gcTehsm/v7RcOx2+jp0Ryjsg==",
             "dev": true,
             "dependencies": {
                 "@babel/template": "^7.12.13",
-                "@babel/traverse": "^7.13.0",
-                "@babel/types": "^7.13.0"
+                "@babel/traverse": "^7.13.17",
+                "@babel/types": "^7.13.17"
             }
         },
         "node_modules/@babel/highlight": {
@@ -436,9 +436,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.13.15",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.15.tgz",
-            "integrity": "sha512-b9COtcAlVEQljy/9fbcMHpG+UIW9ReF+gpaxDHTlZd0c6/UU9ng8zdySAW9sRTzpvcdCHn6bUcbuYUgGzLAWVQ==",
+            "version": "7.13.16",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.16.tgz",
+            "integrity": "sha512-6bAg36mCwuqLO0hbR+z7PHuqWiCeP7Dzg73OpQwsAB1Eb8HnGEz5xYBzCfbu+YjoaJsJs+qheDxVAuqbt3ILEw==",
             "dev": true,
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -821,12 +821,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-block-scoping": {
-            "version": "7.12.13",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.13.tgz",
-            "integrity": "sha512-Pxwe0iqWJX4fOOM2kEZeUuAxHMWb9nK+9oh5d11bsLoB0xMg+mkDpt0eYuDZB7ETrY9bbcVlKUGTOGWy7BHsMQ==",
+            "version": "7.13.16",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.13.16.tgz",
+            "integrity": "sha512-ad3PHUxGnfWF4Efd3qFuznEtZKoBp0spS+DgqzVzRPV7urEBvPLue3y2j80w4Jf2YLzZHj8TOv/Lmvdmh3b2xg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.12.13"
+                "@babel/helper-plugin-utils": "^7.13.0"
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0-0"
@@ -863,9 +863,9 @@
             }
         },
         "node_modules/@babel/plugin-transform-destructuring": {
-            "version": "7.13.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.13.0.tgz",
-            "integrity": "sha512-zym5em7tePoNT9s964c0/KU3JPPnuq7VhIxPRefJ4/s82cD+q1mgKfuGRDMCPL0HTyKz4dISuQlCusfgCJ86HA==",
+            "version": "7.13.17",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.13.17.tgz",
+            "integrity": "sha512-UAUqiLv+uRLO+xuBKKMEpC+t7YRNVRqBsWWq1yKXbBZBje/t3IXCiSinZhjn/DC3qzBfICeYd2EFGEbHsh5RLA==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.13.0"
@@ -1322,9 +1322,9 @@
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.13.10",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
-            "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+            "version": "7.13.17",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.17.tgz",
+            "integrity": "sha512-NCdgJEelPTSh+FEFylhnP1ylq848l1z9t9N0j1Lfbcw0+KXGjsTvUmkxy+voLLXB5SOKMbLLx4jxYliGrYQseA==",
             "dev": true,
             "dependencies": {
                 "regenerator-runtime": "^0.13.4"
@@ -1342,29 +1342,28 @@
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.13.15",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.15.tgz",
-            "integrity": "sha512-/mpZMNvj6bce59Qzl09fHEs8Bt8NnpEDQYleHUPZQ3wXUMvXi+HJPLars68oAbmp839fGoOkv2pSL2z9ajCIaQ==",
+            "version": "7.13.17",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.17.tgz",
+            "integrity": "sha512-BMnZn0R+X6ayqm3C3To7o1j7Q020gWdqdyP50KEoVqaCO2c/Im7sYZSmVgvefp8TTMQ+9CtwuBp0Z1CZ8V3Pvg==",
             "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.12.13",
-                "@babel/generator": "^7.13.9",
+                "@babel/generator": "^7.13.16",
                 "@babel/helper-function-name": "^7.12.13",
                 "@babel/helper-split-export-declaration": "^7.12.13",
-                "@babel/parser": "^7.13.15",
-                "@babel/types": "^7.13.14",
+                "@babel/parser": "^7.13.16",
+                "@babel/types": "^7.13.17",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.13.14",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
-            "integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
+            "version": "7.13.17",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.17.tgz",
+            "integrity": "sha512-RawydLgxbOPDlTLJNtoIypwdmAy//uQIzlKt2+iBiJaRlVuI6QLUxVAyWGNfOzp8Yu4L4lLIacoCyTNtpb4wiA==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-validator-identifier": "^7.12.11",
-                "lodash": "^4.17.19",
                 "to-fast-properties": "^2.0.0"
             }
         },
@@ -1945,9 +1944,9 @@
             }
         },
         "node_modules/@types/estree": {
-            "version": "0.0.46",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
-            "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg==",
+            "version": "0.0.47",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.47.tgz",
+            "integrity": "sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==",
             "dev": true
         },
         "node_modules/@types/glob": {
@@ -3245,15 +3244,15 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001210",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001210.tgz",
-            "integrity": "sha512-avmGf0Jo00I8vB0I89J4Pba48kddasErV7slu7wrkyM5uY9gE5P+B+V3hjABv8Hp4YNG2nBqIUFUXlnqNteXEA==",
+            "version": "1.0.30001214",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001214.tgz",
+            "integrity": "sha512-O2/SCpuaU3eASWVaesQirZv1MSjUNOvmugaD8zNSJqw6Vv5SGwoOpA9LJs3pNPfM745nxqPvfZY3MQKY4AKHYg==",
             "dev": true
         },
         "node_modules/chalk": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-            "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+            "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
             "dev": true,
             "dependencies": {
                 "ansi-styles": "^4.1.0",
@@ -3764,12 +3763,12 @@
             }
         },
         "node_modules/core-js-compat": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.10.1.tgz",
-            "integrity": "sha512-ZHQTdTPkqvw2CeHiZC970NNJcnwzT6YIueDMASKt+p3WbZsLXOcoD392SkcWhkC0wBBHhlfhqGKKsNCQUozYtg==",
+            "version": "3.10.2",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.10.2.tgz",
+            "integrity": "sha512-IGHnpuaM1N++gLSPI1F1wu3WXICPxSyj/Q++clcwsIOnUVp5uKUIPl/+6h0TQ112KU3fMiSxqJuM+OrCyKj5+A==",
             "dev": true,
             "dependencies": {
-                "browserslist": "^4.16.3",
+                "browserslist": "^4.16.4",
                 "semver": "7.0.0"
             },
             "funding": {
@@ -4049,9 +4048,9 @@
             }
         },
         "node_modules/css-loader": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.2.tgz",
-            "integrity": "sha512-IS722y7Lh2Yq+acMR74tdf3faMOLRP2RfLwS0VzSS7T98IHtacMWJLku3A0OBTFHB07zAa4nWBhA8gfxwQVWGQ==",
+            "version": "5.2.4",
+            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.4.tgz",
+            "integrity": "sha512-OFYGyINCKkdQsTrSYxzGSFnGS4gNjcXkKkQgWxK138jgnPt+lepxdjSZNc8sHAl5vP3DhsJUxufWIjOwI8PMMw==",
             "dev": true,
             "dependencies": {
                 "camelcase": "^6.2.0",
@@ -5048,9 +5047,9 @@
             "dev": true
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.3.717",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.717.tgz",
-            "integrity": "sha512-OfzVPIqD1MkJ7fX+yTl2nKyOE4FReeVfMCzzxQS+Kp43hZYwHwThlGP+EGIZRXJsxCM7dqo8Y65NOX/HP12iXQ==",
+            "version": "1.3.719",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.719.tgz",
+            "integrity": "sha512-heM78GKSqrIzO9Oz0/y22nTBN7bqSP1Pla2SyU9DiSnQD+Ea9SyyN5RWWlgqsqeBLNDkSlE9J9EHFmdMPzxB/g==",
             "dev": true
         },
         "node_modules/elliptic": {
@@ -5099,9 +5098,9 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.7.0.tgz",
-            "integrity": "sha512-6njwt/NsZFUKhM6j9U8hzVyD4E4r0x7NQzhTCbcWOJ0IQjNSAoalWmb0AE51Wn+fwan5qVESWi7t2ToBxs9vrw==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.0.tgz",
+            "integrity": "sha512-Sl3KRpJA8OpprrtaIswVki3cWPiPKxXuFxJXBp+zNb6s6VwNWwFRUdtmzd2ReUut8n+sCPx7QCtQ7w5wfJhSgQ==",
             "dev": true,
             "dependencies": {
                 "graceful-fs": "^4.2.4",
@@ -7371,9 +7370,9 @@
             }
         },
         "node_modules/laravel-mix": {
-            "version": "6.0.16",
-            "resolved": "https://registry.npmjs.org/laravel-mix/-/laravel-mix-6.0.16.tgz",
-            "integrity": "sha512-d+u9zG2AsoONT+Z/Vbn73RDkgDJtR0dAH6UoZCNb8ewm+dG2JURYI9oOe8C/w4zKekb1GSIj832LvR2hVrqHGw==",
+            "version": "6.0.18",
+            "resolved": "https://registry.npmjs.org/laravel-mix/-/laravel-mix-6.0.18.tgz",
+            "integrity": "sha512-OIyJFvpdyPRS6UWAbECwK1hRvba7VkH2wJIMWY8bButecpd+6Zde4/uKFDs/Up31jzOh8qPxObkamcsGxGq3jg==",
             "dev": true,
             "dependencies": {
                 "@babel/core": "^7.12.3",
@@ -7400,7 +7399,7 @@
                 "commander": "^7.1.0",
                 "concat": "^1.0.3",
                 "css-loader": "^5.0.0",
-                "cssnano": "^4.1.10",
+                "cssnano": "^4.1.11",
                 "dotenv": "^8.2.0",
                 "dotenv-expand": "^5.1.0",
                 "file-loader": "^6.1.1",
@@ -7416,6 +7415,7 @@
                 "postcss-load-config": "^3.0.0",
                 "postcss-loader": "^5.2.0",
                 "semver": "^7.3.4",
+                "strip-ansi": "^6.0.0",
                 "style-loader": "^2.0.0",
                 "terser": "^5.3.7",
                 "terser-webpack-plugin": "^5.0.0",
@@ -7662,9 +7662,9 @@
             }
         },
         "node_modules/mem": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/mem/-/mem-8.1.0.tgz",
-            "integrity": "sha512-FIkgXo0kTi3XpvaznV5Muk6Y6w8SkdmRXcY7ZLonQesuYezp59UooLxAVBcGuN6PH2tXN84mR3vyzSc6oSMUfA==",
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/mem/-/mem-8.1.1.tgz",
+            "integrity": "sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==",
             "dev": true,
             "dependencies": {
                 "map-age-cleaner": "^0.1.3",
@@ -12246,14 +12246,12 @@
             }
         },
         "node_modules/postcss-selector-parser": {
-            "version": "6.0.4",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz",
-            "integrity": "sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==",
+            "version": "6.0.5",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.5.tgz",
+            "integrity": "sha512-aFYPoYmXbZ1V6HZaSvat08M97A8HqO6Pjz+PiNpw/DhuRrC72XWAdp3hL6wusDCN31sSmcZyMGa2hZEuX+Xfhg==",
             "dev": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
-                "indexes-of": "^1.0.1",
-                "uniq": "^1.0.1",
                 "util-deprecate": "^1.0.2"
             },
             "engines": {
@@ -13339,9 +13337,9 @@
             "dev": true
         },
         "node_modules/sass": {
-            "version": "1.32.10",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.10.tgz",
-            "integrity": "sha512-Nx0pcWoonAkn7CRp0aE/hket1UP97GiR1IFw3kcjV3pnenhWgZEWUf0ZcfPOV2fK52fnOcK3JdC/YYZ9E47DTQ==",
+            "version": "1.32.11",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.11.tgz",
+            "integrity": "sha512-O9tRcob/fegUVSIV1ihLLZcftIOh0AF1VpKgusUfLqnb2jQ0GLDwI5ivv1FYWivGv8eZ/AwntTyTzjcHu0c/qw==",
             "dev": true,
             "dependencies": {
                 "chokidar": ">=3.0.0 <4.0.0"
@@ -15103,20 +15101,20 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.33.2",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.33.2.tgz",
-            "integrity": "sha512-X4b7F1sYBmJx8mlh2B7mV5szEkE0jYNJ2y3akgAP0ERi0vLCG1VvdsIxt8lFd4st6SUy0lf7W0CCQS566MBpJg==",
+            "version": "5.35.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.35.0.tgz",
+            "integrity": "sha512-au3gu55yYF/h6NXFr0KZPZAYxS6Nlc595BzYPke8n0CSff5WXcoixtjh5LC/8mXunkRKxhymhXmBY0+kEbR6jg==",
             "dev": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.0",
-                "@types/estree": "^0.0.46",
+                "@types/estree": "^0.0.47",
                 "@webassemblyjs/ast": "1.11.0",
                 "@webassemblyjs/wasm-edit": "1.11.0",
                 "@webassemblyjs/wasm-parser": "1.11.0",
                 "acorn": "^8.0.4",
                 "browserslist": "^4.14.5",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.7.0",
+                "enhanced-resolve": "^5.8.0",
                 "es-module-lexer": "^0.4.0",
                 "eslint-scope": "^5.1.1",
                 "events": "^3.2.0",
@@ -15621,20 +15619,20 @@
             "dev": true
         },
         "@babel/core": {
-            "version": "7.13.15",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.15.tgz",
-            "integrity": "sha512-6GXmNYeNjS2Uz+uls5jalOemgIhnTMeaXo+yBUA72kC2uX/8VW6XyhVIo2L8/q0goKQA3EVKx0KOQpVKSeWadQ==",
+            "version": "7.13.16",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.16.tgz",
+            "integrity": "sha512-sXHpixBiWWFti0AV2Zq7avpTasr6sIAu7Y396c608541qAU2ui4a193m0KSQmfPSKFZLnQ3cvlKDOm3XkuXm3Q==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.12.13",
-                "@babel/generator": "^7.13.9",
-                "@babel/helper-compilation-targets": "^7.13.13",
+                "@babel/generator": "^7.13.16",
+                "@babel/helper-compilation-targets": "^7.13.16",
                 "@babel/helper-module-transforms": "^7.13.14",
-                "@babel/helpers": "^7.13.10",
-                "@babel/parser": "^7.13.15",
+                "@babel/helpers": "^7.13.16",
+                "@babel/parser": "^7.13.16",
                 "@babel/template": "^7.12.13",
                 "@babel/traverse": "^7.13.15",
-                "@babel/types": "^7.13.14",
+                "@babel/types": "^7.13.16",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -15652,12 +15650,12 @@
             }
         },
         "@babel/generator": {
-            "version": "7.13.9",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
-            "integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
+            "version": "7.13.16",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.16.tgz",
+            "integrity": "sha512-grBBR75UnKOcUWMp8WoDxNsWCFl//XCK6HWTrBQKTr5SV9f5g0pNOjdyzi/DTBv12S9GnYPInIXQBTky7OXEMg==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.13.0",
+                "@babel/types": "^7.13.16",
                 "jsesc": "^2.5.1",
                 "source-map": "^0.5.0"
             }
@@ -15682,12 +15680,12 @@
             }
         },
         "@babel/helper-compilation-targets": {
-            "version": "7.13.13",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.13.tgz",
-            "integrity": "sha512-q1kcdHNZehBwD9jYPh3WyXcsFERi39X4I59I3NadciWtNDyZ6x+GboOxncFK0kXlKIv6BJm5acncehXWUjWQMQ==",
+            "version": "7.13.16",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.16.tgz",
+            "integrity": "sha512-3gmkYIrpqsLlieFwjkGgLaSHmhnvlAYzZLlYVjlW+QwI+1zE17kGxuJGmIqDQdYp56XdmGeD+Bswx0UTyG18xA==",
             "dev": true,
             "requires": {
-                "@babel/compat-data": "^7.13.12",
+                "@babel/compat-data": "^7.13.15",
                 "@babel/helper-validator-option": "^7.12.17",
                 "browserslist": "^4.14.5",
                 "semver": "^6.3.0"
@@ -15778,13 +15776,13 @@
             }
         },
         "@babel/helper-hoist-variables": {
-            "version": "7.13.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.13.0.tgz",
-            "integrity": "sha512-0kBzvXiIKfsCA0y6cFEIJf4OdzfpRuNk4+YTeHZpGGc666SATFKTz6sRncwFnQk7/ugJ4dSrCj6iJuvW4Qwr2g==",
+            "version": "7.13.16",
+            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.13.16.tgz",
+            "integrity": "sha512-1eMtTrXtrwscjcAeO4BVK+vvkxaLJSPFz1w1KLawz6HLNi9bPFGBNwwDyVfiu1Tv/vRRFYfoGaKhmAQPGPn5Wg==",
             "dev": true,
             "requires": {
-                "@babel/traverse": "^7.13.0",
-                "@babel/types": "^7.13.0"
+                "@babel/traverse": "^7.13.15",
+                "@babel/types": "^7.13.16"
             }
         },
         "@babel/helper-member-expression-to-functions": {
@@ -15911,14 +15909,14 @@
             }
         },
         "@babel/helpers": {
-            "version": "7.13.10",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.10.tgz",
-            "integrity": "sha512-4VO883+MWPDUVRF3PhiLBUFHoX/bsLTGFpFK/HqvvfBZz2D57u9XzPVNFVBTc0PW/CWR9BXTOKt8NF4DInUHcQ==",
+            "version": "7.13.17",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.17.tgz",
+            "integrity": "sha512-Eal4Gce4kGijo1/TGJdqp3WuhllaMLSrW6XcL0ulyUAQOuxHcCafZE8KHg9857gcTehsm/v7RcOx2+jp0Ryjsg==",
             "dev": true,
             "requires": {
                 "@babel/template": "^7.12.13",
-                "@babel/traverse": "^7.13.0",
-                "@babel/types": "^7.13.0"
+                "@babel/traverse": "^7.13.17",
+                "@babel/types": "^7.13.17"
             }
         },
         "@babel/highlight": {
@@ -15985,9 +15983,9 @@
             }
         },
         "@babel/parser": {
-            "version": "7.13.15",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.15.tgz",
-            "integrity": "sha512-b9COtcAlVEQljy/9fbcMHpG+UIW9ReF+gpaxDHTlZd0c6/UU9ng8zdySAW9sRTzpvcdCHn6bUcbuYUgGzLAWVQ==",
+            "version": "7.13.16",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.16.tgz",
+            "integrity": "sha512-6bAg36mCwuqLO0hbR+z7PHuqWiCeP7Dzg73OpQwsAB1Eb8HnGEz5xYBzCfbu+YjoaJsJs+qheDxVAuqbt3ILEw==",
             "dev": true
         },
         "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
@@ -16274,12 +16272,12 @@
             }
         },
         "@babel/plugin-transform-block-scoping": {
-            "version": "7.12.13",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.13.tgz",
-            "integrity": "sha512-Pxwe0iqWJX4fOOM2kEZeUuAxHMWb9nK+9oh5d11bsLoB0xMg+mkDpt0eYuDZB7ETrY9bbcVlKUGTOGWy7BHsMQ==",
+            "version": "7.13.16",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.13.16.tgz",
+            "integrity": "sha512-ad3PHUxGnfWF4Efd3qFuznEtZKoBp0spS+DgqzVzRPV7urEBvPLue3y2j80w4Jf2YLzZHj8TOv/Lmvdmh3b2xg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.12.13"
+                "@babel/helper-plugin-utils": "^7.13.0"
             }
         },
         "@babel/plugin-transform-classes": {
@@ -16307,9 +16305,9 @@
             }
         },
         "@babel/plugin-transform-destructuring": {
-            "version": "7.13.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.13.0.tgz",
-            "integrity": "sha512-zym5em7tePoNT9s964c0/KU3JPPnuq7VhIxPRefJ4/s82cD+q1mgKfuGRDMCPL0HTyKz4dISuQlCusfgCJ86HA==",
+            "version": "7.13.17",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.13.17.tgz",
+            "integrity": "sha512-UAUqiLv+uRLO+xuBKKMEpC+t7YRNVRqBsWWq1yKXbBZBje/t3IXCiSinZhjn/DC3qzBfICeYd2EFGEbHsh5RLA==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.13.0"
@@ -16677,9 +16675,9 @@
             }
         },
         "@babel/runtime": {
-            "version": "7.13.10",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
-            "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+            "version": "7.13.17",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.17.tgz",
+            "integrity": "sha512-NCdgJEelPTSh+FEFylhnP1ylq848l1z9t9N0j1Lfbcw0+KXGjsTvUmkxy+voLLXB5SOKMbLLx4jxYliGrYQseA==",
             "dev": true,
             "requires": {
                 "regenerator-runtime": "^0.13.4"
@@ -16697,29 +16695,28 @@
             }
         },
         "@babel/traverse": {
-            "version": "7.13.15",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.15.tgz",
-            "integrity": "sha512-/mpZMNvj6bce59Qzl09fHEs8Bt8NnpEDQYleHUPZQ3wXUMvXi+HJPLars68oAbmp839fGoOkv2pSL2z9ajCIaQ==",
+            "version": "7.13.17",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.17.tgz",
+            "integrity": "sha512-BMnZn0R+X6ayqm3C3To7o1j7Q020gWdqdyP50KEoVqaCO2c/Im7sYZSmVgvefp8TTMQ+9CtwuBp0Z1CZ8V3Pvg==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.12.13",
-                "@babel/generator": "^7.13.9",
+                "@babel/generator": "^7.13.16",
                 "@babel/helper-function-name": "^7.12.13",
                 "@babel/helper-split-export-declaration": "^7.12.13",
-                "@babel/parser": "^7.13.15",
-                "@babel/types": "^7.13.14",
+                "@babel/parser": "^7.13.16",
+                "@babel/types": "^7.13.17",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
             }
         },
         "@babel/types": {
-            "version": "7.13.14",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
-            "integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
+            "version": "7.13.17",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.17.tgz",
+            "integrity": "sha512-RawydLgxbOPDlTLJNtoIypwdmAy//uQIzlKt2+iBiJaRlVuI6QLUxVAyWGNfOzp8Yu4L4lLIacoCyTNtpb4wiA==",
             "dev": true,
             "requires": {
                 "@babel/helper-validator-identifier": "^7.12.11",
-                "lodash": "^4.17.19",
                 "to-fast-properties": "^2.0.0"
             }
         },
@@ -17208,9 +17205,9 @@
             }
         },
         "@types/estree": {
-            "version": "0.0.46",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
-            "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg==",
+            "version": "0.0.47",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.47.tgz",
+            "integrity": "sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==",
             "dev": true
         },
         "@types/glob": {
@@ -18301,15 +18298,15 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001210",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001210.tgz",
-            "integrity": "sha512-avmGf0Jo00I8vB0I89J4Pba48kddasErV7slu7wrkyM5uY9gE5P+B+V3hjABv8Hp4YNG2nBqIUFUXlnqNteXEA==",
+            "version": "1.0.30001214",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001214.tgz",
+            "integrity": "sha512-O2/SCpuaU3eASWVaesQirZv1MSjUNOvmugaD8zNSJqw6Vv5SGwoOpA9LJs3pNPfM745nxqPvfZY3MQKY4AKHYg==",
             "dev": true
         },
         "chalk": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-            "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+            "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
             "dev": true,
             "requires": {
                 "ansi-styles": "^4.1.0",
@@ -18736,12 +18733,12 @@
             "dev": true
         },
         "core-js-compat": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.10.1.tgz",
-            "integrity": "sha512-ZHQTdTPkqvw2CeHiZC970NNJcnwzT6YIueDMASKt+p3WbZsLXOcoD392SkcWhkC0wBBHhlfhqGKKsNCQUozYtg==",
+            "version": "3.10.2",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.10.2.tgz",
+            "integrity": "sha512-IGHnpuaM1N++gLSPI1F1wu3WXICPxSyj/Q++clcwsIOnUVp5uKUIPl/+6h0TQ112KU3fMiSxqJuM+OrCyKj5+A==",
             "dev": true,
             "requires": {
-                "browserslist": "^4.16.3",
+                "browserslist": "^4.16.4",
                 "semver": "7.0.0"
             },
             "dependencies": {
@@ -18978,9 +18975,9 @@
             }
         },
         "css-loader": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.2.tgz",
-            "integrity": "sha512-IS722y7Lh2Yq+acMR74tdf3faMOLRP2RfLwS0VzSS7T98IHtacMWJLku3A0OBTFHB07zAa4nWBhA8gfxwQVWGQ==",
+            "version": "5.2.4",
+            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.4.tgz",
+            "integrity": "sha512-OFYGyINCKkdQsTrSYxzGSFnGS4gNjcXkKkQgWxK138jgnPt+lepxdjSZNc8sHAl5vP3DhsJUxufWIjOwI8PMMw==",
             "dev": true,
             "requires": {
                 "camelcase": "^6.2.0",
@@ -19771,9 +19768,9 @@
             "dev": true
         },
         "electron-to-chromium": {
-            "version": "1.3.717",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.717.tgz",
-            "integrity": "sha512-OfzVPIqD1MkJ7fX+yTl2nKyOE4FReeVfMCzzxQS+Kp43hZYwHwThlGP+EGIZRXJsxCM7dqo8Y65NOX/HP12iXQ==",
+            "version": "1.3.719",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.719.tgz",
+            "integrity": "sha512-heM78GKSqrIzO9Oz0/y22nTBN7bqSP1Pla2SyU9DiSnQD+Ea9SyyN5RWWlgqsqeBLNDkSlE9J9EHFmdMPzxB/g==",
             "dev": true
         },
         "elliptic": {
@@ -19818,9 +19815,9 @@
             "dev": true
         },
         "enhanced-resolve": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.7.0.tgz",
-            "integrity": "sha512-6njwt/NsZFUKhM6j9U8hzVyD4E4r0x7NQzhTCbcWOJ0IQjNSAoalWmb0AE51Wn+fwan5qVESWi7t2ToBxs9vrw==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.0.tgz",
+            "integrity": "sha512-Sl3KRpJA8OpprrtaIswVki3cWPiPKxXuFxJXBp+zNb6s6VwNWwFRUdtmzd2ReUut8n+sCPx7QCtQ7w5wfJhSgQ==",
             "dev": true,
             "requires": {
                 "graceful-fs": "^4.2.4",
@@ -21550,9 +21547,9 @@
             "dev": true
         },
         "laravel-mix": {
-            "version": "6.0.16",
-            "resolved": "https://registry.npmjs.org/laravel-mix/-/laravel-mix-6.0.16.tgz",
-            "integrity": "sha512-d+u9zG2AsoONT+Z/Vbn73RDkgDJtR0dAH6UoZCNb8ewm+dG2JURYI9oOe8C/w4zKekb1GSIj832LvR2hVrqHGw==",
+            "version": "6.0.18",
+            "resolved": "https://registry.npmjs.org/laravel-mix/-/laravel-mix-6.0.18.tgz",
+            "integrity": "sha512-OIyJFvpdyPRS6UWAbECwK1hRvba7VkH2wJIMWY8bButecpd+6Zde4/uKFDs/Up31jzOh8qPxObkamcsGxGq3jg==",
             "dev": true,
             "requires": {
                 "@babel/core": "^7.12.3",
@@ -21579,7 +21576,7 @@
                 "commander": "^7.1.0",
                 "concat": "^1.0.3",
                 "css-loader": "^5.0.0",
-                "cssnano": "^4.1.10",
+                "cssnano": "^4.1.11",
                 "dotenv": "^8.2.0",
                 "dotenv-expand": "^5.1.0",
                 "file-loader": "^6.1.1",
@@ -21595,6 +21592,7 @@
                 "postcss-load-config": "^3.0.0",
                 "postcss-loader": "^5.2.0",
                 "semver": "^7.3.4",
+                "strip-ansi": "^6.0.0",
                 "style-loader": "^2.0.0",
                 "terser": "^5.3.7",
                 "terser-webpack-plugin": "^5.0.0",
@@ -21799,9 +21797,9 @@
             "dev": true
         },
         "mem": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/mem/-/mem-8.1.0.tgz",
-            "integrity": "sha512-FIkgXo0kTi3XpvaznV5Muk6Y6w8SkdmRXcY7ZLonQesuYezp59UooLxAVBcGuN6PH2tXN84mR3vyzSc6oSMUfA==",
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/mem/-/mem-8.1.1.tgz",
+            "integrity": "sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==",
             "dev": true,
             "requires": {
                 "map-age-cleaner": "^0.1.3",
@@ -25396,14 +25394,12 @@
             }
         },
         "postcss-selector-parser": {
-            "version": "6.0.4",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz",
-            "integrity": "sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==",
+            "version": "6.0.5",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.5.tgz",
+            "integrity": "sha512-aFYPoYmXbZ1V6HZaSvat08M97A8HqO6Pjz+PiNpw/DhuRrC72XWAdp3hL6wusDCN31sSmcZyMGa2hZEuX+Xfhg==",
             "dev": true,
             "requires": {
                 "cssesc": "^3.0.0",
-                "indexes-of": "^1.0.1",
-                "uniq": "^1.0.1",
                 "util-deprecate": "^1.0.2"
             }
         },
@@ -26264,9 +26260,9 @@
             "dev": true
         },
         "sass": {
-            "version": "1.32.10",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.10.tgz",
-            "integrity": "sha512-Nx0pcWoonAkn7CRp0aE/hket1UP97GiR1IFw3kcjV3pnenhWgZEWUf0ZcfPOV2fK52fnOcK3JdC/YYZ9E47DTQ==",
+            "version": "1.32.11",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.11.tgz",
+            "integrity": "sha512-O9tRcob/fegUVSIV1ihLLZcftIOh0AF1VpKgusUfLqnb2jQ0GLDwI5ivv1FYWivGv8eZ/AwntTyTzjcHu0c/qw==",
             "dev": true,
             "requires": {
                 "chokidar": ">=3.0.0 <4.0.0"
@@ -27688,20 +27684,20 @@
             }
         },
         "webpack": {
-            "version": "5.33.2",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.33.2.tgz",
-            "integrity": "sha512-X4b7F1sYBmJx8mlh2B7mV5szEkE0jYNJ2y3akgAP0ERi0vLCG1VvdsIxt8lFd4st6SUy0lf7W0CCQS566MBpJg==",
+            "version": "5.35.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.35.0.tgz",
+            "integrity": "sha512-au3gu55yYF/h6NXFr0KZPZAYxS6Nlc595BzYPke8n0CSff5WXcoixtjh5LC/8mXunkRKxhymhXmBY0+kEbR6jg==",
             "dev": true,
             "requires": {
                 "@types/eslint-scope": "^3.7.0",
-                "@types/estree": "^0.0.46",
+                "@types/estree": "^0.0.47",
                 "@webassemblyjs/ast": "1.11.0",
                 "@webassemblyjs/wasm-edit": "1.11.0",
                 "@webassemblyjs/wasm-parser": "1.11.0",
                 "acorn": "^8.0.4",
                 "browserslist": "^4.14.5",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.7.0",
+                "enhanced-resolve": "^5.8.0",
                 "es-module-lexer": "^0.4.0",
                 "eslint-scope": "^5.1.1",
                 "events": "^3.2.0",

--- a/resources/markdown/community/requests.md
+++ b/resources/markdown/community/requests.md
@@ -1335,14 +1335,6 @@ Theme title|Links|Episodes|Notes
 -|-|-|-
 ED "Futuristic Player"|[Webm]()||
 
-### [Sazae-san](https://myanimelist.net/anime/2406/)
-**Mrs. Sazae**
-
-Theme title|Links|Episodes|Notes
--|-|-|-
-OP "Sazae-san"|[Webm]()||
-ED "Sazae-san Ikka"|[Webm]()||
-
 ### [Sengoku Musou](https://myanimelist.net/anime/28283/)
 **Samurai Warriors**
 

--- a/tests/Feature/Http/Api/Anime/AnimeIndexTest.php
+++ b/tests/Feature/Http/Api/Anime/AnimeIndexTest.php
@@ -30,14 +30,15 @@ class AnimeIndexTest extends TestCase
     use RefreshDatabase, WithFaker;
 
     /**
-     * By default, the Anime Index Endpoint shall return a collection of Anime Resources with all allowed include paths.
+     * By default, the Anime Index Endpoint shall return a collection of Anime Resources.
      *
      * @return void
      */
     public function testDefault()
     {
-        Anime::factory()->jsonApiResource()->count($this->faker->numberBetween(1, 3))->create();
-        $anime = Anime::with(AnimeCollection::allowedIncludePaths())->get();
+        $this->withoutEvents();
+
+        $anime = Anime::factory()->count($this->faker->numberBetween(1, 3))->create();
 
         $response = $this->get(route('api.anime.index'));
 
@@ -60,6 +61,8 @@ class AnimeIndexTest extends TestCase
      */
     public function testPaginated()
     {
+        $this->withoutEvents();
+
         Anime::factory()->count($this->faker->randomDigitNotNull)->create();
 
         $response = $this->get(route('api.anime.index'));
@@ -109,6 +112,8 @@ class AnimeIndexTest extends TestCase
      */
     public function testSparseFieldsets()
     {
+        $this->withoutEvents();
+
         $fields = collect([
             'id',
             'name',
@@ -129,8 +134,7 @@ class AnimeIndexTest extends TestCase
             ],
         ];
 
-        Anime::factory()->count($this->faker->randomDigitNotNull)->create();
-        $anime = Anime::with(AnimeCollection::allowedIncludePaths())->get();
+        $anime = Anime::factory()->count($this->faker->randomDigitNotNull)->create();
 
         $response = $this->get(route('api.anime.index', $parameters));
 
@@ -153,6 +157,8 @@ class AnimeIndexTest extends TestCase
      */
     public function testSorts()
     {
+        $this->withoutEvents();
+
         $allowed_sorts = collect(AnimeCollection::allowedSortFields());
         $included_sorts = $allowed_sorts->random($this->faker->numberBetween(1, count($allowed_sorts)))->map(function ($included_sort) {
             if ($this->faker->boolean()) {
@@ -172,7 +178,7 @@ class AnimeIndexTest extends TestCase
 
         Anime::factory()->count($this->faker->randomDigitNotNull)->create();
 
-        $builder = Anime::with(AnimeCollection::allowedIncludePaths());
+        $builder = Anime::query();
 
         foreach ($parser->getSorts() as $field => $isAsc) {
             $builder = $builder->orderBy(Str::lower($field), $isAsc ? 'asc' : 'desc');
@@ -199,6 +205,8 @@ class AnimeIndexTest extends TestCase
      */
     public function testSeasonFilter()
     {
+        $this->withoutEvents();
+
         $season_filter = AnimeSeason::getRandomInstance();
 
         $parameters = [
@@ -231,6 +239,8 @@ class AnimeIndexTest extends TestCase
      */
     public function testYearFilter()
     {
+        $this->withoutEvents();
+
         $year_filter = $this->faker->numberBetween(2000, 2002);
 
         $parameters = [
@@ -271,6 +281,8 @@ class AnimeIndexTest extends TestCase
      */
     public function testCreatedAtFilter()
     {
+        $this->withoutEvents();
+
         $created_filter = $this->faker->date();
         $excluded_date = $this->faker->date();
 
@@ -311,6 +323,8 @@ class AnimeIndexTest extends TestCase
      */
     public function testUpdatedAtFilter()
     {
+        $this->withoutEvents();
+
         $updated_filter = $this->faker->date();
         $excluded_date = $this->faker->date();
 
@@ -351,6 +365,8 @@ class AnimeIndexTest extends TestCase
      */
     public function testWithoutTrashedFilter()
     {
+        $this->withoutEvents();
+
         $parameters = [
             QueryParser::PARAM_FILTER => [
                 'trashed' => TrashedStatus::WITHOUT,
@@ -387,6 +403,8 @@ class AnimeIndexTest extends TestCase
      */
     public function testWithTrashedFilter()
     {
+        $this->withoutEvents();
+
         $parameters = [
             QueryParser::PARAM_FILTER => [
                 'trashed' => TrashedStatus::WITH,
@@ -423,6 +441,8 @@ class AnimeIndexTest extends TestCase
      */
     public function testOnlyTrashedFilter()
     {
+        $this->withoutEvents();
+
         $parameters = [
             QueryParser::PARAM_FILTER => [
                 'trashed' => TrashedStatus::ONLY,
@@ -459,6 +479,8 @@ class AnimeIndexTest extends TestCase
      */
     public function testDeletedAtFilter()
     {
+        $this->withoutEvents();
+
         $deleted_filter = $this->faker->date();
         $excluded_date = $this->faker->date();
 
@@ -513,6 +535,7 @@ class AnimeIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'group' => $group_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'themes',
         ];
 
         Anime::factory()
@@ -562,6 +585,7 @@ class AnimeIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'sequence' => $sequence_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'themes',
         ];
 
         Anime::factory()
@@ -610,6 +634,7 @@ class AnimeIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'type' => $type_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'themes',
         ];
 
         Anime::factory()
@@ -651,6 +676,7 @@ class AnimeIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'nsfw' => $nsfw_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'themes.entries',
         ];
 
         Anime::factory()
@@ -696,6 +722,7 @@ class AnimeIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'spoiler' => $spoiler_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'themes.entries',
         ];
 
         Anime::factory()
@@ -742,6 +769,7 @@ class AnimeIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'version' => $version_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'themes.entries',
         ];
 
         Anime::factory()
@@ -794,6 +822,7 @@ class AnimeIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'site' => $site_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'externalResources',
         ];
 
         Anime::factory()
@@ -835,6 +864,7 @@ class AnimeIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'facet' => $facet_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'images',
         ];
 
         Anime::factory()
@@ -876,6 +906,7 @@ class AnimeIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'lyrics' => $lyrics_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'themes.entries.videos',
         ];
 
         Anime::factory()->jsonApiResource()->count($this->faker->numberBetween(1, 3))->create();
@@ -914,6 +945,7 @@ class AnimeIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'nc' => $nc_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'themes.entries.videos',
         ];
 
         Anime::factory()->jsonApiResource()->count($this->faker->numberBetween(1, 3))->create();
@@ -952,6 +984,7 @@ class AnimeIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'overlap' => $overlap_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'themes.entries.videos',
         ];
 
         Anime::factory()->jsonApiResource()->count($this->faker->numberBetween(1, 3))->create();
@@ -991,6 +1024,7 @@ class AnimeIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'resolution' => $resolution_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'themes.entries.videos',
         ];
 
         Anime::factory()
@@ -1047,6 +1081,7 @@ class AnimeIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'source' => $source_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'themes.entries.videos',
         ];
 
         Anime::factory()->jsonApiResource()->count($this->faker->numberBetween(1, 3))->create();
@@ -1085,6 +1120,7 @@ class AnimeIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'subbed' => $subbed_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'themes.entries.videos',
         ];
 
         Anime::factory()->jsonApiResource()->count($this->faker->numberBetween(1, 3))->create();
@@ -1123,6 +1159,7 @@ class AnimeIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'uncen' => $uncen_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'themes.entries.videos',
         ];
 
         Anime::factory()->jsonApiResource()->count($this->faker->numberBetween(1, 3))->create();

--- a/tests/Feature/Http/Api/Anime/AnimeShowTest.php
+++ b/tests/Feature/Http/Api/Anime/AnimeShowTest.php
@@ -18,6 +18,7 @@ use App\Models\Video;
 use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\WithoutEvents;
 use Tests\TestCase;
 
 class AnimeShowTest extends TestCase
@@ -25,14 +26,15 @@ class AnimeShowTest extends TestCase
     use RefreshDatabase, WithFaker;
 
     /**
-     * By default, the Anime Show Endpoint shall return an Anime Resource with all allowed include paths.
+     * By default, the Anime Show Endpoint shall return an Anime Resource.
      *
      * @return void
      */
     public function testDefault()
     {
-        Anime::factory()->jsonApiResource()->create();
-        $anime = Anime::with(AnimeResource::allowedIncludePaths())->first();
+        $this->withoutEvents();
+
+        $anime = Anime::factory()->create();
 
         $response = $this->get(route('api.anime.show', ['anime' => $anime]));
 
@@ -49,17 +51,19 @@ class AnimeShowTest extends TestCase
     }
 
     /**
-     * The Image Show Endpoint shall return an Anime Resource for soft deleted anime.
+     * The Anime Show Endpoint shall return an Anime Resource for soft deleted anime.
      *
      * @return void
      */
     public function testSoftDelete()
     {
+        $this->withoutEvents();
+
         $anime = Anime::factory()->createOne();
 
         $anime->delete();
 
-        $anime = Anime::withTrashed()->with(AnimeResource::allowedIncludePaths())->first();
+        $anime->unsetRelations();
 
         $response = $this->get(route('api.anime.show', ['anime' => $anime]));
 
@@ -113,6 +117,8 @@ class AnimeShowTest extends TestCase
      */
     public function testSparseFieldsets()
     {
+        $this->withoutEvents();
+
         $fields = collect([
             'id',
             'name',
@@ -133,8 +139,7 @@ class AnimeShowTest extends TestCase
             ],
         ];
 
-        Anime::factory()->create();
-        $anime = Anime::with(AnimeResource::allowedIncludePaths())->first();
+        $anime = Anime::factory()->create();
 
         $response = $this->get(route('api.anime.show', ['anime' => $anime] + $parameters));
 
@@ -164,6 +169,7 @@ class AnimeShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'group' => $group_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'themes',
         ];
 
         Anime::factory()
@@ -212,6 +218,7 @@ class AnimeShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'sequence' => $sequence_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'themes',
         ];
 
         Anime::factory()
@@ -259,6 +266,7 @@ class AnimeShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'type' => $type_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'themes',
         ];
 
         Anime::factory()
@@ -299,6 +307,7 @@ class AnimeShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'nsfw' => $nsfw_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'themes.entries',
         ];
 
         Anime::factory()
@@ -343,6 +352,7 @@ class AnimeShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'spoiler' => $spoiler_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'themes.entries',
         ];
 
         Anime::factory()
@@ -388,6 +398,7 @@ class AnimeShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'version' => $version_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'themes.entries',
         ];
 
         Anime::factory()
@@ -433,12 +444,15 @@ class AnimeShowTest extends TestCase
      */
     public function testResourcesBySite()
     {
+        $this->withoutEvents();
+
         $site_filter = ResourceSite::getRandomInstance();
 
         $parameters = [
             QueryParser::PARAM_FILTER => [
                 'site' => $site_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'externalResources',
         ];
 
         Anime::factory()
@@ -473,12 +487,15 @@ class AnimeShowTest extends TestCase
      */
     public function testImagesByFacet()
     {
+        $this->withoutEvents();
+
         $facet_filter = ImageFacet::getRandomInstance();
 
         $parameters = [
             QueryParser::PARAM_FILTER => [
                 'facet' => $facet_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'images',
         ];
 
         Anime::factory()
@@ -519,6 +536,7 @@ class AnimeShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'lyrics' => $lyrics_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'themes.entries.videos',
         ];
 
         Anime::factory()->jsonApiResource()->create();
@@ -557,6 +575,7 @@ class AnimeShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'nc' => $nc_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'themes.entries.videos',
         ];
 
         Anime::factory()->jsonApiResource()->create();
@@ -595,6 +614,7 @@ class AnimeShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'overlap' => $overlap_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'themes.entries.videos',
         ];
 
         Anime::factory()->jsonApiResource()->create();
@@ -634,6 +654,7 @@ class AnimeShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'resolution' => $resolution_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'themes.entries.videos',
         ];
 
         Anime::factory()
@@ -689,6 +710,7 @@ class AnimeShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'source' => $source_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'themes.entries.videos',
         ];
 
         Anime::factory()->jsonApiResource()->create();
@@ -727,6 +749,7 @@ class AnimeShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'subbed' => $subbed_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'themes.entries.videos',
         ];
 
         Anime::factory()->jsonApiResource()->create();
@@ -765,6 +788,7 @@ class AnimeShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'uncen' => $uncen_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'themes.entries.videos',
         ];
 
         Anime::factory()->jsonApiResource()->create();

--- a/tests/Feature/Http/Api/Anime/AnimeShowTest.php
+++ b/tests/Feature/Http/Api/Anime/AnimeShowTest.php
@@ -18,7 +18,6 @@ use App\Models\Video;
 use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
-use Illuminate\Foundation\Testing\WithoutEvents;
 use Tests\TestCase;
 
 class AnimeShowTest extends TestCase

--- a/tests/Feature/Http/Api/Anime/YearIndexTest.php
+++ b/tests/Feature/Http/Api/Anime/YearIndexTest.php
@@ -5,11 +5,12 @@ namespace Tests\Feature\Http\Api\Anime;
 use App\Models\Anime;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\WithoutEvents;
 use Tests\TestCase;
 
 class YearIndexTest extends TestCase
 {
-    use RefreshDatabase, WithFaker;
+    use RefreshDatabase, WithFaker, WithoutEvents;
 
     /**
      * The Year Index Endpoint shall display a list of unique years of anime.

--- a/tests/Feature/Http/Api/Anime/YearShowTest.php
+++ b/tests/Feature/Http/Api/Anime/YearShowTest.php
@@ -17,56 +17,54 @@ class YearShowTest extends TestCase
     use RefreshDatabase, WithFaker;
 
     /**
-     * By default, the Year Show Endpoint shall return a grouping of Anime Resources of year by season with all allowed include paths.
+     * By default, the Year Show Endpoint shall return a grouping of Anime Resources of year by season.
      *
      * @return void
      */
     public function testDefault()
     {
+        $this->withoutEvents();
+
         $year = intval($this->faker->year());
 
         Anime::factory()
             ->count($this->faker->numberBetween(1, 3))
-            ->jsonApiResource()
             ->create([
                 'year' => $year,
                 'season' => AnimeSeason::WINTER,
             ]);
 
-        $winter_anime = Anime::where('season', AnimeSeason::WINTER)->with(AnimeCollection::allowedIncludePaths())->get();
+        $winter_anime = Anime::where('season', AnimeSeason::WINTER)->get();
         $winter_resources = AnimeCollection::make($winter_anime->sortBy('name')->values(), QueryParser::make());
 
         Anime::factory()
             ->count($this->faker->numberBetween(1, 3))
-            ->jsonApiResource()
             ->create([
                 'year' => $year,
                 'season' => AnimeSeason::SPRING,
             ]);
 
-        $spring_anime = Anime::where('season', AnimeSeason::SPRING)->with(AnimeCollection::allowedIncludePaths())->get();
+        $spring_anime = Anime::where('season', AnimeSeason::SPRING)->get();
         $spring_resources = AnimeCollection::make($spring_anime->sortBy('name')->values(), QueryParser::make());
 
         Anime::factory()
             ->count($this->faker->numberBetween(1, 3))
-            ->jsonApiResource()
             ->create([
                 'year' => $year,
                 'season' => AnimeSeason::SUMMER,
             ]);
 
-        $summer_anime = Anime::where('season', AnimeSeason::SUMMER)->with(AnimeCollection::allowedIncludePaths())->get();
+        $summer_anime = Anime::where('season', AnimeSeason::SUMMER)->get();
         $summer_resources = AnimeCollection::make($summer_anime->sortBy('name')->values(), QueryParser::make());
 
         Anime::factory()
             ->count($this->faker->numberBetween(1, 3))
-            ->jsonApiResource()
             ->create([
                 'year' => $year,
                 'season' => AnimeSeason::FALL,
             ]);
 
-        $fall_anime = Anime::where('season', AnimeSeason::FALL)->with(AnimeCollection::allowedIncludePaths())->get();
+        $fall_anime = Anime::where('season', AnimeSeason::FALL)->get();
         $fall_resources = AnimeCollection::make($fall_anime->sortBy('name')->values(), QueryParser::make());
 
         $response = $this->get(route('api.year.show', ['year' => $year]));
@@ -156,6 +154,8 @@ class YearShowTest extends TestCase
      */
     public function testSparseFieldsets()
     {
+        $this->withoutEvents();
+
         $year = intval($this->faker->year());
 
         $fields = collect([
@@ -180,46 +180,42 @@ class YearShowTest extends TestCase
 
         Anime::factory()
             ->count($this->faker->numberBetween(1, 3))
-            ->jsonApiResource()
             ->create([
                 'year' => $year,
                 'season' => AnimeSeason::WINTER,
             ]);
 
-        $winter_anime = Anime::where('season', AnimeSeason::WINTER)->with(AnimeCollection::allowedIncludePaths())->get();
+        $winter_anime = Anime::where('season', AnimeSeason::WINTER)->get();
         $winter_resources = AnimeCollection::make($winter_anime->sortBy('name')->values(), QueryParser::make($parameters));
 
         Anime::factory()
             ->count($this->faker->numberBetween(1, 3))
-            ->jsonApiResource()
             ->create([
                 'year' => $year,
                 'season' => AnimeSeason::SPRING,
             ]);
 
-        $spring_anime = Anime::where('season', AnimeSeason::SPRING)->with(AnimeCollection::allowedIncludePaths())->get();
+        $spring_anime = Anime::where('season', AnimeSeason::SPRING)->get();
         $spring_resources = AnimeCollection::make($spring_anime->sortBy('name')->values(), QueryParser::make($parameters));
 
         Anime::factory()
             ->count($this->faker->numberBetween(1, 3))
-            ->jsonApiResource()
             ->create([
                 'year' => $year,
                 'season' => AnimeSeason::SUMMER,
             ]);
 
-        $summer_anime = Anime::where('season', AnimeSeason::SUMMER)->with(AnimeCollection::allowedIncludePaths())->get();
+        $summer_anime = Anime::where('season', AnimeSeason::SUMMER)->get();
         $summer_resources = AnimeCollection::make($summer_anime->sortBy('name')->values(), QueryParser::make($parameters));
 
         Anime::factory()
             ->count($this->faker->numberBetween(1, 3))
-            ->jsonApiResource()
             ->create([
                 'year' => $year,
                 'season' => AnimeSeason::FALL,
             ]);
 
-        $fall_anime = Anime::where('season', AnimeSeason::FALL)->with(AnimeCollection::allowedIncludePaths())->get();
+        $fall_anime = Anime::where('season', AnimeSeason::FALL)->get();
         $fall_resources = AnimeCollection::make($fall_anime->sortBy('name')->values(), QueryParser::make($parameters));
 
         $response = $this->get(route('api.year.show', ['year' => $year]));

--- a/tests/Feature/Http/Api/Announcement/AnnouncementIndexTest.php
+++ b/tests/Feature/Http/Api/Announcement/AnnouncementIndexTest.php
@@ -19,14 +19,13 @@ class AnnouncementIndexTest extends TestCase
     use RefreshDatabase, WithFaker, WithoutEvents;
 
     /**
-     * By default, the Announcement Index Endpoint shall return a collection of Announcement Resources with all allowed include paths.
+     * By default, the Announcement Index Endpoint shall return a collection of Announcement Resources.
      *
      * @return void
      */
     public function testDefault()
     {
-        Announcement::factory()->count($this->faker->randomDigitNotNull)->create();
-        $announcements = Announcement::with(AnnouncementCollection::allowedIncludePaths())->get();
+        $announcements = Announcement::factory()->count($this->faker->randomDigitNotNull)->create();
 
         $response = $this->get(route('api.announcement.index'));
 
@@ -114,8 +113,7 @@ class AnnouncementIndexTest extends TestCase
             ],
         ];
 
-        Announcement::factory()->count($this->faker->randomDigitNotNull)->create();
-        $announcements = Announcement::with(AnnouncementCollection::allowedIncludePaths())->get();
+        $announcements = Announcement::factory()->count($this->faker->randomDigitNotNull)->create();
 
         $response = $this->get(route('api.announcement.index', $parameters));
 
@@ -157,7 +155,7 @@ class AnnouncementIndexTest extends TestCase
 
         Announcement::factory()->count($this->faker->randomDigitNotNull)->create();
 
-        $builder = Announcement::with(AnnouncementCollection::allowedIncludePaths());
+        $builder = Announcement::query();
 
         foreach ($parser->getSorts() as $field => $isAsc) {
             $builder = $builder->orderBy(Str::lower($field), $isAsc ? 'asc' : 'desc');

--- a/tests/Feature/Http/Api/Announcement/AnnouncementShowTest.php
+++ b/tests/Feature/Http/Api/Announcement/AnnouncementShowTest.php
@@ -15,14 +15,13 @@ class AnnouncementShowTest extends TestCase
     use RefreshDatabase, WithFaker, WithoutEvents;
 
     /**
-     * By default, the Annouc Show Endpoint shall return an Announcement Resource with all allowed include paths.
+     * By default, the Annouc Show Endpoint shall return an Announcement Resource.
      *
      * @return void
      */
     public function testDefault()
     {
-        Announcement::factory()->create();
-        $announcement = Announcement::with(AnnouncementResource::allowedIncludePaths())->first();
+        $announcement = Announcement::factory()->create();
 
         $response = $this->get(route('api.announcement.show', ['announcement' => $announcement]));
 
@@ -49,7 +48,7 @@ class AnnouncementShowTest extends TestCase
 
         $announcement->delete();
 
-        $announcement = Announcement::withTrashed()->with(AnnouncementResource::allowedIncludePaths())->first();
+        $announcement->unsetRelations();
 
         $response = $this->get(route('api.announcement.show', ['announcement' => $announcement]));
 
@@ -119,8 +118,7 @@ class AnnouncementShowTest extends TestCase
             ],
         ];
 
-        Announcement::factory()->create();
-        $announcement = Announcement::with(AnnouncementResource::allowedIncludePaths())->first();
+        $announcement = Announcement::factory()->create();
 
         $response = $this->get(route('api.announcement.show', ['announcement' => $announcement]));
 

--- a/tests/Feature/Http/Api/Artist/ArtistIndexTest.php
+++ b/tests/Feature/Http/Api/Artist/ArtistIndexTest.php
@@ -28,14 +28,15 @@ class ArtistIndexTest extends TestCase
     use RefreshDatabase, WithFaker;
 
     /**
-     * By default, the Artist Index Endpoint shall return a collection of Artist Resources with all allowed include paths.
+     * By default, the Artist Index Endpoint shall return a collection of Artist Resources.
      *
      * @return void
      */
     public function testDefault()
     {
-        Artist::factory()->jsonApiResource()->create();
-        $artists = Artist::with(ArtistCollection::allowedIncludePaths())->get();
+        $this->withoutEvents();
+
+        $artists = Artist::factory()->count($this->faker->randomDigitNotNull)->create();
 
         $response = $this->get(route('api.artist.index'));
 
@@ -58,7 +59,9 @@ class ArtistIndexTest extends TestCase
      */
     public function testPaginated()
     {
-        Artist::factory()->create();
+        $this->withoutEvents();
+
+        Artist::factory()->count($this->faker->randomDigitNotNull)->create();
 
         $response = $this->get(route('api.artist.index'));
 
@@ -107,6 +110,8 @@ class ArtistIndexTest extends TestCase
      */
     public function testSparseFieldsets()
     {
+        $this->withoutEvents();
+
         $fields = collect([
             'id',
             'name',
@@ -125,8 +130,7 @@ class ArtistIndexTest extends TestCase
             ],
         ];
 
-        Artist::factory()->create();
-        $artists = Artist::with(ArtistCollection::allowedIncludePaths())->get();
+        $artists = Artist::factory()->count($this->faker->randomDigitNotNull)->create();
 
         $response = $this->get(route('api.artist.index', $parameters));
 
@@ -149,6 +153,8 @@ class ArtistIndexTest extends TestCase
      */
     public function testSorts()
     {
+        $this->withoutEvents();
+
         $allowed_sorts = collect(ArtistCollection::allowedSortFields());
         $included_sorts = $allowed_sorts->random($this->faker->numberBetween(1, count($allowed_sorts)))->map(function ($included_sort) {
             if ($this->faker->boolean()) {
@@ -166,9 +172,9 @@ class ArtistIndexTest extends TestCase
 
         $parser = QueryParser::make($parameters);
 
-        Artist::factory()->create();
+        Artist::factory()->count($this->faker->randomDigitNotNull)->create();
 
-        $builder = Artist::with(ArtistCollection::allowedIncludePaths());
+        $builder = Artist::query();
 
         foreach ($parser->getSorts() as $field => $isAsc) {
             $builder = $builder->orderBy(Str::lower($field), $isAsc ? 'asc' : 'desc');
@@ -195,6 +201,8 @@ class ArtistIndexTest extends TestCase
      */
     public function testCreatedAtFilter()
     {
+        $this->withoutEvents();
+
         $created_filter = $this->faker->date();
         $excluded_date = $this->faker->date();
 
@@ -235,6 +243,8 @@ class ArtistIndexTest extends TestCase
      */
     public function testUpdatedAtFilter()
     {
+        $this->withoutEvents();
+
         $updated_filter = $this->faker->date();
         $excluded_date = $this->faker->date();
 
@@ -275,6 +285,8 @@ class ArtistIndexTest extends TestCase
      */
     public function testWithoutTrashedFilter()
     {
+        $this->withoutEvents();
+
         $parameters = [
             QueryParser::PARAM_FILTER => [
                 'trashed' => TrashedStatus::WITHOUT,
@@ -311,6 +323,8 @@ class ArtistIndexTest extends TestCase
      */
     public function testWithTrashedFilter()
     {
+        $this->withoutEvents();
+
         $parameters = [
             QueryParser::PARAM_FILTER => [
                 'trashed' => TrashedStatus::WITH,
@@ -347,6 +361,8 @@ class ArtistIndexTest extends TestCase
      */
     public function testOnlyTrashedFilter()
     {
+        $this->withoutEvents();
+
         $parameters = [
             QueryParser::PARAM_FILTER => [
                 'trashed' => TrashedStatus::ONLY,
@@ -383,6 +399,8 @@ class ArtistIndexTest extends TestCase
      */
     public function testDeletedAtFilter()
     {
+        $this->withoutEvents();
+
         $deleted_filter = $this->faker->date();
         $excluded_date = $this->faker->date();
 
@@ -437,6 +455,7 @@ class ArtistIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'group' => $group_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'songs.themes',
         ];
 
         Artist::factory()
@@ -491,6 +510,7 @@ class ArtistIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'sequence' => $sequence_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'songs.themes',
         ];
 
         Artist::factory()
@@ -544,6 +564,7 @@ class ArtistIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'type' => $type_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'songs.themes',
         ];
 
         Artist::factory()
@@ -593,6 +614,7 @@ class ArtistIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'season' => $season_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'songs.themes.anime',
         ];
 
         Artist::factory()
@@ -643,6 +665,7 @@ class ArtistIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'year' => $year_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'songs.themes.anime',
         ];
 
         Artist::factory()
@@ -691,12 +714,15 @@ class ArtistIndexTest extends TestCase
      */
     public function testResourcesBySite()
     {
+        $this->withoutEvents();
+
         $site_filter = ResourceSite::getRandomInstance();
 
         $parameters = [
             QueryParser::PARAM_FILTER => [
                 'site' => $site_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'externalResources',
         ];
 
         Artist::factory()
@@ -732,12 +758,15 @@ class ArtistIndexTest extends TestCase
      */
     public function testImagesByFacet()
     {
+        $this->withoutEvents();
+
         $facet_filter = ImageFacet::getRandomInstance();
 
         $parameters = [
             QueryParser::PARAM_FILTER => [
                 'facet' => $facet_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'images',
         ];
 
         Artist::factory()

--- a/tests/Feature/Http/Api/Artist/ArtistShowTest.php
+++ b/tests/Feature/Http/Api/Artist/ArtistShowTest.php
@@ -24,14 +24,15 @@ class ArtistShowTest extends TestCase
     use RefreshDatabase, WithFaker;
 
     /**
-     * By default, the Artist Show Endpoint shall return an Artist Resource with all allowed include paths.
+     * By default, the Artist Show Endpoint shall return an Artist Resource.
      *
      * @return void
      */
     public function testDefault()
     {
-        Artist::factory()->jsonApiResource()->create();
-        $artist = Artist::with(ArtistResource::allowedIncludePaths())->first();
+        $this->withoutEvents();
+
+        $artist = Artist::factory()->create();
 
         $response = $this->get(route('api.artist.show', ['artist' => $artist]));
 
@@ -54,11 +55,13 @@ class ArtistShowTest extends TestCase
      */
     public function testSoftDelete()
     {
+        $this->withoutEvents();
+
         $artist = Artist::factory()->createOne();
 
         $artist->delete();
 
-        $artist = Artist::withTrashed()->with(ArtistResource::allowedIncludePaths())->first();
+        $artist->unsetRelations();
 
         $response = $this->get(route('api.artist.show', ['artist' => $artist]));
 
@@ -112,6 +115,8 @@ class ArtistShowTest extends TestCase
      */
     public function testSparseFieldsets()
     {
+        $this->withoutEvents();
+
         $fields = collect([
             'id',
             'name',
@@ -130,8 +135,7 @@ class ArtistShowTest extends TestCase
             ],
         ];
 
-        Artist::factory()->create();
-        $artist = Artist::with(ArtistResource::allowedIncludePaths())->first();
+        $artist = Artist::factory()->create();
 
         $response = $this->get(route('api.artist.show', ['artist' => $artist] + $parameters));
 
@@ -161,6 +165,7 @@ class ArtistShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'group' => $group_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'songs.themes',
         ];
 
         Artist::factory()
@@ -214,6 +219,7 @@ class ArtistShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'sequence' => $sequence_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'songs.themes',
         ];
 
         Artist::factory()
@@ -266,6 +272,7 @@ class ArtistShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'type' => $type_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'songs.themes',
         ];
 
         Artist::factory()
@@ -314,6 +321,7 @@ class ArtistShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'season' => $season_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'songs.themes.anime',
         ];
 
         Artist::factory()
@@ -363,6 +371,7 @@ class ArtistShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'year' => $year_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'songs.themes.anime',
         ];
 
         Artist::factory()
@@ -410,12 +419,15 @@ class ArtistShowTest extends TestCase
      */
     public function testResourcesBySite()
     {
+        $this->withoutEvents();
+
         $site_filter = ResourceSite::getRandomInstance();
 
         $parameters = [
             QueryParser::PARAM_FILTER => [
                 'site' => $site_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'externalResources',
         ];
 
         Artist::factory()
@@ -450,12 +462,15 @@ class ArtistShowTest extends TestCase
      */
     public function testImagesByFacet()
     {
+        $this->withoutEvents();
+
         $facet_filter = ImageFacet::getRandomInstance();
 
         $parameters = [
             QueryParser::PARAM_FILTER => [
                 'facet' => $facet_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'images',
         ];
 
         Artist::factory()

--- a/tests/Feature/Http/Api/Entry/EntryIndexTest.php
+++ b/tests/Feature/Http/Api/Entry/EntryIndexTest.php
@@ -24,19 +24,16 @@ class EntryIndexTest extends TestCase
     use RefreshDatabase, WithFaker;
 
     /**
-     * By default, the Entry Index Endpoint shall return a collection of Entry Resources with all allowed include paths.
+     * By default, the Entry Index Endpoint shall return a collection of Entry Resources.
      *
      * @return void
      */
     public function testDefault()
     {
-        Entry::factory()
+        $entries = Entry::factory()
             ->for(Theme::factory()->for(Anime::factory()))
             ->count($this->faker->randomDigitNotNull)
-            ->has(Video::factory()->count($this->faker->randomDigitNotNull))
             ->create();
-
-        $entries = Entry::with(EntryCollection::allowedIncludePaths())->get();
 
         $response = $this->get(route('api.entry.index'));
 
@@ -62,7 +59,6 @@ class EntryIndexTest extends TestCase
         Entry::factory()
             ->for(Theme::factory()->for(Anime::factory()))
             ->count($this->faker->randomDigitNotNull)
-            ->has(Video::factory()->count($this->faker->randomDigitNotNull))
             ->create();
 
         $response = $this->get(route('api.entry.index'));
@@ -137,13 +133,10 @@ class EntryIndexTest extends TestCase
             ],
         ];
 
-        Entry::factory()
+        $entries = Entry::factory()
             ->for(Theme::factory()->for(Anime::factory()))
             ->count($this->faker->randomDigitNotNull)
-            ->has(Video::factory()->count($this->faker->randomDigitNotNull))
             ->create();
-
-        $entries = Entry::with(EntryCollection::allowedIncludePaths())->get();
 
         $response = $this->get(route('api.entry.index', $parameters));
 
@@ -186,10 +179,9 @@ class EntryIndexTest extends TestCase
         Entry::factory()
             ->for(Theme::factory()->for(Anime::factory()))
             ->count($this->faker->randomDigitNotNull)
-            ->has(Video::factory()->count($this->faker->randomDigitNotNull))
             ->create();
 
-        $builder = Entry::with(EntryCollection::allowedIncludePaths());
+        $builder = Entry::query();
 
         foreach ($parser->getSorts() as $field => $isAsc) {
             $builder = $builder->orderBy(Str::lower($field), $isAsc ? 'asc' : 'desc');
@@ -229,7 +221,6 @@ class EntryIndexTest extends TestCase
             Entry::factory()
                 ->for(Theme::factory()->for(Anime::factory()))
                 ->count($this->faker->randomDigitNotNull)
-                ->has(Video::factory()->count($this->faker->randomDigitNotNull))
                 ->create();
         });
 
@@ -237,7 +228,6 @@ class EntryIndexTest extends TestCase
             Entry::factory()
                 ->for(Theme::factory()->for(Anime::factory()))
                 ->count($this->faker->randomDigitNotNull)
-                ->has(Video::factory()->count($this->faker->randomDigitNotNull))
                 ->create();
         });
 
@@ -277,7 +267,6 @@ class EntryIndexTest extends TestCase
             Entry::factory()
                 ->for(Theme::factory()->for(Anime::factory()))
                 ->count($this->faker->randomDigitNotNull)
-                ->has(Video::factory()->count($this->faker->randomDigitNotNull))
                 ->create();
         });
 
@@ -285,7 +274,6 @@ class EntryIndexTest extends TestCase
             Entry::factory()
                 ->for(Theme::factory()->for(Anime::factory()))
                 ->count($this->faker->randomDigitNotNull)
-                ->has(Video::factory()->count($this->faker->randomDigitNotNull))
                 ->create();
         });
 
@@ -321,13 +309,11 @@ class EntryIndexTest extends TestCase
         Entry::factory()
             ->for(Theme::factory()->for(Anime::factory()))
             ->count($this->faker->randomDigitNotNull)
-            ->has(Video::factory()->count($this->faker->randomDigitNotNull))
             ->create();
 
         $delete_entry = Entry::factory()
             ->for(Theme::factory()->for(Anime::factory()))
             ->count($this->faker->randomDigitNotNull)
-            ->has(Video::factory()->count($this->faker->randomDigitNotNull))
             ->create();
 
         $delete_entry->each(function ($entry) {
@@ -366,13 +352,11 @@ class EntryIndexTest extends TestCase
         Entry::factory()
             ->for(Theme::factory()->for(Anime::factory()))
             ->count($this->faker->randomDigitNotNull)
-            ->has(Video::factory()->count($this->faker->randomDigitNotNull))
             ->create();
 
         $delete_entry = Entry::factory()
             ->for(Theme::factory()->for(Anime::factory()))
             ->count($this->faker->randomDigitNotNull)
-            ->has(Video::factory()->count($this->faker->randomDigitNotNull))
             ->create();
 
         $delete_entry->each(function ($entry) {
@@ -411,13 +395,11 @@ class EntryIndexTest extends TestCase
         Entry::factory()
             ->for(Theme::factory()->for(Anime::factory()))
             ->count($this->faker->randomDigitNotNull)
-            ->has(Video::factory()->count($this->faker->randomDigitNotNull))
             ->create();
 
         $delete_entry = Entry::factory()
             ->for(Theme::factory()->for(Anime::factory()))
             ->count($this->faker->randomDigitNotNull)
-            ->has(Video::factory()->count($this->faker->randomDigitNotNull))
             ->create();
 
         $delete_entry->each(function ($entry) {
@@ -461,7 +443,6 @@ class EntryIndexTest extends TestCase
             $entry = Entry::factory()
                 ->for(Theme::factory()->for(Anime::factory()))
                 ->count($this->faker->randomDigitNotNull)
-                ->has(Video::factory()->count($this->faker->randomDigitNotNull))
                 ->create();
 
             $entry->each(function ($item) {
@@ -473,7 +454,6 @@ class EntryIndexTest extends TestCase
             $entry = Entry::factory()
                 ->for(Theme::factory()->for(Anime::factory()))
                 ->count($this->faker->randomDigitNotNull)
-                ->has(Video::factory()->count($this->faker->randomDigitNotNull))
                 ->create();
 
             $entry->each(function ($item) {
@@ -623,6 +603,7 @@ class EntryIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'season' => $season_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime',
         ];
 
         Entry::factory()
@@ -665,6 +646,7 @@ class EntryIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'year' => $year_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime',
         ];
 
         Entry::factory()
@@ -714,6 +696,7 @@ class EntryIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'group' => $group_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'theme',
         ];
 
         Entry::factory()
@@ -762,6 +745,7 @@ class EntryIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'sequence' => $sequence_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'theme',
         ];
 
         Entry::factory()
@@ -809,6 +793,7 @@ class EntryIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'type' => $type_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'theme',
         ];
 
         Entry::factory()

--- a/tests/Feature/Http/Api/Entry/EntryShowTest.php
+++ b/tests/Feature/Http/Api/Entry/EntryShowTest.php
@@ -19,18 +19,15 @@ class EntryShowTest extends TestCase
     use RefreshDatabase, WithFaker;
 
     /**
-     * By default, the Entry Show Endpoint shall return an Entry Resource with all allowed include paths.
+     * By default, the Entry Show Endpoint shall return an Entry Resource.
      *
      * @return void
      */
     public function testDefault()
     {
-        Entry::factory()
+        $entry = Entry::factory()
             ->for(Theme::factory()->for(Anime::factory()))
-            ->has(Video::factory()->count($this->faker->randomDigitNotNull))
             ->create();
-
-        $entry = Entry::with(EntryResource::allowedIncludePaths())->first();
 
         $response = $this->get(route('api.entry.show', ['entry' => $entry]));
 
@@ -59,7 +56,7 @@ class EntryShowTest extends TestCase
 
         $entry->delete();
 
-        $entry = Entry::withTrashed()->with(EntryResource::allowedIncludePaths())->first();
+        $entry->unsetRelations();
 
         $response = $this->get(route('api.entry.show', ['entry' => $entry]));
 
@@ -137,12 +134,9 @@ class EntryShowTest extends TestCase
             ],
         ];
 
-        Entry::factory()
+        $entry = Entry::factory()
             ->for(Theme::factory()->for(Anime::factory()))
-            ->has(Video::factory()->count($this->faker->randomDigitNotNull))
             ->create();
-
-        $entry = Entry::with(EntryResource::allowedIncludePaths())->first();
 
         $response = $this->get(route('api.entry.show', ['entry' => $entry] + $parameters));
 
@@ -171,6 +165,7 @@ class EntryShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'season' => $season_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime',
         ];
 
         Entry::factory()
@@ -212,6 +207,7 @@ class EntryShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'year' => $year_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime',
         ];
 
         Entry::factory()
@@ -260,6 +256,7 @@ class EntryShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'group' => $group_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'theme',
         ];
 
         Entry::factory()
@@ -307,6 +304,7 @@ class EntryShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'sequence' => $sequence_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'theme',
         ];
 
         Entry::factory()
@@ -353,6 +351,7 @@ class EntryShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'type' => $type_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'theme',
         ];
 
         Entry::factory()

--- a/tests/Feature/Http/Api/ExternalResource/ExternalResourceIndexTest.php
+++ b/tests/Feature/Http/Api/ExternalResource/ExternalResourceIndexTest.php
@@ -29,13 +29,9 @@ class ExternalResourceIndexTest extends TestCase
      */
     public function testDefault()
     {
-        ExternalResource::factory()
-            ->has(Anime::factory()->count($this->faker->randomDigitNotNull))
-            ->has(Artist::factory()->count($this->faker->randomDigitNotNull))
+        $resources = ExternalResource::factory()
             ->count($this->faker->randomDigitNotNull)
             ->create();
-
-        $resources = ExternalResource::with(ExternalResourceCollection::allowedIncludePaths())->get();
 
         $response = $this->get(route('api.resource.index'));
 
@@ -131,13 +127,9 @@ class ExternalResourceIndexTest extends TestCase
             ],
         ];
 
-        ExternalResource::factory()
-            ->has(Anime::factory()->count($this->faker->randomDigitNotNull))
-            ->has(Artist::factory()->count($this->faker->randomDigitNotNull))
+        $resources = ExternalResource::factory()
             ->count($this->faker->randomDigitNotNull)
             ->create();
-
-        $resources = ExternalResource::with(ExternalResourceCollection::allowedIncludePaths())->get();
 
         $response = $this->get(route('api.resource.index', $parameters));
 
@@ -179,7 +171,7 @@ class ExternalResourceIndexTest extends TestCase
 
         ExternalResource::factory()->count($this->faker->randomDigitNotNull)->create();
 
-        $builder = ExternalResource::with(ExternalResourceCollection::allowedIncludePaths());
+        $builder = ExternalResource::query();
 
         foreach ($parser->getSorts() as $field => $isAsc) {
             $builder = $builder->orderBy(Str::lower($field), $isAsc ? 'asc' : 'desc');
@@ -450,8 +442,6 @@ class ExternalResourceIndexTest extends TestCase
         ];
 
         ExternalResource::factory()
-            ->has(Anime::factory()->count($this->faker->randomDigitNotNull))
-            ->has(Artist::factory()->count($this->faker->randomDigitNotNull))
             ->count($this->faker->randomDigitNotNull)
             ->create();
 
@@ -484,6 +474,7 @@ class ExternalResourceIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'season' => $season_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime',
         ];
 
         ExternalResource::factory()
@@ -526,6 +517,7 @@ class ExternalResourceIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'year' => $year_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime',
         ];
 
         ExternalResource::factory()

--- a/tests/Feature/Http/Api/ExternalResource/ExternalResourceIndexTest.php
+++ b/tests/Feature/Http/Api/ExternalResource/ExternalResourceIndexTest.php
@@ -23,7 +23,7 @@ class ExternalResourceIndexTest extends TestCase
     use RefreshDatabase, WithFaker, WithoutEvents;
 
     /**
-     * By default, the Resource Index Endpoint shall return a collection of ExternalResource Resources with all allowed include paths.
+     * By default, the Resource Index Endpoint shall return a collection of ExternalResource Resources.
      *
      * @return void
      */

--- a/tests/Feature/Http/Api/ExternalResource/ExternalResourceShowTest.php
+++ b/tests/Feature/Http/Api/ExternalResource/ExternalResourceShowTest.php
@@ -18,18 +18,13 @@ class ExternalResourceShowTest extends TestCase
     use RefreshDatabase, WithFaker, WithoutEvents;
 
     /**
-     * By default, the Resource Show Endpoint shall return an ExternalResource Resource with all allowed include paths.
+     * By default, the Resource Show Endpoint shall return an ExternalResource Resource.
      *
      * @return void
      */
     public function testDefault()
     {
-        ExternalResource::factory()
-            ->has(Anime::factory()->count($this->faker->randomDigitNotNull))
-            ->has(Artist::factory()->count($this->faker->randomDigitNotNull))
-            ->create();
-
-        $resource = ExternalResource::with(ExternalResourceResource::allowedIncludePaths())->first();
+        $resource = ExternalResource::factory()->create();
 
         $response = $this->get(route('api.resource.show', ['resource' => $resource]));
 
@@ -56,7 +51,7 @@ class ExternalResourceShowTest extends TestCase
 
         $resource->delete();
 
-        $resource = ExternalResource::withTrashed()->with(ExternalResourceResource::allowedIncludePaths())->first();
+        $resource->unsetRelations();
 
         $response = $this->get(route('api.resource.show', ['resource' => $resource]));
 
@@ -133,12 +128,7 @@ class ExternalResourceShowTest extends TestCase
             ],
         ];
 
-        ExternalResource::factory()
-            ->has(Anime::factory()->count($this->faker->randomDigitNotNull))
-            ->has(Artist::factory()->count($this->faker->randomDigitNotNull))
-            ->create();
-
-        $resource = ExternalResource::with(ExternalResourceResource::allowedIncludePaths())->first();
+        $resource = ExternalResource::factory()->create();
 
         $response = $this->get(route('api.resource.show', ['resource' => $resource] + $parameters));
 
@@ -167,6 +157,7 @@ class ExternalResourceShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'season' => $season_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime',
         ];
 
         ExternalResource::factory()
@@ -208,6 +199,7 @@ class ExternalResourceShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'year' => $year_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime',
         ];
 
         ExternalResource::factory()

--- a/tests/Feature/Http/Api/Image/ImageIndexTest.php
+++ b/tests/Feature/Http/Api/Image/ImageIndexTest.php
@@ -23,19 +23,15 @@ class ImageIndexTest extends TestCase
     use RefreshDatabase, WithFaker, WithoutEvents;
 
     /**
-     * By default, the Image Index Endpoint shall return a collection of Image Resources with all allowed include paths.
+     * By default, the Image Index Endpoint shall return a collection of Image Resources.
      *
      * @return void
      */
     public function testDefault()
     {
-        Image::factory()
-            ->has(Anime::factory()->count($this->faker->randomDigitNotNull))
-            ->has(Artist::factory()->count($this->faker->randomDigitNotNull))
+        $images = Image::factory()
             ->count($this->faker->randomDigitNotNull)
             ->create();
-
-        $images = Image::with(ImageCollection::allowedIncludePaths())->get();
 
         $response = $this->get(route('api.image.index'));
 
@@ -131,13 +127,9 @@ class ImageIndexTest extends TestCase
             ],
         ];
 
-        Image::factory()
-            ->has(Anime::factory()->count($this->faker->randomDigitNotNull))
-            ->has(Artist::factory()->count($this->faker->randomDigitNotNull))
+        $images = Image::factory()
             ->count($this->faker->randomDigitNotNull)
             ->create();
-
-        $images = Image::with(ImageCollection::allowedIncludePaths())->get();
 
         $response = $this->get(route('api.image.index', $parameters));
 
@@ -179,7 +171,7 @@ class ImageIndexTest extends TestCase
 
         Image::factory()->count($this->faker->randomDigitNotNull)->create();
 
-        $builder = Image::with(ImageCollection::allowedIncludePaths());
+        $builder = Image::query();
 
         foreach ($parser->getSorts() as $field => $isAsc) {
             $builder = $builder->orderBy(Str::lower($field), $isAsc ? 'asc' : 'desc');
@@ -450,8 +442,6 @@ class ImageIndexTest extends TestCase
         ];
 
         Image::factory()
-            ->has(Anime::factory()->count($this->faker->randomDigitNotNull))
-            ->has(Artist::factory()->count($this->faker->randomDigitNotNull))
             ->count($this->faker->randomDigitNotNull)
             ->create();
 
@@ -484,6 +474,7 @@ class ImageIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'season' => $season_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime',
         ];
 
         Image::factory()
@@ -526,6 +517,7 @@ class ImageIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'year' => $year_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime',
         ];
 
         Image::factory()

--- a/tests/Feature/Http/Api/Image/ImageShowTest.php
+++ b/tests/Feature/Http/Api/Image/ImageShowTest.php
@@ -18,18 +18,13 @@ class ImageShowTest extends TestCase
     use RefreshDatabase, WithFaker, WithoutEvents;
 
     /**
-     * By default, the Image Show Endpoint shall return an Image Resource with all allowed include paths.
+     * By default, the Image Show Endpoint shall return an Image Resource.
      *
      * @return void
      */
     public function testDefault()
     {
-        Image::factory()
-            ->has(Anime::factory()->count($this->faker->randomDigitNotNull))
-            ->has(Artist::factory()->count($this->faker->randomDigitNotNull))
-            ->create();
-
-        $image = Image::with(ImageResource::allowedIncludePaths())->first();
+        $image = Image::factory()->create();
 
         $response = $this->get(route('api.image.show', ['image' => $image]));
 
@@ -56,7 +51,7 @@ class ImageShowTest extends TestCase
 
         $image->delete();
 
-        $image = Image::withTrashed()->with(ImageResource::allowedIncludePaths())->first();
+        $image->unsetRelations();
 
         $response = $this->get(route('api.image.show', ['image' => $image]));
 
@@ -133,12 +128,7 @@ class ImageShowTest extends TestCase
             ],
         ];
 
-        Image::factory()
-            ->has(Anime::factory()->count($this->faker->randomDigitNotNull))
-            ->has(Artist::factory()->count($this->faker->randomDigitNotNull))
-            ->create();
-
-        $image = Image::with(ImageResource::allowedIncludePaths())->first();
+        $image = Image::factory()->create();
 
         $response = $this->get(route('api.image.show', ['image' => $image] + $parameters));
 
@@ -167,6 +157,7 @@ class ImageShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'season' => $season_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime',
         ];
 
         Image::factory()
@@ -208,6 +199,7 @@ class ImageShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'year' => $year_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime',
         ];
 
         Image::factory()

--- a/tests/Feature/Http/Api/Series/SeriesShowTest.php
+++ b/tests/Feature/Http/Api/Series/SeriesShowTest.php
@@ -27,14 +27,15 @@ class SeriesShowTest extends TestCase
     use RefreshDatabase, WithFaker;
 
     /**
-     * By default, the Series Show Endpoint shall return a Series Resource with all allowed include paths.
+     * By default, the Series Show Endpoint shall return a Series Resource.
      *
      * @return void
      */
     public function testDefault()
     {
-        Series::factory()->jsonApiResource()->create();
-        $series = Series::with(SeriesResource::allowedIncludePaths())->first();
+        $this->withoutEvents();
+
+        $series = Series::factory()->create();
 
         $response = $this->get(route('api.series.show', ['series' => $series]));
 
@@ -57,11 +58,13 @@ class SeriesShowTest extends TestCase
      */
     public function testSoftDelete()
     {
+        $this->withoutEvents();
+
         $series = Series::factory()->createOne();
 
         $series->delete();
 
-        $series = Series::withTrashed()->with(SeriesResource::allowedIncludePaths())->first();
+        $series->unsetRelations();
 
         $response = $this->get(route('api.series.show', ['series' => $series]));
 
@@ -115,6 +118,8 @@ class SeriesShowTest extends TestCase
      */
     public function testSparseFieldsets()
     {
+        $this->withoutEvents();
+
         $fields = collect([
             'id',
             'name',
@@ -132,8 +137,7 @@ class SeriesShowTest extends TestCase
             ],
         ];
 
-        Series::factory()->create();
-        $series = Series::with(SeriesResource::allowedIncludePaths())->first();
+        $series = Series::factory()->create();
 
         $response = $this->get(route('api.series.show', ['series' => $series] + $parameters));
 
@@ -156,12 +160,15 @@ class SeriesShowTest extends TestCase
      */
     public function testAnimeBySeason()
     {
+        $this->withoutEvents();
+
         $season_filter = AnimeSeason::getRandomInstance();
 
         $parameters = [
             QueryParser::PARAM_FILTER => [
                 'season' => $season_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime',
         ];
 
         Series::factory()
@@ -196,12 +203,15 @@ class SeriesShowTest extends TestCase
      */
     public function testYearFilter()
     {
+        $this->withoutEvents();
+
         $year_filter = $this->faker->numberBetween(2000, 2002);
 
         $parameters = [
             QueryParser::PARAM_FILTER => [
                 'year' => $year_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime',
         ];
 
         Series::factory()
@@ -251,6 +261,7 @@ class SeriesShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'group' => $group_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime.themes',
         ];
 
         Series::factory()
@@ -303,6 +314,7 @@ class SeriesShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'sequence' => $sequence_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime.themes',
         ];
 
         Series::factory()
@@ -354,6 +366,7 @@ class SeriesShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'type' => $type_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime.themes',
         ];
 
         Series::factory()
@@ -398,6 +411,7 @@ class SeriesShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'nsfw' => $nsfw_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime.themes.entries',
         ];
 
         Series::factory()
@@ -446,6 +460,7 @@ class SeriesShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'spoiler' => $spoiler_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime.themes.entries',
         ];
 
         Series::factory()
@@ -495,6 +510,7 @@ class SeriesShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'version' => $version_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime.themes.entries',
         ];
 
         Series::factory()
@@ -544,12 +560,15 @@ class SeriesShowTest extends TestCase
      */
     public function testResourcesBySite()
     {
+        $this->withoutEvents();
+
         $site_filter = ResourceSite::getRandomInstance();
 
         $parameters = [
             QueryParser::PARAM_FILTER => [
                 'site' => $site_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime.externalResources',
         ];
 
         Series::factory()
@@ -588,12 +607,15 @@ class SeriesShowTest extends TestCase
      */
     public function testImagesByFacet()
     {
+        $this->withoutEvents();
+
         $facet_filter = ImageFacet::getRandomInstance();
 
         $parameters = [
             QueryParser::PARAM_FILTER => [
                 'facet' => $facet_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime.images',
         ];
 
         Series::factory()
@@ -638,6 +660,7 @@ class SeriesShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'lyrics' => $lyrics_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime.themes.entries.videos',
         ];
 
         Series::factory()->jsonApiResource()->create();
@@ -676,6 +699,7 @@ class SeriesShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'nc' => $nc_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime.themes.entries.videos',
         ];
 
         Series::factory()->jsonApiResource()->create();
@@ -714,6 +738,7 @@ class SeriesShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'overlap' => $overlap_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime.themes.entries.videos',
         ];
 
         Series::factory()->jsonApiResource()->create();
@@ -753,6 +778,7 @@ class SeriesShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'resolution' => $resolution_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime.themes.entries.videos',
         ];
 
         Series::factory()
@@ -812,6 +838,7 @@ class SeriesShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'source' => $source_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime.themes.entries.videos',
         ];
 
         Series::factory()->jsonApiResource()->create();
@@ -850,6 +877,7 @@ class SeriesShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'subbed' => $subbed_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime.themes.entries.videos',
         ];
 
         Series::factory()->jsonApiResource()->create();
@@ -888,6 +916,7 @@ class SeriesShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'uncen' => $uncen_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime.themes.entries.videos',
         ];
 
         Series::factory()->jsonApiResource()->create();

--- a/tests/Feature/Http/Api/Song/SongIndexTest.php
+++ b/tests/Feature/Http/Api/Song/SongIndexTest.php
@@ -24,19 +24,15 @@ class SongIndexTest extends TestCase
     use RefreshDatabase, WithFaker;
 
     /**
-     * By default, the Song Index Endpoint shall return a collection of Song Resources with all allowed include paths.
+     * By default, the Song Index Endpoint shall return a collection of Song Resources.
      *
      * @return void
      */
     public function testDefault()
     {
-        Song::factory()
-            ->has(Theme::factory()->count($this->faker->randomDigitNotNull)->for(Anime::factory()))
-            ->has(Artist::factory()->count($this->faker->randomDigitNotNull))
-            ->count($this->faker->randomDigitNotNull)
-            ->create();
+        $this->withoutEvents();
 
-        $songs = Song::with(SongCollection::allowedIncludePaths())->get();
+        $songs = Song::factory()->count($this->faker->randomDigitNotNull)->create();
 
         $response = $this->get(route('api.song.index'));
 
@@ -59,6 +55,8 @@ class SongIndexTest extends TestCase
      */
     public function testPaginated()
     {
+        $this->withoutEvents();
+
         Song::factory()->count($this->faker->randomDigitNotNull)->create();
 
         $response = $this->get(route('api.song.index'));
@@ -113,6 +111,8 @@ class SongIndexTest extends TestCase
      */
     public function testSparseFieldsets()
     {
+        $this->withoutEvents();
+
         $fields = collect([
             'id',
             'title',
@@ -130,13 +130,7 @@ class SongIndexTest extends TestCase
             ],
         ];
 
-        Song::factory()
-            ->has(Theme::factory()->count($this->faker->randomDigitNotNull)->for(Anime::factory()))
-            ->has(Artist::factory()->count($this->faker->randomDigitNotNull))
-            ->count($this->faker->randomDigitNotNull)
-            ->create();
-
-        $songs = Song::with(SongCollection::allowedIncludePaths())->get();
+        $songs = Song::factory()->count($this->faker->randomDigitNotNull)->create();
 
         $response = $this->get(route('api.song.index', $parameters));
 
@@ -178,7 +172,7 @@ class SongIndexTest extends TestCase
 
         Song::factory()->count($this->faker->randomDigitNotNull)->create();
 
-        $builder = Song::with(SongCollection::allowedIncludePaths());
+        $builder = Song::query();
 
         foreach ($parser->getSorts() as $field => $isAsc) {
             $builder = $builder->orderBy(Str::lower($field), $isAsc ? 'asc' : 'desc');
@@ -205,6 +199,8 @@ class SongIndexTest extends TestCase
      */
     public function testCreatedAtFilter()
     {
+        $this->withoutEvents();
+
         $created_filter = $this->faker->date();
         $excluded_date = $this->faker->date();
 
@@ -245,6 +241,8 @@ class SongIndexTest extends TestCase
      */
     public function testUpdatedAtFilter()
     {
+        $this->withoutEvents();
+
         $updated_filter = $this->faker->date();
         $excluded_date = $this->faker->date();
 
@@ -285,6 +283,8 @@ class SongIndexTest extends TestCase
      */
     public function testWithoutTrashedFilter()
     {
+        $this->withoutEvents();
+
         $parameters = [
             QueryParser::PARAM_FILTER => [
                 'trashed' => TrashedStatus::WITHOUT,
@@ -321,6 +321,8 @@ class SongIndexTest extends TestCase
      */
     public function testWithTrashedFilter()
     {
+        $this->withoutEvents();
+
         $parameters = [
             QueryParser::PARAM_FILTER => [
                 'trashed' => TrashedStatus::WITH,
@@ -357,6 +359,8 @@ class SongIndexTest extends TestCase
      */
     public function testOnlyTrashedFilter()
     {
+        $this->withoutEvents();
+
         $parameters = [
             QueryParser::PARAM_FILTER => [
                 'trashed' => TrashedStatus::ONLY,
@@ -393,6 +397,8 @@ class SongIndexTest extends TestCase
      */
     public function testDeletedAtFilter()
     {
+        $this->withoutEvents();
+
         $deleted_filter = $this->faker->date();
         $excluded_date = $this->faker->date();
 
@@ -447,6 +453,7 @@ class SongIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'group' => $group_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'themes',
         ];
 
         Song::factory()
@@ -497,6 +504,7 @@ class SongIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'sequence' => $sequence_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'themes',
         ];
 
         Song::factory()
@@ -546,6 +554,7 @@ class SongIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'type' => $type_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'themes',
         ];
 
         Song::factory()
@@ -587,6 +596,7 @@ class SongIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'season' => $season_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'themes.anime',
         ];
 
         Song::factory()
@@ -629,6 +639,7 @@ class SongIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'year' => $year_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'themes.anime',
         ];
 
         Song::factory()

--- a/tests/Feature/Http/Api/Song/SongShowTest.php
+++ b/tests/Feature/Http/Api/Song/SongShowTest.php
@@ -20,18 +20,15 @@ class SongShowTest extends TestCase
     use RefreshDatabase, WithFaker;
 
     /**
-     * By default, the Song Show Endpoint shall return a Song Resource with all allowed include paths.
+     * By default, the Song Show Endpoint shall return a Song Resource.
      *
      * @return void
      */
     public function testDefault()
     {
-        Song::factory()
-            ->has(Theme::factory()->count($this->faker->randomDigitNotNull)->for(Anime::factory()))
-            ->has(Artist::factory()->count($this->faker->randomDigitNotNull))
-            ->create();
+        $this->withoutEvents();
 
-        $song = Song::with(SongResource::allowedIncludePaths())->first();
+        $song = Song::factory()->create();
 
         $response = $this->get(route('api.song.show', ['song' => $song]));
 
@@ -54,11 +51,13 @@ class SongShowTest extends TestCase
      */
     public function testSoftDelete()
     {
+        $this->withoutEvents();
+
         $song = Song::factory()->createOne();
 
         $song->delete();
 
-        $song = Song::withTrashed()->with(SongResource::allowedIncludePaths())->first();
+        $song->unsetRelations();
 
         $response = $this->get(route('api.song.show', ['song' => $song]));
 
@@ -116,6 +115,8 @@ class SongShowTest extends TestCase
      */
     public function testSparseFieldsets()
     {
+        $this->withoutEvents();
+
         $fields = collect([
             'id',
             'title',
@@ -133,12 +134,7 @@ class SongShowTest extends TestCase
             ],
         ];
 
-        Song::factory()
-            ->has(Theme::factory()->count($this->faker->randomDigitNotNull)->for(Anime::factory()))
-            ->has(Artist::factory()->count($this->faker->randomDigitNotNull))
-            ->create();
-
-        $song = Song::with(SongResource::allowedIncludePaths())->first();
+        $song = Song::factory()->create();
 
         $response = $this->get(route('api.song.show', ['song' => $song] + $parameters));
 
@@ -168,6 +164,7 @@ class SongShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'group' => $group_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'themes',
         ];
 
         Song::factory()
@@ -217,6 +214,7 @@ class SongShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'sequence' => $sequence_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'themes',
         ];
 
         Song::factory()
@@ -265,6 +263,7 @@ class SongShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'type' => $type_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'themes',
         ];
 
         Song::factory()
@@ -305,6 +304,7 @@ class SongShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'season' => $season_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'themes.anime',
         ];
 
         Song::factory()
@@ -346,6 +346,7 @@ class SongShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'year' => $year_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'themes.anime',
         ];
 
         Song::factory()

--- a/tests/Feature/Http/Api/Synonym/SynonymIndexTest.php
+++ b/tests/Feature/Http/Api/Synonym/SynonymIndexTest.php
@@ -21,7 +21,7 @@ class SynonymIndexTest extends TestCase
     use RefreshDatabase, WithFaker, WithoutEvents;
 
     /**
-     * By default, the Synonym Index Endpoint shall return a collection of Synonym Resources with all allowed include paths.
+     * By default, the Synonym Index Endpoint shall return a collection of Synonym Resources.
      *
      * @return void
      */
@@ -32,7 +32,7 @@ class SynonymIndexTest extends TestCase
             ->count($this->faker->randomDigitNotNull)
             ->create();
 
-        $synonyms = Synonym::with(SynonymCollection::allowedIncludePaths())->get();
+        $synonyms = Synonym::all();
 
         $response = $this->get(route('api.synonym.index'));
 
@@ -132,7 +132,7 @@ class SynonymIndexTest extends TestCase
             ->count($this->faker->randomDigitNotNull)
             ->create();
 
-        $synonyms = Synonym::with(SynonymCollection::allowedIncludePaths())->get();
+        $synonyms = Synonym::all();
 
         $response = $this->get(route('api.synonym.index', $parameters));
 
@@ -177,7 +177,7 @@ class SynonymIndexTest extends TestCase
             ->count($this->faker->randomDigitNotNull)
             ->create();
 
-        $builder = Synonym::with(SynonymCollection::allowedIncludePaths());
+        $builder = Synonym::query();
 
         foreach ($parser->getSorts() as $field => $isAsc) {
             $builder = $builder->orderBy(Str::lower($field), $isAsc ? 'asc' : 'desc');
@@ -478,6 +478,7 @@ class SynonymIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'season' => $season_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime',
         ];
 
         Synonym::factory()
@@ -520,6 +521,7 @@ class SynonymIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'year' => $year_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime',
         ];
 
         Synonym::factory()

--- a/tests/Feature/Http/Api/Synonym/SynonymShowTest.php
+++ b/tests/Feature/Http/Api/Synonym/SynonymShowTest.php
@@ -17,17 +17,15 @@ class SynonymShowTest extends TestCase
     use RefreshDatabase, WithFaker, WithoutEvents;
 
     /**
-     * By default, the Synonym Show Endpoint shall return a Synonym Resource with all allowed include paths.
+     * By default, the Synonym Show Endpoint shall return a Synonym Resource.
      *
      * @return void
      */
     public function testDefault()
     {
-        Synonym::factory()
-            ->for(Anime::factory())
-            ->create();
+        $synonym = Synonym::factory()->for(Anime::factory())->createOne();
 
-        $synonym = Synonym::with(SynonymResource::allowedIncludePaths())->first();
+        $synonym->unsetRelations();
 
         $response = $this->get(route('api.synonym.show', ['synonym' => $synonym]));
 
@@ -50,13 +48,11 @@ class SynonymShowTest extends TestCase
      */
     public function testSoftDelete()
     {
-        $synonym = Synonym::factory()
-            ->for(Anime::factory())
-            ->createOne();
+        $synonym = Synonym::factory()->for(Anime::factory())->createOne();
 
         $synonym->delete();
 
-        $synonym = Synonym::withTrashed()->with(SynonymResource::allowedIncludePaths())->first();
+        $synonym->unsetRelations();
 
         $response = $this->get(route('api.synonym.show', ['synonym' => $synonym]));
 
@@ -86,9 +82,7 @@ class SynonymShowTest extends TestCase
             QueryParser::PARAM_INCLUDE => $included_paths->join(','),
         ];
 
-        Synonym::factory()
-            ->for(Anime::factory())
-            ->create();
+        Synonym::factory()->for(Anime::factory())->create();
 
         $synonym = Synonym::with($included_paths->all())->first();
 
@@ -129,12 +123,9 @@ class SynonymShowTest extends TestCase
             ],
         ];
 
-        Synonym::factory()
-            ->for(Anime::factory())
-            ->count($this->faker->randomDigitNotNull)
-            ->create();
+        $synonym = Synonym::factory()->for(Anime::factory())->createOne();
 
-        $synonym = Synonym::with(SynonymResource::allowedIncludePaths())->first();
+        $synonym->unsetRelations();
 
         $response = $this->get(route('api.synonym.show', ['synonym' => $synonym] + $parameters));
 
@@ -163,11 +154,10 @@ class SynonymShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'season' => $season_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime',
         ];
 
-        Synonym::factory()
-            ->for(Anime::factory())
-            ->create();
+        Synonym::factory()->for(Anime::factory())->create();
 
         $synonym = Synonym::with([
             'anime' => function ($query) use ($season_filter) {
@@ -204,6 +194,7 @@ class SynonymShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'year' => $year_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime',
         ];
 
         Synonym::factory()

--- a/tests/Feature/Http/Api/Theme/ThemeIndexTest.php
+++ b/tests/Feature/Http/Api/Theme/ThemeIndexTest.php
@@ -29,7 +29,7 @@ class ThemeIndexTest extends TestCase
     use RefreshDatabase, WithFaker;
 
     /**
-     * By default, the Theme Index Endpoint shall return a collection of Theme Resources with all allowed include paths.
+     * By default, the Theme Index Endpoint shall return a collection of Theme Resources.
      *
      * @return void
      */
@@ -38,15 +38,10 @@ class ThemeIndexTest extends TestCase
         Theme::factory()
             ->for(Anime::factory())
             ->for(Song::factory())
-            ->has(
-                Entry::factory()
-                    ->count($this->faker->randomDigitNotNull)
-                    ->has(Video::factory()->count($this->faker->randomDigitNotNull))
-            )
             ->count($this->faker->randomDigitNotNull)
             ->create();
 
-        $themes = Theme::with(ThemeCollection::allowedIncludePaths())->get();
+        $themes = Theme::all();
 
         $response = $this->get(route('api.theme.index'));
 
@@ -155,7 +150,7 @@ class ThemeIndexTest extends TestCase
             ->count($this->faker->randomDigitNotNull)
             ->create();
 
-        $themes = Theme::with(ThemeCollection::allowedIncludePaths())->get();
+        $themes = Theme::all();
 
         $response = $this->get(route('api.theme.index', $parameters));
 
@@ -200,7 +195,7 @@ class ThemeIndexTest extends TestCase
             ->count($this->faker->randomDigitNotNull)
             ->create();
 
-        $builder = Theme::with(ThemeCollection::allowedIncludePaths());
+        $builder = Theme::query();
 
         foreach ($parser->getSorts() as $field => $isAsc) {
             $builder = $builder->orderBy(Str::lower($field), $isAsc ? 'asc' : 'desc');
@@ -619,6 +614,7 @@ class ThemeIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'season' => $season_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime',
         ];
 
         Theme::factory()
@@ -661,6 +657,7 @@ class ThemeIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'year' => $year_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime',
         ];
 
         Theme::factory()
@@ -707,6 +704,7 @@ class ThemeIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'facet' => $facet_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime.images',
         ];
 
         Theme::factory()
@@ -751,6 +749,7 @@ class ThemeIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'nsfw' => $nsfw_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'entries',
         ];
 
         Theme::factory()
@@ -793,6 +792,7 @@ class ThemeIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'spoiler' => $spoiler_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'entries',
         ];
 
         Theme::factory()
@@ -836,6 +836,7 @@ class ThemeIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'version' => $version_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'entries',
         ];
 
         Theme::factory()
@@ -885,6 +886,7 @@ class ThemeIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'lyrics' => $lyrics_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'entries.videos',
         ];
 
         Theme::factory()
@@ -931,6 +933,7 @@ class ThemeIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'nc' => $nc_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'entries.videos',
         ];
 
         Theme::factory()
@@ -977,6 +980,7 @@ class ThemeIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'overlap' => $overlap_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'entries.videos',
         ];
 
         Theme::factory()
@@ -1024,6 +1028,7 @@ class ThemeIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'resolution' => $resolution_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'entries.videos',
         ];
 
         Theme::factory()
@@ -1077,6 +1082,7 @@ class ThemeIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'source' => $source_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'entries.videos',
         ];
 
         Theme::factory()
@@ -1123,6 +1129,7 @@ class ThemeIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'subbed' => $subbed_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'entries.videos',
         ];
 
         Theme::factory()
@@ -1169,6 +1176,7 @@ class ThemeIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'uncen' => $uncen_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'entries.videos',
         ];
 
         Theme::factory()

--- a/tests/Feature/Http/Api/Theme/ThemeShowTest.php
+++ b/tests/Feature/Http/Api/Theme/ThemeShowTest.php
@@ -24,23 +24,17 @@ class ThemeShowTest extends TestCase
     use RefreshDatabase, WithFaker;
 
     /**
-     * By default, the Theme Show Endpoint shall return a Theme Resource with all allowed include paths.
+     * By default, the Theme Show Endpoint shall return a Theme Resource.
      *
      * @return void
      */
     public function testDefault()
     {
-        Theme::factory()
+        $theme = Theme::factory()
             ->for(Anime::factory())
-            ->for(Song::factory())
-            ->has(
-                Entry::factory()
-                    ->count($this->faker->randomDigitNotNull)
-                    ->has(Video::factory()->count($this->faker->randomDigitNotNull))
-            )
-            ->create();
+            ->createOne();
 
-        $theme = Theme::with(ThemeResource::allowedIncludePaths())->first();
+        $theme->unsetRelations();
 
         $response = $this->get(route('api.theme.show', ['theme' => $theme]));
 
@@ -69,7 +63,7 @@ class ThemeShowTest extends TestCase
 
         $theme->delete();
 
-        $theme = Theme::withTrashed()->with(ThemeResource::allowedIncludePaths())->first();
+        $theme->unsetRelations();
 
         $response = $this->get(route('api.theme.show', ['theme' => $theme]));
 
@@ -151,12 +145,12 @@ class ThemeShowTest extends TestCase
             ],
         ];
 
-        Theme::factory()
+        $theme = Theme::factory()
             ->for(Anime::factory())
             ->count($this->faker->randomDigitNotNull)
-            ->create();
+            ->createOne();
 
-        $theme = Theme::with(ThemeResource::allowedIncludePaths())->first();
+        $theme->unsetRelations();
 
         $response = $this->get(route('api.theme.show', ['theme' => $theme] + $parameters));
 
@@ -185,6 +179,7 @@ class ThemeShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'season' => $season_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime',
         ];
 
         Theme::factory()
@@ -226,6 +221,7 @@ class ThemeShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'year' => $year_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime',
         ];
 
         Theme::factory()
@@ -271,6 +267,7 @@ class ThemeShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'facet' => $facet_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'anime.images',
         ];
 
         Theme::factory()
@@ -314,6 +311,7 @@ class ThemeShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'nsfw' => $nsfw_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'entries',
         ];
 
         Theme::factory()
@@ -355,6 +353,7 @@ class ThemeShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'spoiler' => $spoiler_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'entries',
         ];
 
         Theme::factory()
@@ -397,6 +396,7 @@ class ThemeShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'version' => $version_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'entries',
         ];
 
         Theme::factory()
@@ -445,6 +445,7 @@ class ThemeShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'lyrics' => $lyrics_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'entries.videos',
         ];
 
         Theme::factory()
@@ -490,6 +491,7 @@ class ThemeShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'nc' => $nc_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'entries.videos',
         ];
 
         Theme::factory()
@@ -535,6 +537,7 @@ class ThemeShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'overlap' => $overlap_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'entries.videos',
         ];
 
         Theme::factory()
@@ -581,6 +584,7 @@ class ThemeShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'resolution' => $resolution_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'entries.videos',
         ];
 
         Theme::factory()
@@ -633,6 +637,7 @@ class ThemeShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'source' => $source_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'entries.videos',
         ];
 
         Theme::factory()
@@ -678,6 +683,7 @@ class ThemeShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'subbed' => $subbed_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'entries.videos',
         ];
 
         Theme::factory()
@@ -723,6 +729,7 @@ class ThemeShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'uncen' => $uncen_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'entries.videos',
         ];
 
         Theme::factory()

--- a/tests/Feature/Http/Api/Video/VideoIndexTest.php
+++ b/tests/Feature/Http/Api/Video/VideoIndexTest.php
@@ -26,22 +26,17 @@ class VideoIndexTest extends TestCase
     use RefreshDatabase, WithFaker;
 
     /**
-     * By default, the Video Index Endpoint shall return a collection of Video Resources with all allowed include paths.
+     * By default, the Video Index Endpoint shall return a collection of Video Resources.
      *
      * @return void
      */
     public function testDefault()
     {
-        Video::factory()
-            ->count($this->faker->randomDigitNotNull)
-            ->has(
-                Entry::factory()
-                    ->count($this->faker->randomDigitNotNull)
-                    ->for(Theme::factory()->for(Anime::factory()))
-            )
-            ->create();
+        $this->withoutEvents();
 
-        $videos = Video::with(VideoCollection::allowedIncludePaths())->get();
+        $videos = Video::factory()
+            ->count($this->faker->randomDigitNotNull)
+            ->create();
 
         $response = $this->get(route('api.video.index'));
 
@@ -64,6 +59,8 @@ class VideoIndexTest extends TestCase
      */
     public function testPaginated()
     {
+        $this->withoutEvents();
+
         Video::factory()
             ->count($this->faker->randomDigitNotNull)
             ->create();
@@ -123,6 +120,8 @@ class VideoIndexTest extends TestCase
      */
     public function testSparseFieldsets()
     {
+        $this->withoutEvents();
+
         $fields = collect([
             'id',
             'basename',
@@ -152,11 +151,9 @@ class VideoIndexTest extends TestCase
             ],
         ];
 
-        Video::factory()
+        $videos = Video::factory()
             ->count($this->faker->randomDigitNotNull)
             ->create();
-
-        $videos = Video::with(VideoCollection::allowedIncludePaths())->get();
 
         $response = $this->get(route('api.video.index', $parameters));
 
@@ -179,6 +176,8 @@ class VideoIndexTest extends TestCase
      */
     public function testSorts()
     {
+        $this->withoutEvents();
+
         $allowed_sorts = collect(VideoCollection::allowedSortFields());
         $included_sorts = $allowed_sorts->random($this->faker->numberBetween(1, count($allowed_sorts)))->map(function ($included_sort) {
             if ($this->faker->boolean()) {
@@ -200,7 +199,7 @@ class VideoIndexTest extends TestCase
             ->count($this->faker->randomDigitNotNull)
             ->create();
 
-        $builder = Video::with(VideoCollection::allowedIncludePaths());
+        $builder = Video::query();
 
         foreach ($parser->getSorts() as $field => $isAsc) {
             $builder = $builder->orderBy(Str::lower($field), $isAsc ? 'asc' : 'desc');
@@ -227,6 +226,8 @@ class VideoIndexTest extends TestCase
      */
     public function testCreatedAtFilter()
     {
+        $this->withoutEvents();
+
         $created_filter = $this->faker->date();
         $excluded_date = $this->faker->date();
 
@@ -267,6 +268,8 @@ class VideoIndexTest extends TestCase
      */
     public function testUpdatedAtFilter()
     {
+        $this->withoutEvents();
+
         $updated_filter = $this->faker->date();
         $excluded_date = $this->faker->date();
 
@@ -307,6 +310,8 @@ class VideoIndexTest extends TestCase
      */
     public function testWithoutTrashedFilter()
     {
+        $this->withoutEvents();
+
         $parameters = [
             QueryParser::PARAM_FILTER => [
                 'trashed' => TrashedStatus::WITHOUT,
@@ -343,6 +348,8 @@ class VideoIndexTest extends TestCase
      */
     public function testWithTrashedFilter()
     {
+        $this->withoutEvents();
+
         $parameters = [
             QueryParser::PARAM_FILTER => [
                 'trashed' => TrashedStatus::WITH,
@@ -379,6 +386,8 @@ class VideoIndexTest extends TestCase
      */
     public function testOnlyTrashedFilter()
     {
+        $this->withoutEvents();
+
         $parameters = [
             QueryParser::PARAM_FILTER => [
                 'trashed' => TrashedStatus::ONLY,
@@ -415,6 +424,8 @@ class VideoIndexTest extends TestCase
      */
     public function testDeletedAtFilter()
     {
+        $this->withoutEvents();
+
         $deleted_filter = $this->faker->date();
         $excluded_date = $this->faker->date();
 
@@ -462,6 +473,8 @@ class VideoIndexTest extends TestCase
      */
     public function testLyricsFilter()
     {
+        $this->withoutEvents();
+
         $lyrics_filter = $this->faker->boolean();
 
         $parameters = [
@@ -497,6 +510,8 @@ class VideoIndexTest extends TestCase
      */
     public function testNcFilter()
     {
+        $this->withoutEvents();
+
         $nc_filter = $this->faker->boolean();
 
         $parameters = [
@@ -532,6 +547,8 @@ class VideoIndexTest extends TestCase
      */
     public function testOverlapFilter()
     {
+        $this->withoutEvents();
+
         $overlap_filter = VideoOverlap::getRandomInstance();
 
         $parameters = [
@@ -567,6 +584,8 @@ class VideoIndexTest extends TestCase
      */
     public function testResolutionFilter()
     {
+        $this->withoutEvents();
+
         $resolution_filter = $this->faker->randomNumber();
         $excluded_resolution = $resolution_filter + 1;
 
@@ -607,6 +626,8 @@ class VideoIndexTest extends TestCase
      */
     public function testSourceFilter()
     {
+        $this->withoutEvents();
+
         $source_filter = VideoSource::getRandomInstance();
 
         $parameters = [
@@ -642,6 +663,8 @@ class VideoIndexTest extends TestCase
      */
     public function testSubbedFilter()
     {
+        $this->withoutEvents();
+
         $subbed_filter = $this->faker->boolean();
 
         $parameters = [
@@ -677,6 +700,8 @@ class VideoIndexTest extends TestCase
      */
     public function testUncenFilter()
     {
+        $this->withoutEvents();
+
         $uncen_filter = $this->faker->boolean();
 
         $parameters = [
@@ -718,6 +743,7 @@ class VideoIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'nsfw' => $nsfw_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'entries',
         ];
 
         Video::factory()
@@ -763,6 +789,7 @@ class VideoIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'spoiler' => $spoiler_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'entries',
         ];
 
         Video::factory()
@@ -809,6 +836,7 @@ class VideoIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'version' => $version_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'entries',
         ];
 
         Video::factory()
@@ -859,6 +887,7 @@ class VideoIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'group' => $group_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'entries.theme',
         ];
 
         Video::factory()
@@ -911,6 +940,7 @@ class VideoIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'sequence' => $sequence_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'entries.theme',
         ];
 
         Video::factory()
@@ -962,6 +992,7 @@ class VideoIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'type' => $type_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'entries.theme',
         ];
 
         Video::factory()
@@ -1007,6 +1038,7 @@ class VideoIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'season' => $season_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'entries.theme.anime',
         ];
 
         Video::factory()
@@ -1053,6 +1085,7 @@ class VideoIndexTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'year' => $year_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'entries.theme.anime',
         ];
 
         Video::factory()

--- a/tests/Feature/Http/Api/Video/VideoShowTest.php
+++ b/tests/Feature/Http/Api/Video/VideoShowTest.php
@@ -20,21 +20,15 @@ class VideoShowTest extends TestCase
     use RefreshDatabase, WithFaker;
 
     /**
-     * By default, the Video Show Endpoint shall return a Video Resource with all allowed include paths.
+     * By default, the Video Show Endpoint shall return a Video Resource.
      *
      * @return void
      */
     public function testDefault()
     {
-        Video::factory()
-            ->has(
-                Entry::factory()
-                    ->count($this->faker->randomDigitNotNull)
-                    ->for(Theme::factory()->for(Anime::factory()))
-            )
-            ->create();
+        $this->withoutEvents();
 
-        $video = Video::with(VideoResource::allowedIncludePaths())->first();
+        $video = Video::factory()->create();
 
         $response = $this->get(route('api.video.show', ['video' => $video]));
 
@@ -57,11 +51,11 @@ class VideoShowTest extends TestCase
      */
     public function testSoftDelete()
     {
+        $this->withoutEvents();
+
         $video = Video::factory()->createOne();
 
         $video->delete();
-
-        $video = Video::withTrashed()->with(VideoResource::allowedIncludePaths())->first();
 
         $response = $this->get(route('api.video.show', ['video' => $video]));
 
@@ -122,6 +116,8 @@ class VideoShowTest extends TestCase
      */
     public function testSparseFieldsets()
     {
+        $this->withoutEvents();
+
         $fields = collect([
             'id',
             'basename',
@@ -151,9 +147,7 @@ class VideoShowTest extends TestCase
             ],
         ];
 
-        Video::factory()->create();
-
-        $video = Video::with(VideoResource::allowedIncludePaths())->first();
+        $video = Video::factory()->create();
 
         $response = $this->get(route('api.video.show', ['video' => $video] + $parameters));
 
@@ -182,6 +176,7 @@ class VideoShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'nsfw' => $nsfw_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'entries',
         ];
 
         Video::factory()
@@ -226,6 +221,7 @@ class VideoShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'spoiler' => $spoiler_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'entries',
         ];
 
         Video::factory()
@@ -271,6 +267,7 @@ class VideoShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'version' => $version_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'entries',
         ];
 
         Video::factory()
@@ -320,6 +317,7 @@ class VideoShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'group' => $group_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'entries.theme',
         ];
 
         Video::factory()
@@ -371,6 +369,7 @@ class VideoShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'sequence' => $sequence_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'entries.theme',
         ];
 
         Video::factory()
@@ -421,6 +420,7 @@ class VideoShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'type' => $type_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'entries.theme',
         ];
 
         Video::factory()
@@ -465,6 +465,7 @@ class VideoShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'season' => $season_filter->key,
             ],
+            QueryParser::PARAM_INCLUDE => 'entries.theme.anime',
         ];
 
         Video::factory()
@@ -510,6 +511,7 @@ class VideoShowTest extends TestCase
             QueryParser::PARAM_FILTER => [
                 'year' => $year_filter,
             ],
+            QueryParser::PARAM_INCLUDE => 'entries.theme.anime',
         ];
 
         Video::factory()

--- a/tests/Unit/JsonApi/QueryParserTest.php
+++ b/tests/Unit/JsonApi/QueryParserTest.php
@@ -82,11 +82,11 @@ class QueryParserTest extends TestCase
     }
 
     /**
-     * By default, all include paths are allowed if include paths are not specified.
+     * By default, no include paths are allowed if include paths are not specified.
      *
      * @return void
      */
-    public function testAllAllowedIncludesByDefault()
+    public function testNoAllowedIncludesByDefault()
     {
         $includes = $this->faker->words($this->faker->randomDigitNotNull);
 
@@ -94,7 +94,7 @@ class QueryParserTest extends TestCase
 
         $parser = new QueryParser($parameters);
 
-        $this->assertEmpty(array_diff($includes, $parser->getIncludePaths($includes)));
+        $this->assertEmpty($parser->getIncludePaths($includes));
     }
 
     /**
@@ -136,11 +136,11 @@ class QueryParserTest extends TestCase
     }
 
     /**
-     * By default, all include paths are allowed if selected include paths are not specified.
+     * By default, no include paths are allowed if selected include paths are not specified.
      *
      * @return void
      */
-    public function testAllAllowedResourceIncludesByDefault()
+    public function testNoAllowedResourceIncludesByDefault()
     {
         $type = $this->faker->word();
         $includes = $this->faker->words($this->faker->randomDigitNotNull);
@@ -149,7 +149,7 @@ class QueryParserTest extends TestCase
 
         $parser = new QueryParser($parameters);
 
-        $this->assertEmpty(array_diff($includes, $parser->getResourceIncludePaths($includes, $type)));
+        $this->assertEmpty($parser->getResourceIncludePaths($includes, $type));
     }
 
     /**


### PR DESCRIPTION
Addressing deployment finding: API endpoints hydrate too many models. Previously, the resource inclusion strategy was to include all allowed paths by default. Now, the default is to exclude all allowed include paths, only returning the top-level models in the response. 