### PR TITLE
fix(transparency): restore ordering & adjust reconcile job time, refactor: use lambdas in reconcile traits for comparison

### DIFF
--- a/app/Concerns/Reconcile/Billing/ReconcilesBalance.php
+++ b/app/Concerns/Reconcile/Billing/ReconcilesBalance.php
@@ -25,8 +25,7 @@ trait ReconcilesBalance
      */
     protected function diffCallbackForCreateDelete(): Closure
     {
-        return fn (Balance $first, Balance $second) =>
-            $first->date->format(AllowedDateFormat::YM) <=> $second->date->format(AllowedDateFormat::YM);
+        return fn (Balance $first, Balance $second) => $first->date->format(AllowedDateFormat::YM) <=> $second->date->format(AllowedDateFormat::YM);
     }
 
     /**
@@ -36,8 +35,7 @@ trait ReconcilesBalance
      */
     protected function diffCallbackForUpdate(): Closure
     {
-        return fn (Balance $first, Balance $second) =>
-            [$first->date->format(AllowedDateFormat::YMD), $first->usage, $first->balance]
+        return fn (Balance $first, Balance $second) => [$first->date->format(AllowedDateFormat::YMD), $first->usage, $first->balance]
             <=> [$second->date->format(AllowedDateFormat::YMD), $second->usage, $second->balance];
     }
 

--- a/app/Concerns/Reconcile/Billing/ReconcilesBalance.php
+++ b/app/Concerns/Reconcile/Billing/ReconcilesBalance.php
@@ -7,6 +7,7 @@ namespace App\Concerns\Reconcile\Billing;
 use App\Concerns\Reconcile\ReconcilesRepositories;
 use App\Enums\Filter\AllowedDateFormat;
 use App\Models\Billing\Balance;
+use Closure;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 
@@ -18,31 +19,26 @@ trait ReconcilesBalance
     use ReconcilesRepositories;
 
     /**
-     * Perform set operation for create and delete steps.
+     * Callback for create and delete set operation item comparison.
      *
-     * @param Collection $a
-     * @param Collection $b
-     * @return Collection
+     * @return Closure
      */
-    protected function diffForCreateDelete(Collection $a, Collection $b): Collection
+    protected function diffCallbackForCreateDelete(): Closure
     {
-        return $a->diffUsing($b, function (Balance $first, Balance $second) {
-            return $first->date->format(AllowedDateFormat::WITH_MONTH) <=> $second->date->format(AllowedDateFormat::WITH_MONTH);
-        });
+        return fn (Balance $first, Balance $second) =>
+            $first->date->format(AllowedDateFormat::YM) <=> $second->date->format(AllowedDateFormat::YM);
     }
 
     /**
-     * Perform set operation for update step.
+     * Callback for update set operation item comparison.
      *
-     * @param Collection $a
-     * @param Collection $b
-     * @return Collection
+     * @return Closure
      */
