### PR TITLE
chore: use http facade instead of guzzle client

### DIFF
--- a/app/Actions/Jetstream/RemoveTeamMember.php
+++ b/app/Actions/Jetstream/RemoveTeamMember.php
@@ -47,8 +47,10 @@ class RemoveTeamMember implements RemovesTeamMembers
      */
     protected function authorize(mixed $user, mixed $team, mixed $teamMember)
     {
-        if (! Gate::forUser($user)->check('removeTeamMember', $team) &&
-            $user->id !== $teamMember->id) {
+        if (
+            ! Gate::forUser($user)->check('removeTeamMember', $team)
+            && $user->id !== $teamMember->id
+        ) {
             throw new AuthorizationException();
         }
     }

--- a/app/Http/Api/Filter/Filter.php
+++ b/app/Http/Api/Filter/Filter.php
@@ -122,12 +122,8 @@ abstract class Filter
 
         $filterValues = $this->getFilterValues($condition);
 
-        // Don't apply filter if there is not a subset of valid values specified
-        if (empty($filterValues) || $this->isAllFilterValues($filterValues)) {
-            return false;
-        }
-
-        return true;
+        // Apply filter if we have a subset of valid values specified
+        return ! empty($filterValues) && ! $this->isAllFilterValues($filterValues);
     }
 
     /**

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -24,20 +24,13 @@ use Illuminate\Validation\ValidationException;
 
 /**
  * Class RegisterController.
+ *
+ * This controller handles the registration of new users as well as their
+ * validation and creation. By default this controller uses a trait to
+ * provide this functionality without requiring any additional code.
  */
 class RegisterController extends Controller
 {
-    /*
-    |--------------------------------------------------------------------------
-    | Register Controller
-    |--------------------------------------------------------------------------
-    |
-    | This controller handles the registration of new users as well as their
-    | validation and creation. By default this controller uses a trait to
-    | provide this functionality without requiring any additional code.
-    |
-    */
-
     use PasswordValidationRules;
     use RegistersUsers;
 

--- a/app/Models/Auth/User.php
+++ b/app/Models/Auth/User.php
@@ -177,12 +177,6 @@ class User extends Authenticatable implements MustVerifyEmail, Nameable
      */
     public function hasCurrentTeamPermission(string $permission): bool
     {
-        $currentTeam = $this->currentTeam;
-
-        if ($currentTeam === null) {
-            return false;
-        }
-
-        return $this->hasTeamPermission($currentTeam, $permission);
+        return $this->currentTeam !== null && $this->hasTeamPermission($this->currentTeam, $permission);
     }
 }

