### PR TITLE
fix(console): we have to assume that the video disk uses the s3 driver

### DIFF
--- a/app/Repositories/Service/DigitalOcean/VideoRepository.php
+++ b/app/Repositories/Service/DigitalOcean/VideoRepository.php
@@ -9,6 +9,7 @@ use App\Enums\Models\Wiki\VideoOverlap;
 use App\Models\Wiki\Video;
 use GuzzleHttp\Psr7\MimeType;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Storage;
@@ -27,7 +28,13 @@ class VideoRepository implements Repository
     {
         // Get metadata for all objects in storage
         $fs = Storage::disk('videos');
-        $fsVideos = collect($fs->files('', true));
+
+        // We are assuming an s3 filesystem is used to host video
+        if (! $fs instanceof FilesystemAdapter) {
+            return Collection::make();
+        }
+
+        $fsVideos = collect($fs->listContents('', true));
 
         // Filter all objects for WebM metadata
         // We don't want to filter on the remote filesystem for performance concerns


### PR DESCRIPTION
Addressing staging exception. Video reconciliation was broken. In fixing a psalm finding, a method call was replaced for discoverability, but did not return the data needed for reconciliation. For this process to work as expected, we need to make the assumption that the video disk uses the s3 driver.