-    protected function diffForUpdate(Collection $a, Collection $b): Collection
+    protected function diffCallbackForUpdate(): Closure
     {
-        return $a->diffUsing($b, function (Balance $first, Balance $second) {
-            return [$first->date->format(AllowedDateFormat::WITH_DAY), $first->frequency, $first->usage, $first->balance] <=> [$second->date->format(AllowedDateFormat::WITH_DAY), $second->frequency, $second->usage, $second->balance];
-        });
+        return fn (Balance $first, Balance $second) =>
+            [$first->date->format(AllowedDateFormat::YMD), $first->usage, $first->balance]
+            <=> [$second->date->format(AllowedDateFormat::YMD), $second->usage, $second->balance];
     }
 
     /**
@@ -54,10 +50,10 @@ trait ReconcilesBalance
      */
     protected function resolveUpdatedModel(Collection $sourceModels, Model $destinationModel): ?Model
     {
-        $formattedDestinationDate = $destinationModel->getAttribute('date')->format(AllowedDateFormat::WITH_MONTH);
+        $formattedDestinationDate = $destinationModel->getAttribute('date')->format(AllowedDateFormat::YM);
 
         $filteredSourceModels = $sourceModels->filter(function (Balance $balance) use ($formattedDestinationDate) {
-            return $balance->date->format(AllowedDateFormat::WITH_MONTH) === $formattedDestinationDate;
+            return $balance->date->format(AllowedDateFormat::YM) === $formattedDestinationDate;
         });
 
         return $filteredSourceModels->first();

--- a/app/Concerns/Reconcile/Billing/ReconcilesTransaction.php
+++ b/app/Concerns/Reconcile/Billing/ReconcilesTransaction.php
@@ -7,7 +7,7 @@ namespace App\Concerns\Reconcile\Billing;
 use App\Concerns\Reconcile\ReconcilesRepositories;
 use App\Enums\Filter\AllowedDateFormat;
 use App\Models\Billing\Transaction;
-use Illuminate\Support\Collection;
+use Closure;
 
 /**
  * Trait ReconcilesTransaction.
@@ -17,16 +17,14 @@ trait ReconcilesTransaction
     use ReconcilesRepositories;
 
     /**
-     * Perform set operation for create and delete steps.
+     * Callback for create and delete set operation item comparison.
      *
-     * @param Collection $a
-     * @param Collection $b
-     * @return Collection
+     * @return Closure
      */
-    protected function diffForCreateDelete(Collection $a, Collection $b): Collection
+    protected function diffCallbackForCreateDelete(): Closure
     {
-        return $a->diffUsing($b, function (Transaction $first, Transaction $second) {
-            return [$first->external_id, $first->date->format(AllowedDateFormat::WITH_DAY), $first->amount] <=> [$second->external_id, $second->date->format(AllowedDateFormat::WITH_DAY), $second->amount];
-        });
+        return fn (Transaction $first, Transaction $second) =>
+            [$first->external_id, $first->date->format(AllowedDateFormat::YMD), $first->amount]
+            <=> [$second->external_id, $second->date->format(AllowedDateFormat::YMD), $second->amount];
     }
 }

--- a/app/Concerns/Reconcile/Billing/ReconcilesTransaction.php
+++ b/app/Concerns/Reconcile/Billing/ReconcilesTransaction.php
@@ -23,8 +23,7 @@ trait ReconcilesTransaction
      */
     protected function diffCallbackForCreateDelete(): Closure
     {
-        return fn (Transaction $first, Transaction $second) =>
-            [$first->external_id, $first->date->format(AllowedDateFormat::YMD), $first->amount]
+        return fn (Transaction $first, Transaction $second) => [$first->external_id, $first->date->format(AllowedDateFormat::YMD), $first->amount]
             <=> [$second->external_id, $second->date->format(AllowedDateFormat::YMD), $second->amount];
     }
 }

--- a/app/Concerns/Reconcile/ReconcilesRepositories.php
+++ b/app/Concerns/Reconcile/ReconcilesRepositories.php
@@ -6,6 +6,7 @@ namespace App\Concerns\Reconcile;
 
 use App\Contracts\Repositories\Repository;
 use App\Models\BaseModel;
+use Closure;
 use Exception;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
@@ -203,15 +204,13 @@ trait ReconcilesRepositories
     }
 
     /**
-     * Perform set operation for create and delete steps.
+     * Callback for create and delete set operation item comparison.
      *
-     * @param Collection $a
-     * @param Collection $b
-     * @return Collection
+     * @return Closure
      */
