### PR TITLE
fix: transparency filtering, fix: psalm findings, chore: plural types in docs

### DIFF
--- a/app/Concerns/Discord/HasDiscordEmbedFields.php
+++ b/app/Concerns/Discord/HasDiscordEmbedFields.php
@@ -14,7 +14,7 @@ trait HasDiscordEmbedFields
     /**
      * The array of embed fields.
      *
-     * @var array
+     * @var DiscordEmbedField[]
      */
     protected array $embedFields = [];
 
@@ -32,7 +32,7 @@ trait HasDiscordEmbedFields
     /**
      * Get discord embed fields.
      *
-     * @return array
+     * @return DiscordEmbedField[]
      */
     protected function getEmbedFields(): array
     {

--- a/app/Concerns/JsonApi/PerformsResourceCollectionQuery.php
+++ b/app/Concerns/JsonApi/PerformsResourceCollectionQuery.php
@@ -18,7 +18,7 @@ trait PerformsResourceCollectionQuery
     /**
      * The include paths a client is allowed to request.
      *
-     * @return array
+     * @return string[]
      */
     public static function allowedIncludePaths(): array
     {
@@ -28,7 +28,7 @@ trait PerformsResourceCollectionQuery
     /**
      * The sort field names a client is allowed to request.
      *
-     * @return array
+     * @return string[]
      */
     public static function allowedSortFields(): array
     {
@@ -38,7 +38,7 @@ trait PerformsResourceCollectionQuery
     /**
      * The filters that can be applied by the client for this resource.
      *
-     * @return array
+     * @return string[]
      */
     public static function filters(): array
     {

--- a/app/Concerns/JsonApi/PerformsResourceQuery.php
+++ b/app/Concerns/JsonApi/PerformsResourceQuery.php
@@ -17,7 +17,7 @@ trait PerformsResourceQuery
     /**
      * The include paths a client is allowed to request.
      *
-     * @return array
+     * @return string[]
      */
     public static function allowedIncludePaths(): array
     {

--- a/app/Concerns/Reconcile/ReconcilesRepositories.php
+++ b/app/Concerns/Reconcile/ReconcilesRepositories.php
@@ -222,8 +222,11 @@ trait ReconcilesRepositories
      * @param Collection $destinationModels
      * @return void
      */
-    protected function createModelsFromSource(Repository $destination, Collection $sourceModels, Collection $destinationModels)
-    {
+    protected function createModelsFromSource(
+        Repository $destination,
+        Collection $sourceModels,
+        Collection $destinationModels
+    ) {
         $createModels = $this->diffForCreateDelete($sourceModels, $destinationModels);
 
         foreach ($createModels as $createModel) {
@@ -246,8 +249,11 @@ trait ReconcilesRepositories
      * @param Collection $destinationModels
      * @return void
      */
-    public function deleteModelsFromDestination(Repository $destination, Collection $sourceModels, Collection $destinationModels)
-    {
+    public function deleteModelsFromDestination(
+        Repository $destination,
+        Collection $sourceModels,
+        Collection $destinationModels
+    ) {
         $deleteModels = $this->diffForCreateDelete($destinationModels, $sourceModels);
 
         foreach ($deleteModels as $deleteModel) {
@@ -294,8 +300,11 @@ trait ReconcilesRepositories
      * @param Collection $destinationModels
      * @return void
      */
-    public function updateDestinationModels(Repository $destination, Collection $sourceModels, Collection $destinationModels)
-    {
+    public function updateDestinationModels(
+        Repository $destination,
+        Collection $sourceModels,
+        Collection $destinationModels
+    ) {
         $updatedModels = $this->diffForUpdate($destinationModels, $sourceModels);
 
         foreach ($updatedModels as $updatedModel) {

--- a/app/Console/Commands/Billing/BalanceReconcileCommand.php
+++ b/app/Console/Commands/Billing/BalanceReconcileCommand.php
@@ -189,12 +189,10 @@ class BalanceReconcileCommand extends Command
      */
     protected function getSourceRepository(Service $service): ?Repository
     {
-        switch ($service->value) {
-        case Service::DIGITALOCEAN:
-            return App::make(DigitalOceanSourceRepository::class);
-        }
-
-        return null;
+        return match ($service->value) {
+            Service::DIGITALOCEAN => App::make(DigitalOceanSourceRepository::class),
+            default => null,
+        };
     }
 
     /**
@@ -205,11 +203,9 @@ class BalanceReconcileCommand extends Command
      */
     protected function getDestinationRepository(Service $service): ?Repository
     {
-        switch ($service->value) {
-        case Service::DIGITALOCEAN:
-            return App::make(DigitalOceanDestinationRepository::class);
-        }
-
-        return null;
+        return match ($service->value) {
+            Service::DIGITALOCEAN => App::make(DigitalOceanDestinationRepository::class),
+            default => null,
+        };
     }
 }

--- a/app/Console/Commands/Billing/TransactionReconcileCommand.php
+++ b/app/Console/Commands/Billing/TransactionReconcileCommand.php
@@ -8,7 +8,8 @@ use App\Concerns\Reconcile\Billing\ReconcilesTransaction;
 use App\Contracts\Repositories\Repository;
 use App\Enums\Billing\Service;
 use App\Models\BaseModel;
-use App\Repositories\Eloquent\Billing\DigitalOceanTransactionRepository;
+use App\Repositories\Eloquent\Billing\DigitalOceanTransactionRepository as DigitalOceanDestinationRepository;
+use App\Repositories\Service\Billing\DigitalOceanTransactionRepository as DigitalOceanSourceRepository;
 use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\App;
@@ -188,12 +189,10 @@ class TransactionReconcileCommand extends Command
      */
     protected function getSourceRepository(Service $service): ?Repository
     {
-        switch ($service->value) {
-        case Service::DIGITALOCEAN:
-            return App::make(\App\Repositories\Service\Billing\DigitalOceanTransactionRepository::class);
-        }
-
-        return null;
+        return match ($service->value) {
+            Service::DIGITALOCEAN => App::make(DigitalOceanSourceRepository::class),
+            default => null,
+        };
     }
 
     /**
@@ -204,11 +203,9 @@ class TransactionReconcileCommand extends Command
      */
     protected function getDestinationRepository(Service $service): ?Repository
     {
-        switch ($service->value) {
-        case Service::DIGITALOCEAN:
-            return App::make(DigitalOceanTransactionRepository::class);
-        }
-
-        return null;
+        return match ($service->value) {
+            Service::DIGITALOCEAN => App::make(DigitalOceanDestinationRepository::class),
+            default => null,
+        };
     }
 }

--- a/app/Console/Commands/DatabaseDumpCommand.php
+++ b/app/Console/Commands/DatabaseDumpCommand.php
@@ -31,12 +31,12 @@ class DatabaseDumpCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Produces sanitized database dump, targeting wiki-related tables for local seeding purposes';
+    protected $description = 'Produces sanitized database dump, targeting wiki-related tables for seeding purposes';
 
     /**
      * The list of tables to include in the dump.
      *
-     * @var array
+     * @var string[]
      */
     protected array $allowedTables = [
         'anime',

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -22,7 +22,7 @@ class Kernel extends ConsoleKernel
     /**
      * The Artisan commands provided by your application.
      *
-     * @var array
+     * @var string[]
      */
     protected $commands = [
         BalanceReconcileCommand::class,

--- a/app/Enums/ResourceSite.php
+++ b/app/Enums/ResourceSite.php
@@ -36,30 +36,17 @@ final class ResourceSite extends Enum implements LocalizedEnum
      */
     public static function getDomain(?int $value): ?string
     {
-        if ($value === null) {
-            return null;
-        }
-
-        switch ($value) {
-        case self::TWITTER:
-            return 'twitter.com';
-        case self::ANIDB:
-            return 'anidb.net';
-        case self::ANILIST:
-            return 'anilist.co';
-        case self::ANIME_PLANET:
-            return 'anime-planet.com';
-        case self::ANN:
-            return 'animenewsnetwork.com';
-        case self::KITSU:
-            return 'kitsu.io';
-        case self::MAL:
-            return 'myanimelist.net';
-        case self::WIKI:
-            return 'wikipedia.org';
-        }
-
-        return null;
+        return match ($value) {
+            self::TWITTER => 'twitter.com',
+            self::ANIDB => 'anidb.net',
+            self::ANILIST => 'anilist.co',
+            self::ANIME_PLANET => 'anime-planet.com',
+            self::ANN => 'animenewsnetwork.com',
+            self::KITSU => 'kitsu.io',
+            self::MAL => 'myanimelist.net',
+            self::WIKI => 'wikipedia.org',
+            default => null,
+        };
     }
 
     /**

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -21,7 +21,7 @@ class Handler extends ExceptionHandler
     /**
      * A list of the inputs that are never flashed for validation exceptions.
      *
-     * @var array
+     * @var string[]
      */
     protected $dontFlash = [
         'current_password',

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -45,7 +45,7 @@ class Kernel extends HttpKernel
      *
      * These middleware are run during every request to your application.
      *
-     * @var array
+     * @var string[]
      */
     protected $middleware = [
         TrustHosts::class,

--- a/app/Http/Middleware/EncryptCookies.php
+++ b/app/Http/Middleware/EncryptCookies.php
@@ -14,7 +14,7 @@ class EncryptCookies extends Middleware
     /**
      * The names of the cookies that should not be encrypted.
      *
-     * @var array
+     * @var string[]
      */
     protected $except = [
         //

--- a/app/Http/Middleware/PreventRequestsDuringMaintenance.php
+++ b/app/Http/Middleware/PreventRequestsDuringMaintenance.php
@@ -14,7 +14,7 @@ class PreventRequestsDuringMaintenance extends Middleware
     /**
      * The URIs that should be reachable while maintenance mode is enabled.
      *
-     * @var array
+     * @var string[]
      */
     protected $except = [
         //

--- a/app/Http/Middleware/ThrottleRequestsWithService.php
+++ b/app/Http/Middleware/ThrottleRequestsWithService.php
@@ -29,8 +29,13 @@ class ThrottleRequestsWithService
      * @param string $prefix
      * @return mixed
      */
-    public function handle(Request $request, Closure $next, int | string $maxAttempts = 60, float | int $decayMinutes = 1, string $prefix = ''): mixed
-    {
+    public function handle(
+        Request $request,
+        Closure $next,
+        int | string $maxAttempts = 60,
+        float | int $decayMinutes = 1,
+        string $prefix = ''
+    ): mixed {
         // Throttle with Redis if configured, else use default throttling middleware
         $middleware = $this->appUsesRedis()
             ? App::make(ThrottleRequestsWithRedis::class)

--- a/app/Http/Middleware/TrimStrings.php
+++ b/app/Http/Middleware/TrimStrings.php
@@ -14,7 +14,7 @@ class TrimStrings extends Middleware
     /**
      * The names of the attributes that should not be trimmed.
      *
-     * @var array
+     * @var string[]
      */
     protected $except = [
         'current_password',

--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -14,7 +14,7 @@ class VerifyCsrfToken extends Middleware
     /**
      * The URIs that should be excluded from CSRF verification.
      *
-     * @var array
+     * @var string[]
      */
     protected $except = [
         //

--- a/app/Http/Requests/TransparencyRequest.php
+++ b/app/Http/Requests/TransparencyRequest.php
@@ -99,7 +99,7 @@ class TransparencyRequest extends FormRequest
      */
     public function getSelectedDate(): ?Carbon
     {
-        $validDate =  Arr::get($this->validated(),'date');
+        $validDate =  Arr::get($this->validated(), 'date');
 
         if ($validDate === null) {
             return $this->getValidDates()->first();

--- a/app/Http/Requests/TransparencyRequest.php
+++ b/app/Http/Requests/TransparencyRequest.php
@@ -58,7 +58,7 @@ class TransparencyRequest extends FormRequest
             'date' => [
                 'nullable',
                 'date_format:Y-m',
-                new TransparencyDateRule($this->validDates),
+                new TransparencyDateRule($this->getValidDates()),
             ],
         ];
     }
@@ -95,15 +95,15 @@ class TransparencyRequest extends FormRequest
     /**
      * Get the validated year/month combination for the transparency filter.
      *
-     * @return Carbon
+     * @return Carbon|null
      */
-    public function getSelectedDate(): Carbon
+    public function getSelectedDate(): ?Carbon
     {
-        $validDate = Arr::get(
-            $this->validated(),
-            'date',
-            Carbon::now()->format(AllowedDateFormat::WITH_MONTH)
-        );
+        $validDate =  Arr::get($this->validated(),'date');
+
+        if ($validDate === null) {
+            return $this->getValidDates()->first();
+        }
 
         return Carbon::instance(DateTime::createFromFormat('!'.AllowedDateFormat::WITH_MONTH, $validDate));
     }
@@ -117,8 +117,12 @@ class TransparencyRequest extends FormRequest
     {
         $date = $this->getSelectedDate();
 
-        return Balance::whereBetween('date', [$date->copy()->startOfMonth(), $date->copy()->endOfMonth()])
-            ->orderBy('usage', 'desc')
+        if ($date === null) {
+            return Collection::make();
+        }
+
+        return Balance::whereMonth('date', strval($date->month))
+            ->whereYear('date', strval($date->year))
             ->get();
     }
 
@@ -131,8 +135,12 @@ class TransparencyRequest extends FormRequest
     {
         $date = $this->getSelectedDate();
 
-        return Transaction::whereBetween('date', [$date->copy()->startOfMonth(), $date->copy()->endOfMonth()])
-            ->orderBy('date', 'desc')
+        if ($date === null) {
+            return Collection::make();
+        }
+
+        return Transaction::whereMonth('date', strval($date->month))
+            ->whereYear('date', strval($date->year))
             ->get();
     }
 }

--- a/app/Http/Requests/TransparencyRequest.php
+++ b/app/Http/Requests/TransparencyRequest.php
@@ -99,7 +99,7 @@ class TransparencyRequest extends FormRequest
      */
     public function getSelectedDate(): ?Carbon
     {
-        $validDate =  Arr::get($this->validated(), 'date');
+        $validDate = Arr::get($this->validated(), 'date');
 
         if ($validDate === null) {
             return $this->getValidDates()->first();

--- a/app/Http/Resources/AnimeCollection.php
+++ b/app/Http/Resources/AnimeCollection.php
@@ -45,7 +45,7 @@ class AnimeCollection extends BaseCollection
     /**
      * The include paths a client is allowed to request.
      *
-     * @return array
+     * @return string[]
      */
     public static function allowedIncludePaths(): array
     {
@@ -65,7 +65,7 @@ class AnimeCollection extends BaseCollection
     /**
      * The sort field names a client is allowed to request.
      *
-     * @return array
+     * @return string[]
      */
     public static function allowedSortFields(): array
     {
@@ -84,7 +84,7 @@ class AnimeCollection extends BaseCollection
     /**
      * The filters that can be applied by the client for this resource.
      *
-     * @return array
+     * @return string[]
      */
     public static function filters(): array
     {

--- a/app/Http/Resources/AnimeResource.php
+++ b/app/Http/Resources/AnimeResource.php
@@ -143,7 +143,7 @@ class AnimeResource extends BaseResource
     /**
      * The include paths a client is allowed to request.
      *
-     * @return array
+     * @return string[]
      */
     public static function allowedIncludePaths(): array
     {

--- a/app/Http/Resources/AnnouncementCollection.php
+++ b/app/Http/Resources/AnnouncementCollection.php
@@ -41,7 +41,7 @@ class AnnouncementCollection extends BaseCollection
     /**
      * The sort field names a client is allowed to request.
      *
-     * @return array
+     * @return string[]
      */
     public static function allowedSortFields(): array
     {
@@ -56,7 +56,7 @@ class AnnouncementCollection extends BaseCollection
     /**
      * The filters that can be applied by the client for this resource.
      *
-     * @return array
+     * @return string[]
      */
     public static function filters(): array
     {

--- a/app/Http/Resources/ArtistCollection.php
+++ b/app/Http/Resources/ArtistCollection.php
@@ -44,7 +44,7 @@ class ArtistCollection extends BaseCollection
     /**
      * The include paths a client is allowed to request.
      *
-     * @return array
+     * @return string[]
      */
     public static function allowedIncludePaths(): array
     {
@@ -62,7 +62,7 @@ class ArtistCollection extends BaseCollection
     /**
      * The sort field names a client is allowed to request.
      *
-     * @return array
+     * @return string[]
      */
     public static function allowedSortFields(): array
     {
@@ -79,7 +79,7 @@ class ArtistCollection extends BaseCollection
     /**
      * The filters that can be applied by the client for this resource.
      *
-     * @return array
+     * @return string[]
      */
     public static function filters(): array
     {

--- a/app/Http/Resources/ArtistResource.php
+++ b/app/Http/Resources/ArtistResource.php
@@ -107,7 +107,7 @@ class ArtistResource extends BaseResource
     /**
      * The include paths a client is allowed to request.
      *
-     * @return array
+     * @return string[]
      */
     public static function allowedIncludePaths(): array
     {

--- a/app/Http/Resources/Billing/BalanceCollection.php
+++ b/app/Http/Resources/Billing/BalanceCollection.php
@@ -58,7 +58,7 @@ class BalanceCollection extends BaseCollection
     /**
      * The sort field names a client is allowed to request.
      *
-     * @return array
+     * @return string[]
      */
     public static function allowedSortFields(): array
     {
@@ -78,7 +78,7 @@ class BalanceCollection extends BaseCollection
     /**
      * The filters that can be applied by the client for this resource.
      *
-     * @return array
+     * @return string[]
      */
     public static function filters(): array
     {

--- a/app/Http/Resources/Billing/TransactionCollection.php
+++ b/app/Http/Resources/Billing/TransactionCollection.php
@@ -57,7 +57,7 @@ class TransactionCollection extends BaseCollection
     /**
      * The sort field names a client is allowed to request.
      *
-     * @return array
+     * @return string[]
      */
     public static function allowedSortFields(): array
     {
@@ -77,7 +77,7 @@ class TransactionCollection extends BaseCollection
     /**
      * The filters that can be applied by the client for this resource.
      *
-     * @return array
+     * @return string[]
      */
     public static function filters(): array
     {

--- a/app/Http/Resources/EntryCollection.php
+++ b/app/Http/Resources/EntryCollection.php
@@ -46,7 +46,7 @@ class EntryCollection extends BaseCollection
     /**
      * The include paths a client is allowed to request.
      *
-     * @return array
+     * @return string[]
      */
     public static function allowedIncludePaths(): array
     {
@@ -79,7 +79,7 @@ class EntryCollection extends BaseCollection
     /**
      * The filters that can be applied by the client for this resource.
      *
-     * @return array
+     * @return string[]
      */
     public static function filters(): array
     {

--- a/app/Http/Resources/EntryResource.php
+++ b/app/Http/Resources/EntryResource.php
@@ -93,7 +93,7 @@ class EntryResource extends BaseResource
     /**
      * The include paths a client is allowed to request.
      *
-     * @return array
+     * @return string[]
      */
     public static function allowedIncludePaths(): array
     {

--- a/app/Http/Resources/ExternalResourceCollection.php
+++ b/app/Http/Resources/ExternalResourceCollection.php
@@ -42,7 +42,7 @@ class ExternalResourceCollection extends BaseCollection
     /**
      * The include paths a client is allowed to request.
      *
-     * @return array
+     * @return string[]
      */
     public static function allowedIncludePaths(): array
     {
@@ -55,7 +55,7 @@ class ExternalResourceCollection extends BaseCollection
     /**
      * The sort field names a client is allowed to request.
      *
-     * @return array
+     * @return string[]
      */
     public static function allowedSortFields(): array
     {
@@ -73,7 +73,7 @@ class ExternalResourceCollection extends BaseCollection
     /**
      * The filters that can be applied by the client for this resource.
      *
-     * @return array
+     * @return string[]
      */
     public static function filters(): array
     {

--- a/app/Http/Resources/ExternalResourceResource.php
+++ b/app/Http/Resources/ExternalResourceResource.php
@@ -71,7 +71,7 @@ class ExternalResourceResource extends BaseResource
     /**
      * The include paths a client is allowed to request.
      *
-     * @return array
+     * @return string[]
      */
     public static function allowedIncludePaths(): array
     {

--- a/app/Http/Resources/ImageCollection.php
+++ b/app/Http/Resources/ImageCollection.php
@@ -42,7 +42,7 @@ class ImageCollection extends BaseCollection
     /**
      * The include paths a client is allowed to request.
      *
-     * @return array
+     * @return string[]
      */
     public static function allowedIncludePaths(): array
     {
@@ -55,7 +55,7 @@ class ImageCollection extends BaseCollection
     /**
      * The sort field names a client is allowed to request.
      *
-     * @return array
+     * @return string[]
      */
     public static function allowedSortFields(): array
     {
@@ -74,7 +74,7 @@ class ImageCollection extends BaseCollection
     /**
      * The filters that can be applied by the client for this resource.
      *
-     * @return array
+     * @return string[]
      */
     public static function filters(): array
     {

--- a/app/Http/Resources/ImageResource.php
+++ b/app/Http/Resources/ImageResource.php
@@ -66,7 +66,7 @@ class ImageResource extends BaseResource
     /**
      * The include paths a client is allowed to request.
      *
-     * @return array
+     * @return string[]
      */
     public static function allowedIncludePaths(): array
     {

--- a/app/Http/Resources/SeriesCollection.php
+++ b/app/Http/Resources/SeriesCollection.php
@@ -43,7 +43,7 @@ class SeriesCollection extends BaseCollection
     /**
      * The include paths a client is allowed to request.
      *
-     * @return array
+     * @return string[]
      */
     public static function allowedIncludePaths(): array
     {
@@ -55,7 +55,7 @@ class SeriesCollection extends BaseCollection
     /**
      * The sort field names a client is allowed to request.
      *
-     * @return array
+     * @return string[]
      */
     public static function allowedSortFields(): array
     {
@@ -72,7 +72,7 @@ class SeriesCollection extends BaseCollection
     /**
      * The filters that can be applied by the client for this resource.
      *
-     * @return array
+     * @return string[]
      */
     public static function filters(): array
     {

--- a/app/Http/Resources/SeriesResource.php
+++ b/app/Http/Resources/SeriesResource.php
@@ -131,7 +131,7 @@ class SeriesResource extends BaseResource
     /**
      * The include paths a client is allowed to request.
      *
-     * @return array
+     * @return string[]
      */
     public static function allowedIncludePaths(): array
     {

--- a/app/Http/Resources/SongCollection.php
+++ b/app/Http/Resources/SongCollection.php
@@ -43,7 +43,7 @@ class SongCollection extends BaseCollection
     /**
      * The include paths a client is allowed to request.
      *
-     * @return array
+     * @return string[]
      */
     public static function allowedIncludePaths(): array
     {
@@ -57,7 +57,7 @@ class SongCollection extends BaseCollection
     /**
      * The sort field names a client is allowed to request.
      *
-     * @return array
+     * @return string[]
      */
     public static function allowedSortFields(): array
     {
@@ -73,7 +73,7 @@ class SongCollection extends BaseCollection
     /**
      * The filters that can be applied by the client for this resource.
      *
-     * @return array
+     * @return string[]
      */
     public static function filters(): array
     {

--- a/app/Http/Resources/SongResource.php
+++ b/app/Http/Resources/SongResource.php
@@ -80,7 +80,7 @@ class SongResource extends BaseResource
     /**
      * The include paths a client is allowed to request.
      *
-     * @return array
+     * @return string[]
      */
     public static function allowedIncludePaths(): array
     {

--- a/app/Http/Resources/SynonymCollection.php
+++ b/app/Http/Resources/SynonymCollection.php
@@ -43,7 +43,7 @@ class SynonymCollection extends BaseCollection
     /**
      * The include paths a client is allowed to request.
      *
-     * @return array
+     * @return string[]
      */
     public static function allowedIncludePaths(): array
     {
@@ -55,7 +55,7 @@ class SynonymCollection extends BaseCollection
     /**
      * The sort field names a client is allowed to request.
      *
-     * @return array
+     * @return string[]
      */
     public static function allowedSortFields(): array
     {
@@ -72,7 +72,7 @@ class SynonymCollection extends BaseCollection
     /**
      * The filters that can be applied by the client for this resource.
      *
-     * @return array
+     * @return string[]
      */
     public static function filters(): array
     {

--- a/app/Http/Resources/SynonymResource.php
+++ b/app/Http/Resources/SynonymResource.php
@@ -59,7 +59,7 @@ class SynonymResource extends BaseResource
     /**
      * The include paths a client is allowed to request.
      *
-     * @return array
+     * @return string[]
      */
     public static function allowedIncludePaths(): array
     {

--- a/app/Http/Resources/ThemeCollection.php
+++ b/app/Http/Resources/ThemeCollection.php
@@ -46,7 +46,7 @@ class ThemeCollection extends BaseCollection
     /**
      * The include paths a client is allowed to request.
      *
-     * @return array
+     * @return string[]
      */
     public static function allowedIncludePaths(): array
     {
@@ -63,7 +63,7 @@ class ThemeCollection extends BaseCollection
     /**
      * The sort field names a client is allowed to request.
      *
-     * @return array
+     * @return string[]
      */
     public static function allowedSortFields(): array
     {
@@ -84,7 +84,7 @@ class ThemeCollection extends BaseCollection
     /**
      * The filters that can be applied by the client for this resource.
      *
-     * @return array
+     * @return string[]
      */
     public static function filters(): array
     {

--- a/app/Http/Resources/ThemeResource.php
+++ b/app/Http/Resources/ThemeResource.php
@@ -115,7 +115,7 @@ class ThemeResource extends BaseResource
     /**
      * The include paths a client is allowed to request.
      *
-     * @return array
+     * @return string[]
      */
     public static function allowedIncludePaths(): array
     {

--- a/app/Http/Resources/VideoCollection.php
+++ b/app/Http/Resources/VideoCollection.php
@@ -50,7 +50,7 @@ class VideoCollection extends BaseCollection
     /**
      * The include paths a client is allowed to request.
      *
-     * @return array
+     * @return string[]
      */
     public static function allowedIncludePaths(): array
     {
@@ -64,7 +64,7 @@ class VideoCollection extends BaseCollection
     /**
      * The sort field names a client is allowed to request.
      *
-     * @return array
+     * @return string[]
      */
     public static function allowedSortFields(): array
     {
@@ -91,7 +91,7 @@ class VideoCollection extends BaseCollection
     /**
      * The filters that can be applied by the client for this resource.
      *
-     * @return array
+     * @return string[]
      */
     public static function filters(): array
     {

--- a/app/Http/Resources/VideoResource.php
+++ b/app/Http/Resources/VideoResource.php
@@ -102,7 +102,7 @@ class VideoResource extends BaseResource
     /**
      * The include paths a client is allowed to request.
      *
-     * @return array
+     * @return string[]
      */
     public static function allowedIncludePaths(): array
     {

--- a/app/JsonApi/Condition/WhereCondition.php
+++ b/app/JsonApi/Condition/WhereCondition.php
@@ -144,32 +144,22 @@ class WhereCondition extends Condition
      */
     protected function getElasticsearchClause(Filter $filter): AbstractParameterizedQueryBuilder
     {
-        if (ComparisonOperator::LT()->is($this->getComparisonOperator())) {
-            return (new RangeQueryBuilder())
+        return match (optional($this->getComparisonOperator())->value) {
+            ComparisonOperator::LT => (new RangeQueryBuilder())
                 ->field($filter->getKey())
-                ->lt(collect($filter->getFilterValues($this))->first());
-        }
-
-        if (ComparisonOperator::GT()->is($this->getComparisonOperator())) {
-            return (new RangeQueryBuilder())
+                ->lt(collect($filter->getFilterValues($this))->first()),
+            ComparisonOperator::GT => (new RangeQueryBuilder())
                 ->field($filter->getKey())
-                ->gt(collect($filter->getFilterValues($this))->first());
-        }
-
-        if (ComparisonOperator::LTE()->is($this->getComparisonOperator())) {
-            return (new RangeQueryBuilder())
+                ->gt(collect($filter->getFilterValues($this))->first()),
+            ComparisonOperator::LTE => (new RangeQueryBuilder())
                 ->field($filter->getKey())
-                ->lte(collect($filter->getFilterValues($this))->first());
-        }
-
-        if (ComparisonOperator::GTE()->is($this->getComparisonOperator())) {
-            return (new RangeQueryBuilder())
+                ->lte(collect($filter->getFilterValues($this))->first()),
+            ComparisonOperator::GTE => (new RangeQueryBuilder())
                 ->field($filter->getKey())
-                ->gte(collect($filter->getFilterValues($this))->first());
-        }
-
-        return (new TermQueryBuilder())
-            ->field($filter->getKey())
-            ->value(collect($filter->getFilterValues($this))->first());
+                ->gte(collect($filter->getFilterValues($this))->first()),
+            default => (new TermQueryBuilder())
+                ->field($filter->getKey())
+                ->value(collect($filter->getFilterValues($this))->first()),
+        };
     }
 }

--- a/app/JsonApi/QueryParser.php
+++ b/app/JsonApi/QueryParser.php
@@ -43,7 +43,7 @@ class QueryParser
     /**
      * The list of fields and direction to base sorting on.
      *
-     * @var array
+     * @var array<string, bool>
      */
     protected array $sorts;
 
@@ -159,7 +159,7 @@ class QueryParser
      * Parse sorts from parameters.
      *
      * @param array $parameters
-     * @return array
+     * @return array<string, bool>
      */
     protected function parseSorts(array $parameters): array
     {
@@ -196,7 +196,7 @@ class QueryParser
     /**
      * Get sorts.
      *
-     * @return array
+     * @return array<string, bool>
      */
     public function getSorts(): array
     {
@@ -353,7 +353,7 @@ class QueryParser
      *
      * @param array $allowedIncludePaths
      * @param string $type
-     * @return array
+     * @return string[]
      */
     public function getIncludePaths(array $allowedIncludePaths, string $type = ''): array
     {

--- a/app/Models/Anime.php
+++ b/app/Models/Anime.php
@@ -32,7 +32,7 @@ class Anime extends BaseModel
     /**
      * The attributes that are mass assignable.
      *
-     * @var array
+     * @var string[]
      */
     protected $fillable = ['slug', 'name', 'year', 'season', 'synopsis'];
 
@@ -41,7 +41,7 @@ class Anime extends BaseModel
      *
      * Allows for object-based events for native Eloquent events.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $dispatchesEvents = [
         'created' => AnimeCreated::class,
@@ -102,7 +102,7 @@ class Anime extends BaseModel
     /**
      * The attributes that should be cast to enum types.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $enumCasts = [
         'season' => AnimeSeason::class,
@@ -111,7 +111,7 @@ class Anime extends BaseModel
     /**
      * The attributes that should be cast to native types.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $casts = [
         'season' => 'int',

--- a/app/Models/Announcement.php
+++ b/app/Models/Announcement.php
@@ -17,7 +17,7 @@ class Announcement extends BaseModel
     /**
      * The attributes that are mass assignable.
      *
-     * @var array
+     * @var string[]
      */
     protected $fillable = ['content'];
 
@@ -26,7 +26,7 @@ class Announcement extends BaseModel
      *
      * Allows for object-based events for native Eloquent events.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $dispatchesEvents = [
         'created' => AnnouncementCreated::class,

--- a/app/Models/Artist.php
+++ b/app/Models/Artist.php
@@ -28,7 +28,7 @@ class Artist extends BaseModel
     /**
      * The attributes that are mass assignable.
      *
-     * @var array
+     * @var string[]
      */
     protected $fillable = ['slug', 'name'];
 
@@ -37,7 +37,7 @@ class Artist extends BaseModel
      *
      * Allows for object-based events for native Eloquent events.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $dispatchesEvents = [
         'created' => ArtistCreated::class,

--- a/app/Models/Billing/Balance.php
+++ b/app/Models/Billing/Balance.php
@@ -23,7 +23,7 @@ class Balance extends BaseModel
     use CastsEnums;
 
     /**
-     * @var array
+     * @var string[]
      */
     protected $fillable = ['date', 'service', 'frequency', 'usage', 'balance'];
 
@@ -32,7 +32,7 @@ class Balance extends BaseModel
      *
      * Allows for object-based events for native Eloquent events.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $dispatchesEvents = [
         'created' => BalanceCreated::class,
@@ -56,7 +56,9 @@ class Balance extends BaseModel
     protected $primaryKey = 'balance_id';
 
     /**
-     * @var array
+     * The attributes that should be cast to enum types.
+     *
+     * @var array<string, string>
      */
     protected $enumCasts = [
         'service' => Service::class,
@@ -64,7 +66,9 @@ class Balance extends BaseModel
     ];
 
     /**
-     * @var array
+     * The attributes that should be cast to native types.
+     *
+     * @var array<string, string>
      */
     protected $casts = [
         'service' => 'int',

--- a/app/Models/Billing/Transaction.php
+++ b/app/Models/Billing/Transaction.php
@@ -22,7 +22,7 @@ class Transaction extends BaseModel
     use CastsEnums;
 
     /**
-     * @var array
+     * @var string[]
      */
     protected $fillable = ['date', 'service', 'description', 'amount', 'external_id'];
 
@@ -31,7 +31,7 @@ class Transaction extends BaseModel
      *
      * Allows for object-based events for native Eloquent events.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $dispatchesEvents = [
         'created' => TransactionCreated::class,
@@ -55,14 +55,18 @@ class Transaction extends BaseModel
     protected $primaryKey = 'transaction_id';
 
     /**
-     * @var array
+     * The attributes that should be cast to enum types.
+     *
+     * @var array<string, string>
      */
     protected $enumCasts = [
         'service' => Service::class,
     ];
 
     /**
-     * @var array
+     * The attributes that should be cast to native types.
+     *
+     * @var array<string, string>
      */
     protected $casts = [
         'service' => 'int',

--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -30,7 +30,7 @@ class Entry extends BaseModel
     /**
      * The attributes that are mass assignable.
      *
-     * @var array
+     * @var string[]
      */
     protected $fillable = ['version', 'episodes', 'nsfw', 'spoiler', 'notes'];
 
@@ -39,7 +39,7 @@ class Entry extends BaseModel
      *
      * Allows for object-based events for native Eloquent events.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $dispatchesEvents = [
         'created' => EntryCreated::class,
@@ -66,7 +66,7 @@ class Entry extends BaseModel
     /**
      * The attributes that should be cast to native types.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $casts = [
         'nsfw' => 'boolean',

--- a/app/Models/ExternalResource.php
+++ b/app/Models/ExternalResource.php
@@ -24,7 +24,7 @@ class ExternalResource extends BaseModel
     /**
      * The attributes that are mass assignable.
      *
-     * @var array
+     * @var string[]
      */
     protected $fillable = ['site', 'link', 'external_id'];
 
@@ -33,7 +33,7 @@ class ExternalResource extends BaseModel
      *
      * Allows for object-based events for native Eloquent events.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $dispatchesEvents = [
         'created' => ExternalResourceCreated::class,
@@ -59,7 +59,7 @@ class ExternalResource extends BaseModel
     /**
      * The attributes that should be cast to enum types.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $enumCasts = [
         'site' => ResourceSite::class,
@@ -68,7 +68,7 @@ class ExternalResource extends BaseModel
     /**
      * The attributes that should be cast to native types.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $casts = [
         'site' => 'int',

--- a/app/Models/Image.php
+++ b/app/Models/Image.php
@@ -26,7 +26,7 @@ class Image extends BaseModel implements Streamable
     /**
      * The attributes that are mass assignable.
      *
-     * @var array
+     * @var string[]
      */
     protected $fillable = ['path', 'facet', 'size', 'mimetype'];
 
@@ -35,7 +35,7 @@ class Image extends BaseModel implements Streamable
      *
      * Allows for object-based events for native Eloquent events.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $dispatchesEvents = [
         'created' => ImageCreated::class,
@@ -62,7 +62,7 @@ class Image extends BaseModel implements Streamable
     /**
      * The attributes that should be cast to enum types.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $enumCasts = [
         'facet' => ImageFacet::class,
@@ -71,7 +71,7 @@ class Image extends BaseModel implements Streamable
     /**
      * The attributes that should be cast to native types.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $casts = [
         'facet' => 'int',

--- a/app/Models/Invitation.php
+++ b/app/Models/Invitation.php
@@ -24,7 +24,7 @@ class Invitation extends BaseModel
     /**
      * The attributes that are mass assignable.
      *
-     * @var array
+     * @var string[]
      */
     protected $fillable = ['name', 'email', 'status'];
 
@@ -33,7 +33,7 @@ class Invitation extends BaseModel
      *
      * Allows for object-based events for native Eloquent events.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $dispatchesEvents = [
         'created' => InvitationCreated::class,
@@ -60,7 +60,7 @@ class Invitation extends BaseModel
     /**
      * The attributes that should be cast to enum types.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $enumCasts = [
         'status' => InvitationStatus::class,
@@ -69,7 +69,7 @@ class Invitation extends BaseModel
     /**
      * The attributes that should be cast to native types.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $casts = [
         'status' => 'int',

--- a/app/Models/Series.php
+++ b/app/Models/Series.php
@@ -24,7 +24,7 @@ class Series extends BaseModel
     /**
      * The attributes that are mass assignable.
      *
-     * @var array
+     * @var string[]
      */
     protected $fillable = ['slug', 'name'];
 
@@ -33,7 +33,7 @@ class Series extends BaseModel
      *
      * Allows for object-based events for native Eloquent events.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $dispatchesEvents = [
         'created' => SeriesCreated::class,

--- a/app/Models/Song.php
+++ b/app/Models/Song.php
@@ -26,7 +26,7 @@ class Song extends BaseModel
     /**
      * The attributes that are mass assignable.
      *
-     * @var array
+     * @var string[]
      */
     protected $fillable = ['title'];
 
@@ -35,7 +35,7 @@ class Song extends BaseModel
      *
      * Allows for object-based events for native Eloquent events.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $dispatchesEvents = [
         'created' => SongCreated::class,

--- a/app/Models/Synonym.php
+++ b/app/Models/Synonym.php
@@ -23,7 +23,7 @@ class Synonym extends BaseModel
     /**
      * The attributes that are mass assignable.
      *
-     * @var array
+     * @var string[]
      */
     protected $fillable = ['text'];
 
@@ -32,7 +32,7 @@ class Synonym extends BaseModel
      *
      * Allows for object-based events for native Eloquent events.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $dispatchesEvents = [
         'created' => SynonymCreated::class,

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -20,7 +20,7 @@ class Team extends JetstreamTeam
     /**
      * The attributes that should be cast to native types.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $casts = [
         'personal_team' => 'boolean',
@@ -29,17 +29,14 @@ class Team extends JetstreamTeam
     /**
      * The attributes that are mass assignable.
      *
-     * @var array
+     * @var string[]
      */
-    protected $fillable = [
-        'name',
-        'personal_team',
-    ];
+    protected $fillable = ['name', 'personal_team'];
 
     /**
      * The event map for the model.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $dispatchesEvents = [
         'created' => TeamCreated::class,

--- a/app/Models/TeamInvitation.php
+++ b/app/Models/TeamInvitation.php
@@ -16,12 +16,9 @@ class TeamInvitation extends JetstreamTeamInvitation
     /**
      * The attributes that are mass assignable.
      *
-     * @var array
+     * @var string[]
      */
-    protected $fillable = [
-        'email',
-        'role',
-    ];
+    protected $fillable = ['email', 'role'];
 
     /**
      * Get the team that the invitation belongs to.

--- a/app/Models/Theme.php
+++ b/app/Models/Theme.php
@@ -28,7 +28,7 @@ class Theme extends BaseModel
     use Searchable;
 
     /**
-     * @var array
+     * @var string[]
      */
     protected $fillable = ['type', 'sequence', 'group'];
 
@@ -37,7 +37,7 @@ class Theme extends BaseModel
      *
      * Allows for object-based events for native Eloquent events.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $dispatchesEvents = [
         'created' => ThemeCreated::class,
@@ -88,14 +88,18 @@ class Theme extends BaseModel
     }
 
     /**
-     * @var array
+     * The attributes that should be cast to enum types.
+     *
+     * @var array<string, string>
      */
     protected $enumCasts = [
         'type' => ThemeType::class,
     ];
 
     /**
-     * @var array
+     * The attributes that should be cast to native types.
+     *
+     * @var array<string, string>
      */
     protected $casts = [
         'type' => 'int',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -33,20 +33,16 @@ class User extends Authenticatable implements MustVerifyEmail, Nameable
     /**
      * The attributes that are mass assignable.
      *
-     * @var array
+     * @var string[]
      */
-    protected $fillable = [
-        'name',
-        'email',
-        'password',
-    ];
+    protected $fillable = ['name', 'email', 'password'];
 
     /**
      * The event map for the model.
      *
      * Allows for object-based events for native Eloquent events.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $dispatchesEvents = [
         'created' => UserCreated::class,
@@ -58,14 +54,9 @@ class User extends Authenticatable implements MustVerifyEmail, Nameable
     /**
      * The attributes that should be hidden for arrays.
      *
-     * @var array
+     * @var string[]
      */
-    protected $hidden = [
-        'password',
-        'remember_token',
-        'two_factor_recovery_codes',
-        'two_factor_secret',
-    ];
+    protected $hidden = ['password', 'remember_token', 'two_factor_recovery_codes', 'two_factor_secret'];
 
     /**
      * The storage format of the model's date columns.
@@ -77,7 +68,7 @@ class User extends Authenticatable implements MustVerifyEmail, Nameable
     /**
      * The attributes that should be cast to native types.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $casts = [
         'email_verified_at' => 'datetime',

--- a/app/Models/Video.php
+++ b/app/Models/Video.php
@@ -32,7 +32,9 @@ class Video extends BaseModel implements Streamable, Viewable
     use Searchable;
 
     /**
-     * @var array
+     * The attributes that are mass assignable.
+     *
+     * @var string[]
      */
     protected $fillable = ['basename', 'filename', 'path', 'size', 'mimetype'];
 
@@ -41,7 +43,7 @@ class Video extends BaseModel implements Streamable, Viewable
      *
      * Allows for object-based events for native Eloquent events.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $dispatchesEvents = [
         'created' => VideoCreated::class,
@@ -68,7 +70,7 @@ class Video extends BaseModel implements Streamable, Viewable
     /**
      * The accessors to append to the model's array form.
      *
-     * @var array
+     * @var string[]
      */
     protected $appends = ['tags'];
 
@@ -135,7 +137,9 @@ class Video extends BaseModel implements Streamable, Viewable
     }
 
     /**
-     * @var array
+     * The attributes that should be cast to enum types.
+     *
+     * @var array<string, string>
      */
     protected $enumCasts = [
         'overlap' => VideoOverlap::class,
@@ -143,7 +147,9 @@ class Video extends BaseModel implements Streamable, Viewable
     ];
 
     /**
-     * @var array
+     * The attributes that should be cast to native types.
+     *
+     * @var array<string, string>
      */
     protected $casts = [
         'overlap' => 'int',

--- a/app/Nova/Anime.php
+++ b/app/Nova/Anime.php
@@ -83,7 +83,7 @@ class Anime extends Resource
     /**
      * The columns that should be searched.
      *
-     * @var array
+     * @var string[]
      */
     public static $search = [
         'name',

--- a/app/Nova/Announcement.php
+++ b/app/Nova/Announcement.php
@@ -63,7 +63,7 @@ class Announcement extends Resource
     /**
      * The columns that should be searched.
      *
-     * @var array
+     * @var string[]
      */
     public static $search = [
         'announcement_id',

--- a/app/Nova/Artist.php
+++ b/app/Nova/Artist.php
@@ -65,7 +65,7 @@ class Artist extends Resource
     /**
      * The columns that should be searched.
      *
-     * @var array
+     * @var string[]
      */
     public static $search = [
         'name',

--- a/app/Nova/Balance.php
+++ b/app/Nova/Balance.php
@@ -68,7 +68,7 @@ class Balance extends Resource
     /**
      * The columns that should be searched.
      *
-     * @var array
+     * @var string[]
      */
     public static $search = [
         'balance_id',

--- a/app/Nova/Entry.php
+++ b/app/Nova/Entry.php
@@ -64,7 +64,7 @@ class Entry extends Resource
     /**
      * The columns that should be searched.
      *
-     * @var array
+     * @var string[]
      */
     public static $search = [
         'entry_id',

--- a/app/Nova/ExternalResource.php
+++ b/app/Nova/ExternalResource.php
@@ -51,7 +51,7 @@ class ExternalResource extends Resource
     /**
      * The columns that should be searched.
      *
-     * @var array
+     * @var string[]
      */
     public static $search = [
         'link',

--- a/app/Nova/Image.php
+++ b/app/Nova/Image.php
@@ -50,7 +50,7 @@ class Image extends Resource
     /**
      * The columns that should be searched.
      *
-     * @var array
+     * @var string[]
      */
     public static $search = [
         'image_id',

--- a/app/Nova/Invitation.php
+++ b/app/Nova/Invitation.php
@@ -67,7 +67,7 @@ class Invitation extends Resource
     /**
      * The columns that should be searched.
      *
-     * @var array
+     * @var string[]
      */
     public static $search = [
         'email',

--- a/app/Nova/Series.php
+++ b/app/Nova/Series.php
@@ -65,7 +65,7 @@ class Series extends Resource
     /**
      * The columns that should be searched.
      *
-     * @var array
+     * @var string[]
      */
     public static $search = [
         'name',

--- a/app/Nova/Song.php
+++ b/app/Nova/Song.php
@@ -35,7 +35,7 @@ class Song extends Resource
     /**
      * The relationships that should be eager loaded on index queries.
      *
-     * @var array
+     * @var string[]
      */
     public static $with = ['artists'];
 
@@ -72,7 +72,7 @@ class Song extends Resource
     /**
      * The columns that should be searched.
      *
-     * @var array
+     * @var string[]
      */
     public static $search = [
         'title',

--- a/app/Nova/Synonym.php
+++ b/app/Nova/Synonym.php
@@ -61,7 +61,7 @@ class Synonym extends Resource
     /**
      * The columns that should be searched.
      *
-     * @var array
+     * @var string[]
      */
     public static $search = [
         'text',

--- a/app/Nova/Theme.php
+++ b/app/Nova/Theme.php
@@ -60,7 +60,7 @@ class Theme extends Resource
     /**
      * The columns that should be searched.
      *
-     * @var array
+     * @var string[]
      */
     public static $search = [
         'slug',

--- a/app/Nova/Transaction.php
+++ b/app/Nova/Transaction.php
@@ -69,7 +69,7 @@ class Transaction extends Resource
     /**
      * The columns that should be searched.
      *
-     * @var array
+     * @var string[]
      */
     public static $search = [
         'transaction_id',

--- a/app/Nova/User.php
+++ b/app/Nova/User.php
@@ -76,7 +76,7 @@ class User extends Resource
     /**
      * The columns that should be searched.
      *
-     * @var array
+     * @var string[]
      */
     public static $search = [
         'name',

--- a/app/Nova/Video.php
+++ b/app/Nova/Video.php
@@ -71,7 +71,7 @@ class Video extends Resource
     /**
      * The columns that should be searched.
      *
-     * @var array
+     * @var string[]
      */
     public static $search = [
         'filename',

--- a/app/Pivots/AnimeImage.php
+++ b/app/Pivots/AnimeImage.php
@@ -28,7 +28,7 @@ class AnimeImage extends BasePivot
      *
      * Allows for object-based events for native Eloquent events.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $dispatchesEvents = [
         'created' => AnimeImageCreated::class,

--- a/app/Pivots/AnimeResource.php
+++ b/app/Pivots/AnimeResource.php
@@ -18,7 +18,7 @@ class AnimeResource extends BasePivot
     use HasFactory;
 
     /**
-     * @var array
+     * @var string[]
      */
     protected $fillable = ['as'];
 
@@ -34,7 +34,7 @@ class AnimeResource extends BasePivot
      *
      * Allows for object-based events for native Eloquent events.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $dispatchesEvents = [
         'created' => AnimeResourceCreated::class,

--- a/app/Pivots/AnimeSeries.php
+++ b/app/Pivots/AnimeSeries.php
@@ -28,7 +28,7 @@ class AnimeSeries extends BasePivot
      *
      * Allows for object-based events for native Eloquent events.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $dispatchesEvents = [
         'created' => AnimeSeriesCreated::class,

--- a/app/Pivots/ArtistImage.php
+++ b/app/Pivots/ArtistImage.php
@@ -28,7 +28,7 @@ class ArtistImage extends BasePivot
      *
      * Allows for object-based events for native Eloquent events.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $dispatchesEvents = [
         'created' => ArtistImageCreated::class,

--- a/app/Pivots/ArtistMember.php
+++ b/app/Pivots/ArtistMember.php
@@ -18,7 +18,7 @@ class ArtistMember extends BasePivot
     use HasFactory;
 
     /**
-     * @var array
+     * @var string[]
      */
     protected $fillable = ['as'];
 
@@ -34,7 +34,7 @@ class ArtistMember extends BasePivot
      *
      * Allows for object-based events for native Eloquent events.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $dispatchesEvents = [
         'created' => ArtistMemberCreated::class,

--- a/app/Pivots/ArtistResource.php
+++ b/app/Pivots/ArtistResource.php
@@ -18,7 +18,7 @@ class ArtistResource extends BasePivot
     use HasFactory;
 
     /**
-     * @var array
+     * @var string[]
      */
     protected $fillable = ['as'];
 
@@ -34,7 +34,7 @@ class ArtistResource extends BasePivot
      *
      * Allows for object-based events for native Eloquent events.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $dispatchesEvents = [
         'created' => ArtistResourceCreated::class,

--- a/app/Pivots/ArtistSong.php
+++ b/app/Pivots/ArtistSong.php
@@ -18,7 +18,7 @@ class ArtistSong extends BasePivot
     use HasFactory;
 
     /**
-     * @var array
+     * @var string[]
      */
     protected $fillable = ['as'];
 
@@ -34,7 +34,7 @@ class ArtistSong extends BasePivot
      *
      * Allows for object-based events for native Eloquent events.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $dispatchesEvents = [
         'created' => ArtistSongCreated::class,

--- a/app/Pivots/VideoEntry.php
+++ b/app/Pivots/VideoEntry.php
@@ -28,7 +28,7 @@ class VideoEntry extends BasePivot
      *
      * Allows for object-based events for native Eloquent events.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $dispatchesEvents = [
         'created' => VideoEntryCreated::class,

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Providers;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
 
 /**
@@ -19,6 +20,12 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        Model::preventLazyLoading($this->app->isLocal());
+        Model::preventLazyLoading();
+
+        Model::handleLazyLoadingViolationUsing(function (Model $model, string $relation) {
+            $class = get_class($model);
+
+            Log::info("Attempted to lazy load [{$relation}] on model [{$class}]");
+        });
     }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -19,7 +19,7 @@ class AuthServiceProvider extends ServiceProvider
     /**
      * The policy mappings for the application.
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $policies = [
         'App\Models\Anime' => 'App\Policies\AnimePolicy',

--- a/database/seeders/AniDbResourceSeeder.php
+++ b/database/seeders/AniDbResourceSeeder.php
@@ -12,8 +12,8 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\ServerException;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Log;
@@ -91,9 +91,9 @@ class AniDbResourceSeeder extends Seeder
     protected function getUnseededAnime(): Collection
     {
         return Anime::query()
-            ->whereHas('externalResources', function (BelongsToMany $resourceQuery) {
+            ->whereHas('externalResources', function (Builder $resourceQuery) {
                 $resourceQuery->where('site', ResourceSite::MAL);
-            })->whereDoesntHave('externalResources', function (BelongsToMany $resourceQuery) {
+            })->whereDoesntHave('externalResources', function (Builder $resourceQuery) {
                 $resourceQuery->where('site', ResourceSite::ANIDB);
             })
             ->get();

--- a/database/seeders/AnilistAnimeResourceSeeder.php
+++ b/database/seeders/AnilistAnimeResourceSeeder.php
@@ -12,8 +12,8 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\ServerException;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Log;
@@ -105,9 +105,9 @@ class AnilistAnimeResourceSeeder extends Seeder
     protected function getUnseededAnime(): Collection
     {
         return Anime::query()
-            ->whereHas('externalResources', function (BelongsToMany $resourceQuery) {
+            ->whereHas('externalResources', function (Builder $resourceQuery) {
                 $resourceQuery->where('site', ResourceSite::MAL);
-            })->whereDoesntHave('externalResources', function (BelongsToMany $resourceQuery) {
+            })->whereDoesntHave('externalResources', function (Builder $resourceQuery) {
                 $resourceQuery->where('site', ResourceSite::ANILIST);
             })
             ->get();

--- a/database/seeders/AnilistArtistResourceSeeder.php
+++ b/database/seeders/AnilistArtistResourceSeeder.php
@@ -12,7 +12,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\ServerException;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Log;
@@ -30,7 +30,7 @@ class AnilistArtistResourceSeeder extends Seeder
     public function run()
     {
         // Get artists that have MAL resource but do not have Anilist resource
-        $artists = Artist::whereDoesntHave('externalResources', function (BelongsToMany $resourceQuery) {
+        $artists = Artist::whereDoesntHave('externalResources', function (Builder $resourceQuery) {
             $resourceQuery->where('site', ResourceSite::ANILIST);
         })
         ->get();

--- a/database/seeders/AnimeResourceSeeder.php
+++ b/database/seeders/AnimeResourceSeeder.php
@@ -8,7 +8,7 @@ use App\Enums\ResourceSite;
 use App\Models\Anime;
 use App\Models\ExternalResource;
 use Exception;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Log;
 
@@ -62,7 +62,7 @@ class AnimeResourceSeeder extends Seeder
                     // This is not guaranteed as an Anime Name may be inconsistent between indices
                     $resourceAnime = Anime::where('name', $animeName)
                         ->whereIn('year', $years)
-                        ->whereDoesntHave('externalResources', function (BelongsToMany $resourceQuery) use ($resource) {
+                        ->whereDoesntHave('externalResources', function (Builder $resourceQuery) use ($resource) {
                             $resourceQuery->where('site', $resource->site->value)->where('link', $resource->link);
                         })
                         ->get();

--- a/database/seeders/ArtistCoverSeeder.php
+++ b/database/seeders/ArtistCoverSeeder.php
@@ -12,8 +12,8 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\ServerException;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Seeder;
 use Illuminate\Http\Testing\File;
 use Illuminate\Support\Arr;
@@ -134,9 +134,9 @@ class ArtistCoverSeeder extends Seeder
     protected function getUnseededArtists(): Collection
     {
         return Artist::query()
-            ->whereHas('externalResources', function (BelongsToMany $resourceQuery) {
+            ->whereHas('externalResources', function (Builder $resourceQuery) {
                 $resourceQuery->where('site', ResourceSite::ANILIST);
-            })->whereDoesntHave('images', function (BelongsToMany $imageQuery) {
+            })->whereDoesntHave('images', function (Builder $imageQuery) {
                 $imageQuery->whereIn('facet', [ImageFacet::COVER_LARGE, ImageFacet::COVER_SMALL]);
             })
             ->get();

--- a/database/seeders/KitsuResourceSeeder.php
+++ b/database/seeders/KitsuResourceSeeder.php
@@ -12,8 +12,8 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\ServerException;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Log;
@@ -103,9 +103,9 @@ class KitsuResourceSeeder extends Seeder
     protected function getUnseededAnime(): Collection
     {
         return Anime::query()
-            ->whereHas('externalResources', function (BelongsToMany $resourceQuery) {
+            ->whereHas('externalResources', function (Builder $resourceQuery) {
                 $resourceQuery->where('site', ResourceSite::MAL);
-            })->whereDoesntHave('externalResources', function (BelongsToMany $resourceQuery) {
+            })->whereDoesntHave('externalResources', function (Builder $resourceQuery) {
                 $resourceQuery->where('site', ResourceSite::KITSU);
             })
             ->get();

--- a/database/seeders/SynopsisCoverSeeder.php
+++ b/database/seeders/SynopsisCoverSeeder.php
@@ -12,8 +12,8 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\ServerException;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Seeder;
 use Illuminate\Http\Testing\File;
 use Illuminate\Support\Arr;
@@ -143,9 +143,9 @@ class SynopsisCoverSeeder extends Seeder
     protected function getUnseededAnime(): Collection
     {
         return Anime::query()
-            ->whereHas('externalResources', function (BelongsToMany $resourceQuery) {
+            ->whereHas('externalResources', function (Builder $resourceQuery) {
                 $resourceQuery->where('site', ResourceSite::ANILIST);
-            })->whereDoesntHave('images', function (BelongsToMany $imageQuery) {
+            })->whereDoesntHave('images', function (Builder $imageQuery) {
                 $imageQuery->whereIn('facet', [ImageFacet::COVER_LARGE, ImageFacet::COVER_SMALL]);
             })
             ->get();

--- a/resources/views/transparency.blade.php
+++ b/resources/views/transparency.blade.php
@@ -9,30 +9,32 @@
         </div>
 
         <!-- Filters -->
-        <div class="py-4">
-            <div>
-                <h2 class="text-2xl font-semibold leading-tight">{{ __('Select Month') }}</h2>
-            </div>
-            <x-jet-input-error for="date" class="mt-2" />
-            <form method="GET" action="{{ route('transparency.show') }}">
-                <div class="my-2 flex sm:flex-row flex-col">
-                    <div class="flex flex-row mb-1 sm:mb-0">
-                        <div class="relative">
-                            <select name="date" class="h-full rounded-l">
-                                @foreach ($filterOptions as $filterOption)
-                                <option {{ $filterOption->format('Y-m') === $selectedDate->format('Y-m') ? 'selected' : '' }}>{{ $filterOption->format('Y-m') }}</option>
-                                @endforeach
-                            </select>
+        @if ($filterOptions->isNotEmpty())
+            <div class="py-4">
+                <div>
+                    <h2 class="text-2xl font-semibold leading-tight">{{ __('Select Month') }}</h2>
+                </div>
+                <x-jet-input-error for="date" class="mt-2" />
+                <form method="GET" action="{{ route('transparency.show') }}">
+                    <div class="my-2 flex sm:flex-row flex-col">
+                        <div class="flex flex-row mb-1 sm:mb-0">
+                            <div class="relative">
+                                <select name="date" class="h-full rounded-l">
+                                    @foreach ($filterOptions as $filterOption)
+                                        <option {{ $filterOption->format('Y-m') === $selectedDate->format('Y-m') ? 'selected' : '' }}>{{ $filterOption->format('Y-m') }}</option>
+                                    @endforeach
+                                </select>
+                            </div>
+                        </div>
+                        <div class="block relative">
+                            <x-jet-button class="rounded-l-none h-full px-8">
+                                {{ __('Go!') }}
+                            </x-jet-button>
                         </div>
                     </div>
-                    <div class="block relative">
-                        <x-jet-button class="rounded-l-none h-full px-8">
-                            {{ __('Go!') }}
-                        </x-jet-button>
-                    </div>
-                </div>
-            </form>
-        </div>
+                </form>
+            </div>
+        @endif
 
         <!-- Balances -->
         <div class="py-4">

--- a/tests/Feature/Jetstream/PasswordResetTest.php
+++ b/tests/Feature/Jetstream/PasswordResetTest.php
@@ -23,7 +23,7 @@ class PasswordResetTest extends TestCase
     public function testResetPasswordLinkScreenCanBeRendered()
     {
         if (! Features::enabled(Features::updatePasswords())) {
-            return $this->markTestSkipped('Password updates are not enabled.');
+            static::markTestSkipped('Password updates are not enabled.');
         }
 
         $response = $this->get('/forgot-password');
@@ -34,7 +34,7 @@ class PasswordResetTest extends TestCase
     public function testResetPasswordLinkCanBeRequested()
     {
         if (! Features::enabled(Features::updatePasswords())) {
-            return $this->markTestSkipped('Password updates are not enabled.');
+            static::markTestSkipped('Password updates are not enabled.');
         }
 
         Notification::fake();
@@ -51,7 +51,7 @@ class PasswordResetTest extends TestCase
     public function testResetPasswordScreenCanBeRendered()
     {
         if (! Features::enabled(Features::updatePasswords())) {
-            return $this->markTestSkipped('Password updates are not enabled.');
+            static::markTestSkipped('Password updates are not enabled.');
         }
 
         Notification::fake();
@@ -74,7 +74,7 @@ class PasswordResetTest extends TestCase
     public function testPasswordCanBeResetWithValidToken()
     {
         if (! Features::enabled(Features::updatePasswords())) {
-            return $this->markTestSkipped('Password updates are not enabled.');
+            static::markTestSkipped('Password updates are not enabled.');
         }
 
         Notification::fake();


### PR DESCRIPTION
* Fix: addressed selected date and filter option bugs for transparency page
* Fix: lazy loading now has a callback, so we can log violations in all environments without interrupting the user experience.
* Chore: update phpdoc types for arrays where feasible
* Chore: Some line length violation fixes
* Chore: replace switch statements with match statements where feasible
* Chore: don't use fully qualified names for instances created from container
* Chore: fixing other code inspection findings