--- a/app/Policies/Wiki/AnimePolicy.php
+++ b/app/Policies/Wiki/AnimePolicy.php
@@ -115,15 +115,12 @@ class AnimePolicy
      */
     public function attachSeries(User $user, Anime $anime, Series $series): bool
     {
-        if (AnimeSeries::query()
+        $attached = AnimeSeries::query()
             ->where($anime->getKeyName(), $anime->getKey())
             ->where($series->getKeyName(), $series->getKey())
-            ->exists()
-        ) {
-            return false;
-        }
+            ->exists();
 
-        return $user->hasCurrentTeamPermission('anime:update');
+        return ! $attached && $user->hasCurrentTeamPermission('anime:update');
     }
 
     /**
@@ -191,15 +188,12 @@ class AnimePolicy
      */
     public function attachImage(User $user, Anime $anime, Image $image): bool
     {
-        if (AnimeImage::query()
+        $attached = AnimeImage::query()
             ->where($anime->getKeyName(), $anime->getKey())
             ->where($image->getKeyName(), $image->getKey())
-            ->exists()
-        ) {
-            return false;
-        }
+            ->exists();
 
-        return $user->hasCurrentTeamPermission('anime:update');
+        return ! $attached && $user->hasCurrentTeamPermission('anime:update');
     }
 
     /**

--- a/app/Policies/Wiki/ArtistPolicy.php
+++ b/app/Policies/Wiki/ArtistPolicy.php
@@ -212,15 +212,12 @@ class ArtistPolicy
      */
     public function attachImage(User $user, Artist $artist, Image $image): bool
     {
-        if (ArtistImage::query()
+        $attached = ArtistImage::query()
             ->where($artist->getKeyName(), $artist->getKey())
             ->where($image->getKeyName(), $image->getKey())
-            ->exists()
-        ) {
-            return false;
-        }
+            ->exists();
 
-        return $user->hasCurrentTeamPermission('artist:update');
+        return ! $attached && $user->hasCurrentTeamPermission('artist:update');
     }
 
     /**

--- a/app/Policies/Wiki/EntryPolicy.php
+++ b/app/Policies/Wiki/EntryPolicy.php
@@ -113,15 +113,12 @@ class EntryPolicy
      */
     public function attachVideo(User $user, Entry $entry, Video $video): bool
     {
-        if (VideoEntry::query()
+        $attached = VideoEntry::query()
             ->where($entry->getKeyName(), $entry->getKey())
             ->where($video->getKeyName(), $video->getKey())
-            ->exists()
-        ) {
-            return false;
-        }
+            ->exists();
 
-        return $user->hasCurrentTeamPermission('entry:update');
+        return ! $attached && $user->hasCurrentTeamPermission('entry:update');
     }
 
     /**

--- a/app/Policies/Wiki/ImagePolicy.php
+++ b/app/Policies/Wiki/ImagePolicy.php
@@ -115,15 +115,12 @@ class ImagePolicy
      */
     public function attachArtist(User $user, Image $image, Artist $artist): bool
     {
-        if (ArtistImage::query()
+        $attached = ArtistImage::query()
             ->where($artist->getKeyName(), $artist->getKey())
             ->where($image->getKeyName(), $image->getKey())
-            ->exists()
-        ) {
-            return false;
-        }
+            ->exists();
 
-        return $user->hasCurrentTeamPermission('image:update');
+        return ! $attached && $user->hasCurrentTeamPermission('image:update');
     }
 
     /**
@@ -158,15 +155,12 @@ class ImagePolicy
      */
     public function attachAnime(User $user, Image $image, Anime $anime): bool
     {
-        if (AnimeImage::query()
+        $attached = AnimeImage::query()
             ->where($anime->getKeyName(), $anime->getKey())
             ->where($image->getKeyName(), $image->getKey())
-            ->exists()
-        ) {
-            return false;
-        }
+            ->exists();
 
-        return $user->hasCurrentTeamPermission('image:update');
+        return ! $attached && $user->hasCurrentTeamPermission('image:update');
     }
 
     /**

--- a/app/Policies/Wiki/SeriesPolicy.php
+++ b/app/Policies/Wiki/SeriesPolicy.php
@@ -113,15 +113,12 @@ class SeriesPolicy
      */
     public function attachAnime(User $user, Series $series, Anime $anime): bool
     {
-        if (AnimeSeries::query()
+        $attached = AnimeSeries::query()
             ->where($anime->getKeyName(), $anime->getKey())
             ->where($series->getKeyName(), $series->getKey())
-            ->exists()
-        ) {
-            return false;
-        }
+            ->exists();
 
-        return $user->hasCurrentTeamPermission('series:update');
+        return ! $attached && $user->hasCurrentTeamPermission('series:update');
     }
 
     /**

--- a/app/Rules/Wiki/ResourceSiteDomainRule.php
+++ b/app/Rules/Wiki/ResourceSiteDomainRule.php
@@ -46,11 +46,7 @@ class ResourceSiteDomainRule implements Rule
     {
         $domain = ResourceSite::getDomain($this->site);
 
-        if (! empty($domain)) {
-            return $domain === parse_url($value, PHP_URL_HOST);
-        }
-
-        return true;
+        return empty($domain) || $domain === parse_url($value, PHP_URL_HOST);
     }
 
     /**

--- a/database/seeders/AnilistAnimeResourceSeeder.php
+++ b/database/seeders/AnilistAnimeResourceSeeder.php
@@ -8,13 +8,11 @@ use App\Enums\Models\Wiki\ResourceSite;
 use App\Models\Wiki\Anime;
 use App\Models\Wiki\ExternalResource;
 use App\Pivots\AnimeResource;
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\ClientException;
-use GuzzleHttp\Exception\GuzzleException;
-use GuzzleHttp\Exception\ServerException;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Seeder;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
 /**
@@ -46,7 +44,7 @@ class AnilistAnimeResourceSeeder extends Seeder
             $malResource = $anime->resources()->firstWhere('site', ResourceSite::MAL);
             if ($malResource instanceof ExternalResource && $malResource->external_id !== null) {
                 // Try not to upset Anilist
-                sleep(rand(5, 15));
+                sleep(rand(2, 5));
 
                 // Anilist graphql query
                 $query = '
@@ -64,15 +62,14 @@ class AnilistAnimeResourceSeeder extends Seeder
 
                 // Anilist graphql api call
                 try {
-                    $client = new Client();
-                    $response = $client->post('https://graphql.anilist.co', [
-                        'json' => [
+                    $response = Http::post('https://graphql.anilist.co', [
                             'query' => $query,
                             'variables' => $variables,
-                        ],
-                    ]);
-                    $anilistResourceJson = json_decode($response->getBody()->getContents(), true);
-                    $anilistId = Arr::get($anilistResourceJson, 'data.Media.id');
+                        ])
+                        ->throw()
+                        ->json();
+
+                    $anilistId = Arr::get($response, 'data.Media.id');
 
                     // Check if Anilist resource already exists
                     $anilistResource = ExternalResource::query()
@@ -92,22 +89,17 @@ class AnilistAnimeResourceSeeder extends Seeder
                     }
 
                     // Attach Anilist resource to anime
-                    if (AnimeResource::query()
-                        ->where($anime->getKeyName(), $anime->getKey())
-                        ->where($anilistResource->getKeyName(), $anilistResource->getKey())
-                        ->doesntExist()
+                    if (
+                        AnimeResource::query()
+                            ->where($anime->getKeyName(), $anime->getKey())
+                            ->where($anilistResource->getKeyName(), $anilistResource->getKey())
+                            ->doesntExist()
                     ) {
                         Log::info("Attaching resource '{$anilistResource->link}' to anime '{$anime->name}'");
                         $anilistResource->anime()->attach($anime);
                     }
-                } catch (ClientException $e) {
-                    // We may not have a match for this MAL resource
+                } catch (RequestException $e) {
                     Log::info($e->getMessage());
-                } catch (ServerException | GuzzleException $e) {
-                    // We may have upset Anilist, try again later
-                    Log::info($e->getMessage());
-
-                    return;
                 }
             }
         }

--- a/database/seeders/AnilistAnimeResourceSeeder.php
+++ b/database/seeders/AnilistAnimeResourceSeeder.php
@@ -63,9 +63,9 @@ class AnilistAnimeResourceSeeder extends Seeder
                 // Anilist graphql api call
                 try {
                     $response = Http::post('https://graphql.anilist.co', [
-                            'query' => $query,
-                            'variables' => $variables,
-                        ])
+                        'query' => $query,
+                        'variables' => $variables,
+                    ])
                         ->throw()
                         ->json();
 

--- a/database/seeders/AnilistArtistResourceSeeder.php
+++ b/database/seeders/AnilistArtistResourceSeeder.php
@@ -59,9 +59,9 @@ class AnilistArtistResourceSeeder extends Seeder
             // Anilist graphql api call
             try {
                 $response = Http::post('https://graphql.anilist.co', [
-                        'query' => $query,
-                        'variables' => $variables,
-                    ])
+                    'query' => $query,
+                    'variables' => $variables,
+                ])
                     ->throw()
                     ->json();
 
@@ -96,6 +96,7 @@ class AnilistArtistResourceSeeder extends Seeder
                 }
             } catch (RequestException $e) {
                 Log::info($e->getMessage());
+
                 return;
             }
         }

--- a/database/seeders/AnilistArtistResourceSeeder.php
+++ b/database/seeders/AnilistArtistResourceSeeder.php
@@ -8,13 +8,11 @@ use App\Enums\Models\Wiki\ResourceSite;
 use App\Models\Wiki\Artist;
 use App\Models\Wiki\ExternalResource;
 use App\Pivots\ArtistResource;
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\ClientException;
-use GuzzleHttp\Exception\GuzzleException;
-use GuzzleHttp\Exception\ServerException;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Seeder;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
 /**
@@ -42,7 +40,7 @@ class AnilistArtistResourceSeeder extends Seeder
             }
 
             // Try not to upset Anilist
-            sleep(rand(5, 15));
+            sleep(rand(2, 5));
 
             // Anilist graphql query
             $query = '
@@ -60,15 +58,14 @@ class AnilistArtistResourceSeeder extends Seeder
 
             // Anilist graphql api call
             try {
-                $client = new Client();
-                $response = $client->post('https://graphql.anilist.co', [
-                    'json' => [
+                $response = Http::post('https://graphql.anilist.co', [
                         'query' => $query,
                         'variables' => $variables,
-                    ],
-                ]);
-                $anilistResourceJson = json_decode($response->getBody()->getContents(), true);
-                $anilistId = Arr::get($anilistResourceJson, 'data.Staff.id');
+                    ])
+                    ->throw()
+                    ->json();
+
+                $anilistId = Arr::get($response, 'data.Staff.id');
 
                 // Check if Anilist resource already exists
                 $anilistResource = ExternalResource::query()
@@ -88,21 +85,17 @@ class AnilistArtistResourceSeeder extends Seeder
                 }
 
                 // Attach Anilist resource to artist
-                if (ArtistResource::query()
-                    ->where($artist->getKeyName(), $artist->getKey())
-                    ->where($anilistResource->getKeyName(), $anilistResource->getKey())
-                    ->doesntExist()
+                if (
+                    ArtistResource::query()
+                        ->where($artist->getKeyName(), $artist->getKey())
+                        ->where($anilistResource->getKeyName(), $anilistResource->getKey())
+                        ->doesntExist()
                 ) {
                     Log::info("Attaching resource '{$anilistResource->link}' to artist '{$artist->name}'");
                     $anilistResource->artists()->attach($artist);
                 }
-            } catch (ClientException $e) {
-                // We may not have a match for this MAL resource
+            } catch (RequestException $e) {
                 Log::info($e->getMessage());
-            } catch (ServerException | GuzzleException $e) {
-                // We may have upset Anilist, try again later
-                Log::info($e->getMessage());
-
                 return;
             }
         }

--- a/database/seeders/AnimeResourceSeeder.php
+++ b/database/seeders/AnimeResourceSeeder.php
@@ -26,7 +26,7 @@ class AnimeResourceSeeder extends Seeder
     {
         foreach (WikiPages::YEAR_MAP as $yearPage => $years) {
             // Try not to upset Reddit
-            sleep(rand(5, 15));
+            sleep(rand(2, 5));
 
             // Get JSON of Year page content
             $yearWikiContents = WikiPages::getPageContents($yearPage);

--- a/database/seeders/AnimeSeasonSeeder.php
+++ b/database/seeders/AnimeSeasonSeeder.php
@@ -25,7 +25,7 @@ class AnimeSeasonSeeder extends Seeder
     {
         foreach (WikiPages::YEAR_MAP as $yearPage => $years) {
             // Try not to upset Reddit
-            sleep(rand(5, 15));
+            sleep(rand(2, 5));
 
             // Get JSON of Year page content
             $yearWikiContents = WikiPages::getPageContents($yearPage);

--- a/database/seeders/AnimeThemeSeeder.php
+++ b/database/seeders/AnimeThemeSeeder.php
@@ -33,7 +33,7 @@ class AnimeThemeSeeder extends Seeder
     {
         foreach (WikiPages::YEAR_MAP as $yearPage => $years) {
             // Try not to upset Reddit
-            sleep(rand(5, 15));
+            sleep(rand(2, 5));
 
             // Get JSON of Year page content
             $yearWikiContents = WikiPages::getPageContents($yearPage);

--- a/database/seeders/ArtistCoverSeeder.php
+++ b/database/seeders/ArtistCoverSeeder.php
@@ -74,9 +74,9 @@ class ArtistCoverSeeder extends Seeder
                 // Anilist graphql api call
                 try {
                     $response = Http::post('https://graphql.anilist.co', [
-                            'query' => $query,
-                            'variables' => $variables,
-                        ])
+                        'query' => $query,
+                        'variables' => $variables,
+                    ])
                         ->throw()
                         ->json();
 

--- a/database/seeders/ArtistCoverSeeder.php
+++ b/database/seeders/ArtistCoverSeeder.php
@@ -9,14 +9,12 @@ use App\Enums\Models\Wiki\ResourceSite;
 use App\Models\Wiki\Artist;
 use App\Models\Wiki\ExternalResource;
 use App\Models\Wiki\Image;
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\ClientException;
-use GuzzleHttp\Exception\GuzzleException;
-use GuzzleHttp\Exception\ServerException;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Seeder;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Testing\File;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 
@@ -54,7 +52,7 @@ class ArtistCoverSeeder extends Seeder
                 $artistCoverSmall = $artist->images()->where('facet', ImageFacet::COVER_SMALL)->first();
 
                 // Try not to upset Anilist
-                sleep(rand(5, 15));
+                sleep(rand(2, 5));
 
                 // Anilist graphql query
                 $query = '
@@ -75,29 +73,28 @@ class ArtistCoverSeeder extends Seeder
 
                 // Anilist graphql api call
                 try {
-                    $client = new Client();
-                    $response = $client->post('https://graphql.anilist.co', [
-                        'json' => [
+                    $response = Http::post('https://graphql.anilist.co', [
                             'query' => $query,
                             'variables' => $variables,
-                        ],
-                    ]);
-                    $anilistResourceJson = json_decode($response->getBody()->getContents(), true);
-                    $anilistCoverLarge = Arr::get($anilistResourceJson, 'data.Staff.image.large');
-                    $anilistCoverSmall = Arr::get($anilistResourceJson, 'data.Staff.image.medium');
+                        ])
+                        ->throw()
+                        ->json();
+
+                    $anilistCoverLarge = Arr::get($response, 'data.Staff.image.large');
+                    $anilistCoverSmall = Arr::get($response, 'data.Staff.image.medium');
 
                     // Create large cover image
                     if ($anilistCoverLarge !== null && $artistCoverLarge === null) {
-                        $coverImageResponse = $client->get($anilistCoverLarge);
-                        $coverImage = $coverImageResponse->getBody()->getContents();
+                        $coverImageResponse = Http::get($anilistCoverLarge);
+                        $coverImage = $coverImageResponse->body();
                         $coverFile = File::createWithContent(basename($anilistCoverLarge), $coverImage);
                         $coverLarge = $fs->putFile('', $coverFile);
 
                         $coverLargeImage = Image::factory()->createOne([
                             'facet' => ImageFacet::COVER_LARGE,
                             'path' => $coverLarge,
-                            'size' => $coverImageResponse->getHeader('Content-Length')[0],
-                            'mimetype' => $coverImageResponse->getHeader('Content-Type')[0],
+                            'size' => $coverImageResponse->header('Content-Length'),
+                            'mimetype' => $coverImageResponse->header('Content-Type'),
                         ]);
 
                         // Attach large cover to artist
@@ -107,30 +104,24 @@ class ArtistCoverSeeder extends Seeder
 
                     // Create small cover image
                     if ($anilistCoverSmall !== null && $artistCoverSmall === null) {
-                        $coverImageResponse = $client->get($anilistCoverSmall);
-                        $coverImage = $coverImageResponse->getBody()->getContents();
+                        $coverImageResponse = Http::get($anilistCoverSmall);
+                        $coverImage = $coverImageResponse->body();
                         $coverFile = File::createWithContent(basename($anilistCoverSmall), $coverImage);
                         $coverSmall = $fs->putFile('', $coverFile);
 
                         $coverSmallImage = Image::factory()->createOne([
                             'facet' => ImageFacet::COVER_SMALL,
                             'path' => $coverSmall,
-                            'size' => $coverImageResponse->getHeader('Content-Length')[0],
-                            'mimetype' => $coverImageResponse->getHeader('Content-Type')[0],
+                            'size' => $coverImageResponse->header('Content-Length'),
+                            'mimetype' => $coverImageResponse->header('Content-Type'),
                         ]);
 
                         // Attach large cover to artist
                         Log::info("Attaching image '{$coverSmallImage->path}' to artist '{$artist->name}'");
                         $coverSmallImage->artists()->attach($artist);
                     }
-                } catch (ClientException $e) {
-                    // We may not have a match for this MAL resource
+                } catch (RequestException $e) {
                     Log::info($e->getMessage());
-                } catch (ServerException | GuzzleException $e) {
-                    // We may have upset Anilist, try again later
-                    Log::info($e->getMessage());
-
-                    return;
                 }
             }
         }

--- a/database/seeders/ArtistSeeder.php
+++ b/database/seeders/ArtistSeeder.php
@@ -54,7 +54,7 @@ class ArtistSeeder extends Seeder
             }
 
             // Try not to upset Reddit
-            sleep(rand(5, 15));
+            sleep(rand(2, 5));
 
             // Get JSON of Artist Entry page content
             $artistLink = WikiPages::getArtistPage($artistSlug);

--- a/database/seeders/ArtistSongSeeder.php
+++ b/database/seeders/ArtistSongSeeder.php
@@ -52,7 +52,7 @@ class ArtistSongSeeder extends Seeder
             }
 
             // Try not to upset Reddit
-            sleep(rand(5, 15));
+            sleep(rand(2, 5));
 
             // Get JSON of Artist Entry page content
             $artistLink = WikiPages::getArtistPage($artistSlug);

--- a/database/seeders/SeriesSeeder.php
+++ b/database/seeders/SeriesSeeder.php
@@ -53,7 +53,7 @@ class SeriesSeeder extends Seeder
             }
 
             // Try not to upset Reddit
-            sleep(rand(5, 15));
+            sleep(rand(2, 5));
 
             // Get JSON of Series Entry page content
             $seriesLink = WikiPages::getSeriesPage($seriesSlug);

--- a/database/seeders/SynopsisCoverSeeder.php
+++ b/database/seeders/SynopsisCoverSeeder.php
@@ -9,14 +9,12 @@ use App\Enums\Models\Wiki\ResourceSite;
 use App\Models\Wiki\Anime;
 use App\Models\Wiki\ExternalResource;
 use App\Models\Wiki\Image;
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\ClientException;
-use GuzzleHttp\Exception\GuzzleException;
-use GuzzleHttp\Exception\ServerException;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Seeder;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Testing\File;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 
@@ -54,7 +52,7 @@ class SynopsisCoverSeeder extends Seeder
                 $animeCoverSmall = $anime->images()->where('facet', ImageFacet::COVER_SMALL)->first();
 
                 // Try not to upset Anilist
-                sleep(rand(5, 15));
+                sleep(rand(2, 5));
 
                 // Anilist graphql query
                 $query = '
@@ -76,17 +74,16 @@ class SynopsisCoverSeeder extends Seeder
 
                 // Anilist graphql api call
                 try {
-                    $client = new Client();
-                    $response = $client->post('https://graphql.anilist.co', [
-                        'json' => [
+                    $response = Http::post('https://graphql.anilist.co', [
                             'query' => $query,
                             'variables' => $variables,
-                        ],
-                    ]);
-                    $anilistResourceJson = json_decode($response->getBody()->getContents(), true);
-                    $anilistSynopsis = Arr::get($anilistResourceJson, 'data.Media.description');
-                    $anilistCoverLarge = Arr::get($anilistResourceJson, 'data.Media.coverImage.extraLarge');
-                    $anilistCoverSmall = Arr::get($anilistResourceJson, 'data.Media.coverImage.medium');
+                        ])
+                        ->throw()
+                        ->json();
+
+                    $anilistSynopsis = Arr::get($response, 'data.Media.description');
+                    $anilistCoverLarge = Arr::get($response, 'data.Media.coverImage.extraLarge');
+                    $anilistCoverSmall = Arr::get($response, 'data.Media.coverImage.medium');
 
                     // Set Anime synopsis
                     if ($anilistSynopsis !== null && $anime->synopsis === null) {
@@ -97,16 +94,16 @@ class SynopsisCoverSeeder extends Seeder
 
                     // Create large cover image
                     if ($anilistCoverLarge !== null && $animeCoverLarge === null) {
-                        $coverImageResponse = $client->get($anilistCoverLarge);
-                        $coverImage = $coverImageResponse->getBody()->getContents();
+                        $coverImageResponse = Http::get($anilistCoverLarge);
+                        $coverImage = $coverImageResponse->body();
                         $coverFile = File::createWithContent(basename($anilistCoverLarge), $coverImage);
                         $coverLarge = $fs->putFile('', $coverFile);
 
                         $coverLargeImage = Image::factory()->createOne([
                             'facet' => ImageFacet::COVER_LARGE,
                             'path' => $coverLarge,
-                            'size' => $coverImageResponse->getHeader('Content-Length')[0],
-                            'mimetype' => $coverImageResponse->getHeader('Content-Type')[0],
+                            'size' => $coverImageResponse->header('Content-Length'),
+                            'mimetype' => $coverImageResponse->header('Content-Type'),
                         ]);
 
                         // Attach large cover to anime
@@ -116,30 +113,24 @@ class SynopsisCoverSeeder extends Seeder
 
                     // Create small cover image
                     if ($anilistCoverSmall !== null && $animeCoverSmall === null) {
-                        $coverImageResponse = $client->get($anilistCoverSmall);
-                        $coverImage = $coverImageResponse->getBody()->getContents();
+                        $coverImageResponse = Http::get($anilistCoverSmall);
+                        $coverImage = $coverImageResponse->body();
                         $coverFile = File::createWithContent(basename($anilistCoverSmall), $coverImage);
                         $coverSmall = $fs->putFile('', $coverFile);
 
                         $coverSmallImage = Image::factory()->createOne([
                             'facet' => ImageFacet::COVER_SMALL,
                             'path' => $coverSmall,
-                            'size' => $coverImageResponse->getHeader('Content-Length')[0],
-                            'mimetype' => $coverImageResponse->getHeader('Content-Type')[0],
+                            'size' => $coverImageResponse->header('Content-Length'),
+                            'mimetype' => $coverImageResponse->header('Content-Type'),
                         ]);
 
                         // Attach large cover to anime
                         Log::info("Attaching image '{$coverSmallImage->path}' to anime '{$anime->name}'");
                         $coverSmallImage->anime()->attach($anime);
                     }
-                } catch (ClientException $e) {
-                    // We may not have a match for this MAL resource
+                } catch (RequestException $e) {
                     Log::info($e->getMessage());
-                } catch (ServerException | GuzzleException $e) {
-                    // We may have upset Anilist, try again later
-                    Log::info($e->getMessage());
-
-                    return;
                 }
             }
         }

--- a/database/seeders/SynopsisCoverSeeder.php
+++ b/database/seeders/SynopsisCoverSeeder.php
@@ -75,9 +75,9 @@ class SynopsisCoverSeeder extends Seeder
                 // Anilist graphql api call
                 try {
                     $response = Http::post('https://graphql.anilist.co', [
-                            'query' => $query,
-                            'variables' => $variables,
-                        ])
+                        'query' => $query,
+                        'variables' => $variables,
+                    ])
                         ->throw()
                         ->json();
 

--- a/database/seeders/VideoTagsSeeder.php
+++ b/database/seeders/VideoTagsSeeder.php
@@ -26,7 +26,7 @@ class VideoTagsSeeder extends Seeder
         $videoPages = collect(WikiPages::YEAR_MAP)->keys()->push(WikiPages::MISC_INDEX);
         foreach ($videoPages as $videoPage) {
             // Try not to upset Reddit
-            sleep(rand(5, 15));
+            sleep(rand(2, 5));
 
             // Get JSON of Year page content
             $yearWikiContents = WikiPages::getPageContents($videoPage);

--- a/database/seeders/WikiPages.php
+++ b/database/seeders/WikiPages.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 
 namespace Database\Seeders;
 
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\ClientException;
-use GuzzleHttp\Exception\GuzzleException;
-use GuzzleHttp\Exception\ServerException;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 
@@ -108,14 +106,12 @@ class WikiPages
     public static function getPageContents(string $page): mixed
     {
         try {
-            $client = new Client();
+            $response = Http::get($page)
+                ->throw()
+                ->json();
 
-            $response = $client->get($page);
-
-            $contents = json_decode($response->getBody()->getContents(), true);
-
-            return Arr::get($contents, 'data.content_md');
-        } catch (ClientException | ServerException | GuzzleException $e) {
+            return Arr::get($response, 'data.content_md');
+        } catch (RequestException $e) {
             Log::info($e->getMessage());
 
             return null;


### PR DESCRIPTION
* Minor fix to balance reconciliation for an error introduced when addressing psalm finding
* Prefer Http Facade to using guzzle client
* Reduce sleep time for seeders
* Address some PSR-12 compliance findings
* Reduce boolean return statements