-    protected function diffForCreateDelete(Collection $a, Collection $b): Collection
+    protected function diffCallbackForCreateDelete(): Closure
     {
-        return Collection::make();
+        return fn () => 0;
     }
 
     /**
@@ -227,7 +226,7 @@ trait ReconcilesRepositories
         Collection $sourceModels,
         Collection $destinationModels
     ) {
-        $createModels = $this->diffForCreateDelete($sourceModels, $destinationModels);
+        $createModels = $sourceModels->diffUsing($destinationModels, $this->diffCallbackForCreateDelete());
 
         foreach ($createModels as $createModel) {
             $createResult = $destination->save($createModel);
@@ -254,7 +253,7 @@ trait ReconcilesRepositories
         Collection $sourceModels,
         Collection $destinationModels
     ) {
-        $deleteModels = $this->diffForCreateDelete($destinationModels, $sourceModels);
+        $deleteModels = $destinationModels->diffUsing($sourceModels, $this->diffCallbackForCreateDelete());
 
         foreach ($deleteModels as $deleteModel) {
             $deleteResult = $destination->delete($deleteModel);
@@ -269,15 +268,13 @@ trait ReconcilesRepositories
     }
 
     /**
-     * Perform set operation for update step.
+     * Callback for update set operation item comparison.
      *
-     * @param Collection $a
-     * @param Collection $b
-     * @return Collection
+     * @return Closure
      */
-    protected function diffForUpdate(Collection $a, Collection $b): Collection
+    protected function diffCallbackForUpdate(): Closure
     {
-        return Collection::make();
+        return fn () => 0;
     }
 
     /**
@@ -305,7 +302,7 @@ trait ReconcilesRepositories
         Collection $sourceModels,
         Collection $destinationModels
     ) {
-        $updatedModels = $this->diffForUpdate($destinationModels, $sourceModels);
+        $updatedModels = $destinationModels->diffUsing($sourceModels, $this->diffCallbackForUpdate());
 
         foreach ($updatedModels as $updatedModel) {
             $sourceModel = $this->resolveUpdatedModel($sourceModels, $updatedModel);

--- a/app/Concerns/Reconcile/ReconcilesVideo.php
+++ b/app/Concerns/Reconcile/ReconcilesVideo.php
@@ -33,8 +33,7 @@ trait ReconcilesVideo
      */
     protected function diffCallbackForUpdate(): Closure
     {
-        return fn (Video $first, Video $second) =>
-            [$first->basename, $first->path, $first->size] <=> [$second->basename, $second->path, $second->size];
+        return fn (Video $first, Video $second) => [$first->basename, $first->path, $first->size] <=> [$second->basename, $second->path, $second->size];
     }
 
     /**

--- a/app/Concerns/Reconcile/ReconcilesVideo.php
+++ b/app/Concerns/Reconcile/ReconcilesVideo.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Concerns\Reconcile;
 
 use App\Models\Video;
+use Closure;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 
@@ -16,31 +17,24 @@ trait ReconcilesVideo
     use ReconcilesRepositories;
 
     /**
-     * Perform set operation for create and delete steps.
+     * Callback for create and delete set operation item comparison.
      *
-     * @param Collection $a
-     * @param Collection $b
-     * @return Collection
+     * @return Closure
      */
-    protected function diffForCreateDelete(Collection $a, Collection $b): Collection
+    protected function diffCallbackForCreateDelete(): Closure
     {
-        return $a->diffUsing($b, function (Video $first, Video $second) {
-            return $first->basename <=> $second->basename;
-        });
+        return fn (Video $first, Video $second) => $first->basename <=> $second->basename;
     }
 
     /**
-     * Perform set operation for update step.
+     * Callback for update set operation item comparison.
      *
-     * @param Collection $a
-     * @param Collection $b
-     * @return Collection
+     * @return Closure
      */
