### PR TITLE
fix(api): allow sorting on searches

### DIFF
--- a/app/Http/Resources/SearchableCollection.php
+++ b/app/Http/Resources/SearchableCollection.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Concerns\Http\Resources;
+namespace App\Http\Resources;
 
 use App\Enums\Http\Api\PaginationStrategy;
 use App\Http\Api\QueryParser;
@@ -17,9 +17,9 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
 
 /**
- * Trait PerformsResourceCollectionSearch.
+ * Class SearchableCollection.
  */
-trait PerformsResourceCollectionSearch
+abstract class SearchableCollection extends BaseCollection
 {
     /**
      * Perform query to prepare models for resource collection.
@@ -96,6 +96,13 @@ trait PerformsResourceCollectionSearch
             $builder->filter($filterBuilder);
         } catch (QueryBuilderException) {
             // There doesn't appear to be a way to check if any filters have been set in the filter builder
+        }
+
+        // apply sorts
+        foreach ($parser->getSorts() as $field => $isAsc) {
+            if (in_array(Str::lower($field), static::allowedSortFields())) {
+                $builder = $builder->sort(Str::lower($field), $isAsc ? 'asc' : 'desc');
+            }
         }
 
         // limit page size

--- a/app/Http/Resources/Wiki/Collection/AnimeCollection.php
+++ b/app/Http/Resources/Wiki/Collection/AnimeCollection.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 
 namespace App\Http\Resources\Wiki\Collection;
 
-use App\Concerns\Http\Resources\PerformsResourceCollectionSearch;
 use App\Http\Api\Filter\Base\CreatedAtFilter;
 use App\Http\Api\Filter\Base\DeletedAtFilter;
 use App\Http\Api\Filter\Base\TrashedFilter;
 use App\Http\Api\Filter\Base\UpdatedAtFilter;
 use App\Http\Api\Filter\Wiki\Anime\AnimeSeasonFilter;
 use App\Http\Api\Filter\Wiki\Anime\AnimeYearFilter;
-use App\Http\Resources\BaseCollection;
+use App\Http\Resources\SearchableCollection;
 use App\Http\Resources\Wiki\Resource\AnimeResource;
 use App\Models\Wiki\Anime;
 use Illuminate\Http\Request;
@@ -19,10 +18,8 @@ use Illuminate\Http\Request;
 /**
  * Class AnimeCollection.
  */
-class AnimeCollection extends BaseCollection
+class AnimeCollection extends SearchableCollection
 {
-    use PerformsResourceCollectionSearch;
-
     /**
      * The "data" wrapper that should be applied.
      *

--- a/app/Http/Resources/Wiki/Collection/ArtistCollection.php
+++ b/app/Http/Resources/Wiki/Collection/ArtistCollection.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace App\Http\Resources\Wiki\Collection;
 
-use App\Concerns\Http\Resources\PerformsResourceCollectionSearch;
 use App\Http\Api\Filter\Base\CreatedAtFilter;
 use App\Http\Api\Filter\Base\DeletedAtFilter;
 use App\Http\Api\Filter\Base\TrashedFilter;
 use App\Http\Api\Filter\Base\UpdatedAtFilter;
-use App\Http\Resources\BaseCollection;
+use App\Http\Resources\SearchableCollection;
 use App\Http\Resources\Wiki\Resource\ArtistResource;
 use App\Models\Wiki\Artist;
 use Illuminate\Http\Request;
@@ -17,10 +16,8 @@ use Illuminate\Http\Request;
 /**
  * Class ArtistCollection.
  */
-class ArtistCollection extends BaseCollection
+class ArtistCollection extends SearchableCollection
 {
-    use PerformsResourceCollectionSearch;
-
     /**
      * The "data" wrapper that should be applied.
      *

--- a/app/Http/Resources/Wiki/Collection/EntryCollection.php
+++ b/app/Http/Resources/Wiki/Collection/EntryCollection.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Http\Resources\Wiki\Collection;
 
-use App\Concerns\Http\Resources\PerformsResourceCollectionSearch;
 use App\Http\Api\Filter\Base\CreatedAtFilter;
 use App\Http\Api\Filter\Base\DeletedAtFilter;
 use App\Http\Api\Filter\Base\TrashedFilter;
@@ -12,7 +11,7 @@ use App\Http\Api\Filter\Base\UpdatedAtFilter;
 use App\Http\Api\Filter\Wiki\Entry\EntryNsfwFilter;
 use App\Http\Api\Filter\Wiki\Entry\EntrySpoilerFilter;
 use App\Http\Api\Filter\Wiki\Entry\EntryVersionFilter;
-use App\Http\Resources\BaseCollection;
+use App\Http\Resources\SearchableCollection;
 use App\Http\Resources\Wiki\Resource\EntryResource;
 use App\Models\Wiki\Entry;
 use Illuminate\Http\Request;
@@ -20,10 +19,8 @@ use Illuminate\Http\Request;
 /**
  * Class EntryCollection.
  */
-class EntryCollection extends BaseCollection
+class EntryCollection extends SearchableCollection
 {
-    use PerformsResourceCollectionSearch;
-
     /**
      * The "data" wrapper that should be applied.
      *

--- a/app/Http/Resources/Wiki/Collection/SeriesCollection.php
+++ b/app/Http/Resources/Wiki/Collection/SeriesCollection.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace App\Http\Resources\Wiki\Collection;
 
-use App\Concerns\Http\Resources\PerformsResourceCollectionSearch;
 use App\Http\Api\Filter\Base\CreatedAtFilter;
 use App\Http\Api\Filter\Base\DeletedAtFilter;
 use App\Http\Api\Filter\Base\TrashedFilter;
 use App\Http\Api\Filter\Base\UpdatedAtFilter;
-use App\Http\Resources\BaseCollection;
+use App\Http\Resources\SearchableCollection;
 use App\Http\Resources\Wiki\Resource\SeriesResource;
 use App\Models\Wiki\Series;
 use Illuminate\Http\Request;
@@ -17,10 +16,8 @@ use Illuminate\Http\Request;
 /**
  * Class SeriesCollection.
  */
-class SeriesCollection extends BaseCollection
+class SeriesCollection extends SearchableCollection
 {
-    use PerformsResourceCollectionSearch;
-
     /**
      * The "data" wrapper that should be applied.
      *

--- a/app/Http/Resources/Wiki/Collection/SongCollection.php
+++ b/app/Http/Resources/Wiki/Collection/SongCollection.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace App\Http\Resources\Wiki\Collection;
 
-use App\Concerns\Http\Resources\PerformsResourceCollectionSearch;
 use App\Http\Api\Filter\Base\CreatedAtFilter;
 use App\Http\Api\Filter\Base\DeletedAtFilter;
 use App\Http\Api\Filter\Base\TrashedFilter;
 use App\Http\Api\Filter\Base\UpdatedAtFilter;
-use App\Http\Resources\BaseCollection;
+use App\Http\Resources\SearchableCollection;
 use App\Http\Resources\Wiki\Resource\SongResource;
 use App\Models\Wiki\Song;
 use Illuminate\Http\Request;
@@ -17,10 +16,8 @@ use Illuminate\Http\Request;
 /**
  * Class SongCollection.
  */
-class SongCollection extends BaseCollection
+class SongCollection extends SearchableCollection
 {
-    use PerformsResourceCollectionSearch;
-
     /**
      * The "data" wrapper that should be applied.
      *

--- a/app/Http/Resources/Wiki/Collection/SynonymCollection.php
+++ b/app/Http/Resources/Wiki/Collection/SynonymCollection.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace App\Http\Resources\Wiki\Collection;
 
-use App\Concerns\Http\Resources\PerformsResourceCollectionSearch;
 use App\Http\Api\Filter\Base\CreatedAtFilter;
 use App\Http\Api\Filter\Base\DeletedAtFilter;
 use App\Http\Api\Filter\Base\TrashedFilter;
 use App\Http\Api\Filter\Base\UpdatedAtFilter;
-use App\Http\Resources\BaseCollection;
+use App\Http\Resources\SearchableCollection;
 use App\Http\Resources\Wiki\Resource\SynonymResource;
 use App\Models\Wiki\Synonym;
 use Illuminate\Http\Request;
@@ -17,10 +16,8 @@ use Illuminate\Http\Request;
 /**
  * Class SynonymCollection.
  */
-class SynonymCollection extends BaseCollection
+class SynonymCollection extends SearchableCollection
 {
-    use PerformsResourceCollectionSearch;
-
     /**
      * The "data" wrapper that should be applied.
      *

--- a/app/Http/Resources/Wiki/Collection/ThemeCollection.php
+++ b/app/Http/Resources/Wiki/Collection/ThemeCollection.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Http\Resources\Wiki\Collection;
 
-use App\Concerns\Http\Resources\PerformsResourceCollectionSearch;
 use App\Http\Api\Filter\Base\CreatedAtFilter;
 use App\Http\Api\Filter\Base\DeletedAtFilter;
 use App\Http\Api\Filter\Base\TrashedFilter;
@@ -12,7 +11,7 @@ use App\Http\Api\Filter\Base\UpdatedAtFilter;
 use App\Http\Api\Filter\Wiki\Theme\ThemeGroupFilter;
 use App\Http\Api\Filter\Wiki\Theme\ThemeSequenceFilter;
 use App\Http\Api\Filter\Wiki\Theme\ThemeTypeFilter;
-use App\Http\Resources\BaseCollection;
+use App\Http\Resources\SearchableCollection;
 use App\Http\Resources\Wiki\Resource\ThemeResource;
 use App\Models\Wiki\Theme;
 use Illuminate\Http\Request;
@@ -20,10 +19,8 @@ use Illuminate\Http\Request;
 /**
  * Class ThemeCollection.
  */
-class ThemeCollection extends BaseCollection
+class ThemeCollection extends SearchableCollection
 {
-    use PerformsResourceCollectionSearch;
-
     /**
      * The "data" wrapper that should be applied.
      *

--- a/app/Http/Resources/Wiki/Collection/VideoCollection.php
+++ b/app/Http/Resources/Wiki/Collection/VideoCollection.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Http\Resources\Wiki\Collection;
 
-use App\Concerns\Http\Resources\PerformsResourceCollectionSearch;
 use App\Http\Api\Filter\Base\CreatedAtFilter;
 use App\Http\Api\Filter\Base\DeletedAtFilter;
 use App\Http\Api\Filter\Base\TrashedFilter;
@@ -16,7 +15,7 @@ use App\Http\Api\Filter\Wiki\Video\VideoResolutionFilter;
 use App\Http\Api\Filter\Wiki\Video\VideoSourceFilter;
 use App\Http\Api\Filter\Wiki\Video\VideoSubbedFilter;
 use App\Http\Api\Filter\Wiki\Video\VideoUncenFilter;
-use App\Http\Resources\BaseCollection;
+use App\Http\Resources\SearchableCollection;
 use App\Http\Resources\Wiki\Resource\VideoResource;
 use App\Models\Wiki\Video;
 use Illuminate\Http\Request;
@@ -24,10 +23,8 @@ use Illuminate\Http\Request;
 /**
  * Class VideoCollection.
  */
-class VideoCollection extends BaseCollection
+class VideoCollection extends SearchableCollection
 {
-    use PerformsResourceCollectionSearch;
-
     /**
      * The "data" wrapper that should be applied.
      *


### PR DESCRIPTION
Previously, we didn't support the `sort` query parameter for searches. This change adds that support. This shouldn't affect what matches are returned, but allows the user to order those matches if they want.

I refactored the trait into an abstract class that extends BaseCollection. The trait itself is only used by these subtypes and access static properties, so this better abides by the coding standards and is slightly more friendly in static analysis contexts.