### PR TITLE
#162 feat(console): prune stale database dumps

### DIFF
--- a/app/Console/Commands/Wiki/DatabaseDumpCommand.php
+++ b/app/Console/Commands/Wiki/DatabaseDumpCommand.php
@@ -13,6 +13,7 @@ use Illuminate\Database\PostgresConnection;
 use Illuminate\Database\SQLiteConnection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Spatie\DbDumper\Databases\MySql;
 use Spatie\DbDumper\Databases\PostgreSql;
@@ -105,7 +106,7 @@ class DatabaseDumpCommand extends Command
                 $dumper->setPort($port);
             }
 
-            $dumpFile = $this->getDumpFile($create);
+            $dumpFile = static::getDumpFile($create);
 
             $dumper->dumpToFile($dumpFile);
 
@@ -130,17 +131,16 @@ class DatabaseDumpCommand extends Command
      * @param bool $create
      * @return string
      */
-    protected function getDumpFile(bool $create): string
+    public static function getDumpFile(bool $create = false): string
     {
-        $dumpFile = Str::of('db-dumps')
-            ->append(DIRECTORY_SEPARATOR)
+        $fs = Storage::disk('db-dumps');
+
+        return Str::of($fs->path(''))
             ->append('animethemes-db-dump-')
             ->append($create ? 'create-' : '')
             ->append(Carbon::now()->toDateString())
             ->append('.sql')
             ->__toString();
-
-        return storage_path($dumpFile);
     }
 
     /**

--- a/app/Console/Commands/Wiki/PruneDatabaseDumpsCommand.php
+++ b/app/Console/Commands/Wiki/PruneDatabaseDumpsCommand.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Wiki;
+
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+/**
+ * Class PruneDatabaseDumpsCommand.
+ */
+class PruneDatabaseDumpsCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'db:prune-dumps {--H|hours=72 : The number of hours to retain sanitized database dumps}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Prune stale database dumps from local storage';
+
+    /**
+     * The number of dumps deleted.
+     *
+     * @var int
+     */
+    protected int $deleted = 0;
+
+    /**
+     * The number of dumps whose deletion failed.
+     *
+     * @var int
+     */
+    protected int $deletedFailed = 0;
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle(): int
+    {
+        $hours = $this->option('hours');
+        if (! is_numeric($hours)) {
+            Log::error("Invalid hours value '{$hours}'");
+            $this->error("Invalid hours value '{$hours}'");
+
+            return 1;
+        }
+
+        $this->prune(
+            Storage::disk('db-dumps'),
+            Carbon::now()->subHours(intval($hours))
+        );
+
+        $this->printResults();
+
+        return 0;
+    }
+
+    /**
+     * Prune database dumps in filesystem against date.
+     *
+     * @param Filesystem $fs
+     * @param Carbon $pruneDate
+     * @return void
+     */
+    protected function prune(Filesystem $fs, Carbon $pruneDate)
+    {
+        foreach ($fs->allFiles() as $path) {
+            $lastModified = Carbon::createFromTimestamp($fs->lastModified($path));
+            if (Str::contains($path, 'animethemes-db-dump') && $lastModified->isBefore($pruneDate)) {
+                $result = $fs->delete($path);
+                if ($result) {
+                    $this->deleted++;
+                    Log::info("Deleted database dump '{$path}'");
+                    $this->info("Deleted database dump '{$path}'");
+                } else {
+                    $this->deletedFailed++;
+                    Log::error("Failed to delete database dump '{$path}'");
+                    $this->error("Failed to delete database dump '{$path}'");
+                }
+            }
+        }
+    }
+
+    /**
+     * Print results to console and logs.
+     *
+     * @return void
+     */
+    protected function printResults()
+    {
+        if ($this->hasResults()) {
+            if ($this->hasDeletions()) {
+                Log::info("{$this->deleted} database dumps deleted");
+                $this->info("{$this->deleted} database dumps deleted");
+            }
+            if ($this->hasFailures()) {
+                Log::error("Failed to delete {$this->deletedFailed} database dumps");
+                $this->error("Failed to delete {$this->deletedFailed} database dumps");
+            }
+        } else {
+            Log::info('No database dumps deleted');
+            $this->info('No database dumps deleted');
+        }
+    }
+
+    /**
+     * Determines if any deletions, successful or not, were made during pruning.
+     *
+     * @return bool
+     */
+    protected function hasResults(): bool
+    {
+        return $this->hasDeletions() || $this->hasFailures();
+    }
+
+    /**
+     * Determines if any successful deletions were made during pruning.
+     *
+     * @return bool
+     */
+    protected function hasDeletions(): bool
+    {
+        return $this->deleted > 0;
+    }
+
+    /**
+     * Determines if any unsuccessful deletions were attempted during pruning.
+     *
+     * @return bool
+     */
+    protected function hasFailures(): bool
+    {
+        return $this->deletedFailed > 0;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -7,6 +7,7 @@ namespace App\Console;
 use App\Console\Commands\Billing\BalanceReconcileCommand;
 use App\Console\Commands\Billing\TransactionReconcileCommand;
 use App\Console\Commands\Wiki\DatabaseDumpCommand;
+use App\Console\Commands\Wiki\PruneDatabaseDumpsCommand;
 use App\Console\Commands\Wiki\VideoReconcileCommand;
 use App\Enums\Models\Billing\Service;
 use Illuminate\Console\Scheduling\Schedule;
@@ -28,6 +29,7 @@ class Kernel extends ConsoleKernel
     protected $commands = [
         BalanceReconcileCommand::class,
         DatabaseDumpCommand::class,
+        PruneDatabaseDumpsCommand::class,
         TransactionReconcileCommand::class,
         VideoReconcileCommand::class,
     ];
@@ -46,6 +48,7 @@ class Kernel extends ConsoleKernel
         $schedule->command(DatabaseDumpCommand::class)->daily();
         $schedule->command(DatabaseDumpCommand::class, ['--create'])->daily();
         $schedule->command(PruneCommand::class)->daily();
+        $schedule->command(PruneDatabaseDumpsCommand::class)->dailyAt('00:15');
         $schedule->command(PruneFailedJobsCommand::class)->daily();
         $schedule->command(SnapshotCommand::class)->everyFiveMinutes();
         $schedule->command(TransactionReconcileCommand::class, [Service::DIGITALOCEAN()->key])->dailyAt('07:00');

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -68,6 +68,10 @@ return [
             'visibility' => env('VIDEO_VISIBILITY'),
         ],
 
+        'db-dumps' => [
+            'driver' => 'local',
+            'root' => storage_path('db-dumps'),
+        ],
     ],
 
     /*

--- a/tests/Feature/Console/Commands/Wiki/PruneDatabaseDumpsTest.php
+++ b/tests/Feature/Console/Commands/Wiki/PruneDatabaseDumpsTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console\Commands\Wiki;
+
+use App\Console\Commands\Wiki\DatabaseDumpCommand;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+/**
+ * Class PruneDatabaseDumpsTest.
+ */
+class PruneDatabaseDumpsTest extends TestCase
+{
+    use WithFaker;
+
+    /**
+     * If no changes are needed, the Prune Database Dumps Command shall output 'No database dumps deleted'.
+     *
+     * @return void
+     */
+    public function testNoResults()
+    {
+        Storage::fake('db-dumps');
+
+        $this->artisan('db:prune-dumps --hours=0')->expectsOutput('No database dumps deleted');
+    }
+
+    /**
+     * If dumps are deleted, the Prune Database Dumps Command shall output '{Deleted Count} database dumps deleted'.
+     *
+     * @return void
+     */
+    public function testDeleted()
+    {
+        Storage::fake('db-dumps');
+
+        $deletedCount = $this->faker->randomDigitNotNull();
+
+        Collection::times($deletedCount, function () {
+            Carbon::setTestNow($this->faker->iso8601());
+
+            $this->artisan(DatabaseDumpCommand::class)->run();
+        });
+
+        Carbon::setTestNow();
+
+        $this->artisan('db:prune-dumps --hours=-1')->expectsOutput("{$deletedCount} database dumps deleted");
+    }
+}


### PR DESCRIPTION
* Prune stale database dumps in a separate console command like the framework does for failed jobs, stale telescope entries, etc. By default, we are pruning database dumps more than 72 hours old. We can tweak this value in the future if needed.
* Database dumps are now contained in a configured filesystem. This was done primarily for testing, as faking a storage disk will give us a clean disk to perform tests. Parallel testing fails otherwise if we are writing to the actual disk as we were previously doing.