-    protected function diffForUpdate(Collection $a, Collection $b): Collection
+    protected function diffCallbackForUpdate(): Closure
     {
-        return $a->diffUsing($b, function (Video $first, Video $second) {
-            return [$first->basename, $first->path, $first->size] <=> [$second->basename, $second->path, $second->size];
-        });
+        return fn (Video $first, Video $second) =>
+            [$first->basename, $first->path, $first->size] <=> [$second->basename, $second->path, $second->size];
     }
 
     /**

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -39,11 +39,11 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        $schedule->command(BalanceReconcileCommand::class, [Service::DIGITALOCEAN()->key])->daily();
+        $schedule->command(BalanceReconcileCommand::class, [Service::DIGITALOCEAN()->key])->dailyAt('07:00');
         $schedule->command(DatabaseDumpCommand::class)->daily();
         $schedule->command(PruneCommand::class)->daily();
         $schedule->command(SnapshotCommand::class)->everyFiveMinutes();
-        $schedule->command(TransactionReconcileCommand::class, [Service::DIGITALOCEAN()->key])->daily();
+        $schedule->command(TransactionReconcileCommand::class, [Service::DIGITALOCEAN()->key])->dailyAt('07:00');
         $schedule->command(VideoReconcileCommand::class)->hourly();
     }
 

--- a/app/Enums/Filter/AllowedDateFormat.php
+++ b/app/Enums/Filter/AllowedDateFormat.php
@@ -11,11 +11,11 @@ use BenSampo\Enum\Enum;
  */
 final class AllowedDateFormat extends Enum
 {
-    public const WITH_MICRO = 'Y-m-d\TH:i:s.u';
-    public const WITH_SEC = 'Y-m-d\TH:i:s';
-    public const WITH_MIN = 'Y-m-d\TH:i';
-    public const WITH_HOUR = 'Y-m-d\TH';
-    public const WITH_DAY = 'Y-m-d';
-    public const WITH_MONTH = 'Y-m';
-    public const WITH_YEAR = 'Y';
+    public const YMDHISU = 'Y-m-d\TH:i:s.u';
+    public const YMDHIS = 'Y-m-d\TH:i:s';
+    public const YMDHI = 'Y-m-d\TH:i';
+    public const YMDH = 'Y-m-d\TH';
+    public const YMD = 'Y-m-d';
+    public const YM = 'Y-m';
+    public const Y = 'Y';
 }

--- a/app/Http/Requests/TransparencyRequest.php
+++ b/app/Http/Requests/TransparencyRequest.php
@@ -76,7 +76,7 @@ class TransparencyRequest extends FormRequest
         $validDates = $balanceDates->concat($transactionDates);
 
         $validDates = $validDates->unique(function (Carbon $date) {
-            return $date->format(AllowedDateFormat::WITH_MONTH);
+            return $date->format(AllowedDateFormat::YM);
         });
 
         return $validDates->sortDesc();
@@ -105,7 +105,7 @@ class TransparencyRequest extends FormRequest
             return $this->getValidDates()->first();
         }
 
-        return Carbon::instance(DateTime::createFromFormat('!'.AllowedDateFormat::WITH_MONTH, $validDate));
+        return Carbon::instance(DateTime::createFromFormat('!'.AllowedDateFormat::YM, $validDate));
     }
 
     /**
@@ -123,6 +123,7 @@ class TransparencyRequest extends FormRequest
 
         return Balance::whereMonth('date', strval($date->month))
             ->whereYear('date', strval($date->year))
+            ->orderBy('usage', 'desc')
             ->get();
     }
 
@@ -141,6 +142,7 @@ class TransparencyRequest extends FormRequest
 
         return Transaction::whereMonth('date', strval($date->month))
             ->whereYear('date', strval($date->year))
+            ->orderBy('date', 'desc')
             ->get();
     }
 }

--- a/app/JsonApi/Filter/DateFilter.php
+++ b/app/JsonApi/Filter/DateFilter.php
@@ -25,7 +25,7 @@ abstract class DateFilter extends Filter
                 foreach (AllowedDateFormat::getValues() as $allowedDateFormat) {
                     $date = DateTime::createFromFormat('!'.$allowedDateFormat, $filterValue);
                     if ($date && $date->format($allowedDateFormat) == $filterValue) {
-                        return $date->format(AllowedDateFormat::WITH_MICRO);
+                        return $date->format(AllowedDateFormat::YMDHISU);
                     }
                 }
 

--- a/app/Models/Billing/Balance.php
+++ b/app/Models/Billing/Balance.php
@@ -85,7 +85,7 @@ class Balance extends BaseModel
     {
         return Str::of($this->service->description)
             ->append(' ')
-            ->append($this->date->format(AllowedDateFormat::WITH_MONTH))
+            ->append($this->date->format(AllowedDateFormat::YM))
             ->__toString();
     }
 }

--- a/app/Models/Billing/Transaction.php
+++ b/app/Models/Billing/Transaction.php
@@ -83,7 +83,7 @@ class Transaction extends BaseModel
     {
         return Str::of($this->service->description)
             ->append(' ')
-            ->append($this->date->format(AllowedDateFormat::WITH_DAY))
+            ->append($this->date->format(AllowedDateFormat::YMD))
             ->__toString();
     }
 }

--- a/app/Repositories/Service/Billing/DigitalOceanBalanceRepository.php
+++ b/app/Repositories/Service/Billing/DigitalOceanBalanceRepository.php
@@ -53,7 +53,7 @@ class DigitalOceanBalanceRepository implements Repository
             $balanceJson = json_decode($response->getBody()->getContents(), true);
 
             $balance = Balance::make([
-                'date' => Carbon::now()->firstOfMonth()->format(AllowedDateFormat::WITH_DAY),
+                'date' => Carbon::now()->firstOfMonth()->format(AllowedDateFormat::YMD),
                 'service' => Service::DIGITALOCEAN,
                 'frequency' => Frequency::MONTHLY,
                 'usage' => Arr::get($balanceJson, 'month_to_date_usage'),

--- a/app/Repositories/Service/Billing/DigitalOceanTransactionRepository.php
+++ b/app/Repositories/Service/Billing/DigitalOceanTransactionRepository.php
@@ -62,7 +62,7 @@ class DigitalOceanTransactionRepository implements Repository
                 $billingHistory = Arr::get($billingHistoryJson, 'billing_history', []);
                 foreach ($billingHistory as $sourceTransaction) {
                     $sourceTransactions[] = Transaction::make([
-                        'date' => DateTime::createFromFormat('!'.DateTimeInterface::RFC3339, Arr::get($sourceTransaction, 'date'))->format(AllowedDateFormat::WITH_DAY),
+                        'date' => DateTime::createFromFormat('!'.DateTimeInterface::RFC3339, Arr::get($sourceTransaction, 'date'))->format(AllowedDateFormat::YMD),
                         'service' => Service::DIGITALOCEAN,
                         'description' => Arr::get($sourceTransaction, 'description'),
                         'amount' => Arr::get($sourceTransaction, 'amount'),

--- a/app/Rules/Billing/TransparencyDateRule.php
+++ b/app/Rules/Billing/TransparencyDateRule.php
@@ -47,7 +47,7 @@ class TransparencyDateRule implements Rule
     public function passes($attribute, $value): bool
     {
         return $this->validDates->contains(function (Carbon $validDate) use ($value) {
-            return $validDate->format(AllowedDateFormat::WITH_MONTH) === $value;
+            return $validDate->format(AllowedDateFormat::YM) === $value;
         });
     }
 

--- a/tests/Feature/Console/Billing/BalanceReconcileTest.php
+++ b/tests/Feature/Console/Billing/BalanceReconcileTest.php
@@ -81,7 +81,7 @@ class BalanceReconcileTest extends TestCase
         $balances = Balance::factory()
             ->count($createdBalanceCount)
             ->make([
-                'date' => Carbon::now()->format(AllowedDateFormat::WITH_DAY),
+                'date' => Carbon::now()->format(AllowedDateFormat::YMD),
                 'service' => Service::DIGITALOCEAN,
             ]);
 
@@ -108,7 +108,7 @@ class BalanceReconcileTest extends TestCase
         Balance::factory()
             ->count($deletedBalanceCount)
             ->create([
-                'date' => Carbon::now()->format(AllowedDateFormat::WITH_DAY),
+                'date' => Carbon::now()->format(AllowedDateFormat::YMD),
                 'service' => Service::DIGITALOCEAN,
             ]);
 
@@ -132,13 +132,13 @@ class BalanceReconcileTest extends TestCase
     {
         Balance::factory()
             ->create([
-                'date' => Carbon::now()->format(AllowedDateFormat::WITH_DAY),
+                'date' => Carbon::now()->format(AllowedDateFormat::YMD),
                 'service' => Service::DIGITALOCEAN,
             ]);
 
         $sourceBalances = Balance::factory()
             ->make([
-                'date' => Carbon::now()->format(AllowedDateFormat::WITH_DAY),
+                'date' => Carbon::now()->format(AllowedDateFormat::YMD),
                 'service' => Service::DIGITALOCEAN,
             ]);
 

--- a/tests/Feature/Http/TransparencyTest.php
+++ b/tests/Feature/Http/TransparencyTest.php
@@ -69,7 +69,7 @@ class TransparencyTest extends TestCase
     {
         Balance::factory()->create();
 
-        $date = Carbon::now()->subMonths($this->faker->randomDigitNotNull)->format(AllowedDateFormat::WITH_MONTH);
+        $date = Carbon::now()->subMonths($this->faker->randomDigitNotNull)->format(AllowedDateFormat::YM);
 
         $response = $this->get(route('transparency.show', ['date' => $date]));
 

--- a/tests/Unit/JsonApi/Filter/DateFilterTest.php
+++ b/tests/Unit/JsonApi/Filter/DateFilterTest.php
@@ -129,6 +129,6 @@ class DateFilterTest extends TestCase
 
         $filterValues = $filter->getFilterValues($parser->getConditions($filterField)[0]);
 
-        static::assertEquals(DateTime::createFromFormat('!'.$dateFormat, $dateFilter)->format(AllowedDateFormat::WITH_MICRO), $filterValues[0]);
+        static::assertEquals(DateTime::createFromFormat('!'.$dateFormat, $dateFilter)->format(AllowedDateFormat::YMDHISU), $filterValues[0]);
     }
 }

--- a/tests/Unit/Rules/Billing/TransparencyDateTest.php
+++ b/tests/Unit/Rules/Billing/TransparencyDateTest.php
@@ -73,7 +73,7 @@ class TransparencyDateTest extends TestCase
 
         $rule = new TransparencyDateRule($validDates);
 
-        $formattedDate = Carbon::now()->subMonths($this->faker->randomDigitNotNull)->format(AllowedDateFormat::WITH_MONTH);
+        $formattedDate = Carbon::now()->subMonths($this->faker->randomDigitNotNull)->format(AllowedDateFormat::YM);
 
         static::assertFalse($rule->passes($this->faker->word(), $formattedDate));
     }
@@ -89,7 +89,7 @@ class TransparencyDateTest extends TestCase
 
         $rule = new TransparencyDateRule($validDates);
 
-        $formattedDate = Carbon::now()->format(AllowedDateFormat::WITH_MONTH);
+        $formattedDate = Carbon::now()->format(AllowedDateFormat::YM);
 
         static::assertTrue($rule->passes($this->faker->word(), $formattedDate));
     }


### PR DESCRIPTION
* Restoring the ordering of objects on the transparency page that was accidentally removed in the previous PR.
* Use arrow functions to define closures for set reconciliation operations rather  than performing the operation in the secondary trait.
* Adjust the time of day that we reconcile against DO so that the data isn't stale for almost 20 hours every day.
* Refactoring date format names.