### PR TITLE
fix(api): enum filters should use description instead of key

### DIFF
--- a/app/Enums/BaseEnum.php
+++ b/app/Enums/BaseEnum.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+use BenSampo\Enum\Contracts\LocalizedEnum;
+use BenSampo\Enum\Enum;
+use Illuminate\Support\Str;
+
+/**
+ * Class BaseEnum.
+ */
+abstract class BaseEnum extends Enum implements LocalizedEnum
+{
+    /**
+     * Make a new instance from an enum description.
+     *
+     * @param string $description
+     * @return static|null
+     */
+    public static function fromDescription(string $description): ?static
+    {
+        foreach (static::getInstances() as $instance) {
+            if (Str::lower($instance->description) === Str::lower($description)) {
+                return $instance;
+            }
+        }
+
+        return null;
+    }
+}

--- a/app/Enums/Http/Api/Filter/AllowedDateFormat.php
+++ b/app/Enums/Http/Api/Filter/AllowedDateFormat.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace App\Enums\Http\Api\Filter;
 
-use BenSampo\Enum\Enum;
+use App\Enums\BaseEnum;
 
 /**
  * Class AllowedDateFormat.
  */
-final class AllowedDateFormat extends Enum
+final class AllowedDateFormat extends BaseEnum
 {
     public const YMDHISU = 'Y-m-d\TH:i:s.u';
     public const YMDHIS = 'Y-m-d\TH:i:s';

--- a/app/Enums/Http/Api/Filter/BinaryLogicalOperator.php
+++ b/app/Enums/Http/Api/Filter/BinaryLogicalOperator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Enums\Http\Api\Filter;
 
-use BenSampo\Enum\Enum;
+use App\Enums\BaseEnum;
 
 /**
  * Class BinaryLogicalOperator.
@@ -12,7 +12,7 @@ use BenSampo\Enum\Enum;
  * @method static static AND()
  * @method static static OR()
  */
-final class BinaryLogicalOperator extends Enum
+final class BinaryLogicalOperator extends BaseEnum
 {
     public const AND = 'and';
     public const OR = 'or';

--- a/app/Enums/Http/Api/Filter/ComparisonOperator.php
+++ b/app/Enums/Http/Api/Filter/ComparisonOperator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Enums\Http\Api\Filter;
 
-use BenSampo\Enum\Enum;
+use App\Enums\BaseEnum;
 
 /**
  * Class ComparisonOperator.
@@ -18,7 +18,7 @@ use BenSampo\Enum\Enum;
  * @method static static LIKE()
  * @method static static NOTLIKE()
  */
-final class ComparisonOperator extends Enum
+final class ComparisonOperator extends BaseEnum
 {
     public const EQ = '=';
     public const NE = '<>';

--- a/app/Enums/Http/Api/Filter/TrashedStatus.php
+++ b/app/Enums/Http/Api/Filter/TrashedStatus.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace App\Enums\Http\Api\Filter;
 
-use BenSampo\Enum\Enum;
+use App\Enums\BaseEnum;
 
 /**
  * Class TrashedStatus.
  */
-final class TrashedStatus extends Enum
+final class TrashedStatus extends BaseEnum
 {
     public const WITH = 'with';
     public const WITHOUT = 'without';

--- a/app/Enums/Http/Api/Filter/UnaryLogicalOperator.php
+++ b/app/Enums/Http/Api/Filter/UnaryLogicalOperator.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace App\Enums\Http\Api\Filter;
 
-use BenSampo\Enum\Enum;
+use App\Enums\BaseEnum;
 
 /**
  * Class UnaryLogicalOperator.
  */
-final class UnaryLogicalOperator extends Enum
+final class UnaryLogicalOperator extends BaseEnum
 {
     public const NOT = 'not';
 }

--- a/app/Enums/Http/Api/Paging/PaginationStrategy.php
+++ b/app/Enums/Http/Api/Paging/PaginationStrategy.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Enums\Http\Api\Paging;
 
-use BenSampo\Enum\Enum;
+use App\Enums\BaseEnum;
 
 /**
  * Class PaginationStrategy.
@@ -13,7 +13,7 @@ use BenSampo\Enum\Enum;
  * @method static static LIMIT()
  * @method static static OFFSET()
  */
-final class PaginationStrategy extends Enum
+final class PaginationStrategy extends BaseEnum
 {
     public const NONE = 0;
     public const LIMIT = 1;

--- a/app/Enums/Http/Api/Sort/Direction.php
+++ b/app/Enums/Http/Api/Sort/Direction.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Enums\Http\Api\Sort;
 
-use BenSampo\Enum\Enum;
+use App\Enums\BaseEnum;
 
 /**
  * Class Direction.
@@ -12,7 +12,7 @@ use BenSampo\Enum\Enum;
  * @method static static ASCENDING()
  * @method static static DESCENDING()
  */
-final class Direction extends Enum
+final class Direction extends BaseEnum
 {
     public const ASCENDING = 'asc';
     public const DESCENDING = 'desc';

--- a/app/Enums/Models/Auth/InvitationStatus.php
+++ b/app/Enums/Models/Auth/InvitationStatus.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace App\Enums\Models\Auth;
 
-use BenSampo\Enum\Contracts\LocalizedEnum;
-use BenSampo\Enum\Enum;
+use App\Enums\BaseEnum;
 
 /**
  * Class InvitationStatus.
@@ -13,7 +12,7 @@ use BenSampo\Enum\Enum;
  * @method static static OPEN()
  * @method static static CLOSED()
  */
-final class InvitationStatus extends Enum implements LocalizedEnum
+final class InvitationStatus extends BaseEnum
 {
     public const OPEN = 0;
     public const CLOSED = 1;

--- a/app/Enums/Models/Billing/BalanceFrequency.php
+++ b/app/Enums/Models/Billing/BalanceFrequency.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace App\Enums\Models\Billing;
 
-use BenSampo\Enum\Enum;
+use App\Enums\BaseEnum;
 
 /**
  * Class BalanceFrequency.
  */
-final class BalanceFrequency extends Enum
+final class BalanceFrequency extends BaseEnum
 {
     public const ONCE = 0;
     public const ANNUALLY = 1;

--- a/app/Enums/Models/Billing/Service.php
+++ b/app/Enums/Models/Billing/Service.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace App\Enums\Models\Billing;
 
-use BenSampo\Enum\Contracts\LocalizedEnum;
-use BenSampo\Enum\Enum;
+use App\Enums\BaseEnum;
 
 /**
  * Class Service.
@@ -16,7 +15,7 @@ use BenSampo\Enum\Enum;
  * @method static static HOVER()
  * @method static static WALKERSERVERS()
  */
-final class Service extends Enum implements LocalizedEnum
+final class Service extends BaseEnum
 {
     public const OTHER = 0;
     public const DIGITALOCEAN = 1;

--- a/app/Enums/Models/Wiki/AnimeSeason.php
+++ b/app/Enums/Models/Wiki/AnimeSeason.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace App\Enums\Models\Wiki;
 
-use BenSampo\Enum\Contracts\LocalizedEnum;
-use BenSampo\Enum\Enum;
+use App\Enums\BaseEnum;
 
 /**
  * Class AnimeSeason.
  */
-final class AnimeSeason extends Enum implements LocalizedEnum
+final class AnimeSeason extends BaseEnum
 {
     public const WINTER = 0;
     public const SPRING = 1;

--- a/app/Enums/Models/Wiki/ImageFacet.php
+++ b/app/Enums/Models/Wiki/ImageFacet.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace App\Enums\Models\Wiki;
 
-use BenSampo\Enum\Contracts\LocalizedEnum;
-use BenSampo\Enum\Enum;
+use App\Enums\BaseEnum;
 
 /**
  * Class ImageFacet.
  */
-final class ImageFacet extends Enum implements LocalizedEnum
+final class ImageFacet extends BaseEnum
 {
     public const COVER_SMALL = 0;
     public const COVER_LARGE = 1;

--- a/app/Enums/Models/Wiki/ResourceSite.php
+++ b/app/Enums/Models/Wiki/ResourceSite.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace App\Enums\Models\Wiki;
 
-use BenSampo\Enum\Contracts\LocalizedEnum;
-use BenSampo\Enum\Enum;
+use App\Enums\BaseEnum;
 
 /**
  * Class ResourceSite.
  */
-final class ResourceSite extends Enum implements LocalizedEnum
+final class ResourceSite extends BaseEnum
 {
     // Official Media
     public const OFFICIAL_SITE = 0;

--- a/app/Enums/Models/Wiki/ThemeType.php
+++ b/app/Enums/Models/Wiki/ThemeType.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace App\Enums\Models\Wiki;
 
-use BenSampo\Enum\Contracts\LocalizedEnum;
-use BenSampo\Enum\Enum;
+use App\Enums\BaseEnum;
 
 /**
  * Class ThemeType.
  */
-final class ThemeType extends Enum implements LocalizedEnum
+final class ThemeType extends BaseEnum
 {
     public const OP = 0;
     public const ED = 1;

--- a/app/Enums/Models/Wiki/VideoOverlap.php
+++ b/app/Enums/Models/Wiki/VideoOverlap.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace App\Enums\Models\Wiki;
 
-use BenSampo\Enum\Contracts\LocalizedEnum;
-use BenSampo\Enum\Enum;
+use App\Enums\BaseEnum;
 
 /**
  * Class VideoOverlap.
@@ -14,7 +13,7 @@ use BenSampo\Enum\Enum;
  * @method static static TRANS()
  * @method static static OVER()
  */
-final class VideoOverlap extends Enum implements LocalizedEnum
+final class VideoOverlap extends BaseEnum
 {
     public const NONE = 0;
     public const TRANS = 1;

--- a/app/Enums/Models/Wiki/VideoSource.php
+++ b/app/Enums/Models/Wiki/VideoSource.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace App\Enums\Models\Wiki;
 
-use BenSampo\Enum\Contracts\LocalizedEnum;
-use BenSampo\Enum\Enum;
+use App\Enums\BaseEnum;
 
 /**
  * Class VideoSource.
  */
-final class VideoSource extends Enum implements LocalizedEnum
+final class VideoSource extends BaseEnum
 {
     public const WEB = 0;
     public const RAW = 1;

--- a/app/Enums/Services/Discord/EmbedColor.php
+++ b/app/Enums/Services/Discord/EmbedColor.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace App\Enums\Services\Discord;
 
-use BenSampo\Enum\Enum;
+use App\Enums\BaseEnum;
 
 /**
  * Class EmbedColor.
  */
-final class EmbedColor extends Enum
+final class EmbedColor extends BaseEnum
 {
     public const GREEN = 3066993;
     public const YELLOW = 16776960;

--- a/app/Http/Api/Filter/EnumFilter.php
+++ b/app/Http/Api/Filter/EnumFilter.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace App\Http\Api\Filter;
 
-use BenSampo\Enum\Enum;
+use App\Enums\BaseEnum;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
 
 /**
  * Class EnumFilter.
@@ -16,7 +15,7 @@ abstract class EnumFilter extends Filter
     /**
      * The Enum class string.
      *
-     * @var class-string<Enum>
+     * @var class-string<BaseEnum>
      */
     protected string $enumClass;
 
@@ -25,7 +24,7 @@ abstract class EnumFilter extends Filter
      *
      * @param Collection $criteria
      * @param string $key
-     * @param class-string<Enum> $enumClass
+     * @param class-string<BaseEnum> $enumClass
      */
     public function __construct(Collection $criteria, string $key, string $enumClass)
     {
@@ -43,7 +42,7 @@ abstract class EnumFilter extends Filter
     {
         return array_map(
             function (string $filterValue) {
-                return $this->enumClass::getValue(Str::upper($filterValue));
+                return $this->enumClass::fromDescription($filterValue)?->value;
             },
             $filterValues
         );
@@ -61,7 +60,7 @@ abstract class EnumFilter extends Filter
             array_filter(
                 $filterValues,
                 function (string $filterValue) {
-                    return $this->enumClass::hasKey(Str::upper($filterValue));
+                    return $this->enumClass::fromDescription($filterValue) !== null;
                 }
             )
         );

--- a/tests/Feature/Http/Api/Wiki/Anime/AnimeIndexTest.php
+++ b/tests/Feature/Http/Api/Wiki/Anime/AnimeIndexTest.php
@@ -239,7 +239,7 @@ class AnimeIndexTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'season' => $seasonFilter->key,
+                'season' => $seasonFilter->description,
             ],
         ];
 
@@ -678,7 +678,7 @@ class AnimeIndexTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'type' => $typeFilter->key,
+                'type' => $typeFilter->description,
             ],
             IncludeParser::$param => 'themes',
         ];
@@ -866,7 +866,7 @@ class AnimeIndexTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'site' => $siteFilter->key,
+                'site' => $siteFilter->description,
             ],
             IncludeParser::$param => 'resources',
         ];
@@ -908,7 +908,7 @@ class AnimeIndexTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'facet' => $facetFilter->key,
+                'facet' => $facetFilter->description,
             ],
             IncludeParser::$param => 'images',
         ];
@@ -1028,7 +1028,7 @@ class AnimeIndexTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'overlap' => $overlapFilter->key,
+                'overlap' => $overlapFilter->description,
             ],
             IncludeParser::$param => 'themes.entries.videos',
         ];
@@ -1125,7 +1125,7 @@ class AnimeIndexTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'source' => $sourceFilter->key,
+                'source' => $sourceFilter->description,
             ],
             IncludeParser::$param => 'themes.entries.videos',
         ];

--- a/tests/Feature/Http/Api/Wiki/Anime/AnimeShowTest.php
+++ b/tests/Feature/Http/Api/Wiki/Anime/AnimeShowTest.php
@@ -274,7 +274,7 @@ class AnimeShowTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'type' => $typeFilter->key,
+                'type' => $typeFilter->description,
             ],
             IncludeParser::$param => 'themes',
         ];
@@ -460,7 +460,7 @@ class AnimeShowTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'site' => $siteFilter->key,
+                'site' => $siteFilter->description,
             ],
             IncludeParser::$param => 'resources',
         ];
@@ -503,7 +503,7 @@ class AnimeShowTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'facet' => $facetFilter->key,
+                'facet' => $facetFilter->description,
             ],
             IncludeParser::$param => 'images',
         ];
@@ -622,7 +622,7 @@ class AnimeShowTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'overlap' => $overlapFilter->key,
+                'overlap' => $overlapFilter->description,
             ],
             IncludeParser::$param => 'themes.entries.videos',
         ];
@@ -718,7 +718,7 @@ class AnimeShowTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'source' => $sourceFilter->key,
+                'source' => $sourceFilter->description,
             ],
             IncludeParser::$param => 'themes.entries.videos',
         ];

--- a/tests/Feature/Http/Api/Wiki/Artist/ArtistIndexTest.php
+++ b/tests/Feature/Http/Api/Wiki/Artist/ArtistIndexTest.php
@@ -610,7 +610,7 @@ class ArtistIndexTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'type' => $typeFilter->key,
+                'type' => $typeFilter->description,
             ],
             IncludeParser::$param => 'songs.themes',
         ];
@@ -660,7 +660,7 @@ class ArtistIndexTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'season' => $seasonFilter->key,
+                'season' => $seasonFilter->description,
             ],
             IncludeParser::$param => 'songs.themes.anime',
         ];
@@ -768,7 +768,7 @@ class ArtistIndexTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'site' => $siteFilter->key,
+                'site' => $siteFilter->description,
             ],
             IncludeParser::$param => 'resources',
         ];
@@ -812,7 +812,7 @@ class ArtistIndexTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'facet' => $facetFilter->key,
+                'facet' => $facetFilter->description,
             ],
             IncludeParser::$param => 'images',
         ];

--- a/tests/Feature/Http/Api/Wiki/Artist/ArtistShowTest.php
+++ b/tests/Feature/Http/Api/Wiki/Artist/ArtistShowTest.php
@@ -282,7 +282,7 @@ class ArtistShowTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'type' => $typeFilter->key,
+                'type' => $typeFilter->description,
             ],
             IncludeParser::$param => 'songs.themes',
         ];
@@ -331,7 +331,7 @@ class ArtistShowTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'season' => $seasonFilter->key,
+                'season' => $seasonFilter->description,
             ],
             IncludeParser::$param => 'songs.themes.anime',
         ];
@@ -437,7 +437,7 @@ class ArtistShowTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'site' => $siteFilter->key,
+                'site' => $siteFilter->description,
             ],
             IncludeParser::$param => 'resources',
         ];
@@ -480,7 +480,7 @@ class ArtistShowTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'facet' => $facetFilter->key,
+                'facet' => $facetFilter->description,
             ],
             IncludeParser::$param => 'images',
         ];

--- a/tests/Feature/Http/Api/Wiki/Entry/EntryIndexTest.php
+++ b/tests/Feature/Http/Api/Wiki/Entry/EntryIndexTest.php
@@ -647,7 +647,7 @@ class EntryIndexTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'season' => $seasonFilter->key,
+                'season' => $seasonFilter->description,
             ],
             IncludeParser::$param => 'anime',
         ];
@@ -837,7 +837,7 @@ class EntryIndexTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'type' => $typeFilter->key,
+                'type' => $typeFilter->description,
             ],
             IncludeParser::$param => 'theme',
         ];

--- a/tests/Feature/Http/Api/Wiki/Entry/EntryShowTest.php
+++ b/tests/Feature/Http/Api/Wiki/Entry/EntryShowTest.php
@@ -174,7 +174,7 @@ class EntryShowTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'season' => $seasonFilter->key,
+                'season' => $seasonFilter->description,
             ],
             IncludeParser::$param => 'anime',
         ];
@@ -360,7 +360,7 @@ class EntryShowTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'type' => $typeFilter->key,
+                'type' => $typeFilter->description,
             ],
             IncludeParser::$param => 'theme',
         ];

--- a/tests/Feature/Http/Api/Wiki/ExternalResource/ExternalResourceIndexTest.php
+++ b/tests/Feature/Http/Api/Wiki/ExternalResource/ExternalResourceIndexTest.php
@@ -482,7 +482,7 @@ class ExternalResourceIndexTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'site' => $siteFilter->key,
+                'site' => $siteFilter->description,
             ],
         ];
 
@@ -517,7 +517,7 @@ class ExternalResourceIndexTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'season' => $seasonFilter->key,
+                'season' => $seasonFilter->description,
             ],
             IncludeParser::$param => 'anime',
         ];

--- a/tests/Feature/Http/Api/Wiki/ExternalResource/ExternalResourceShowTest.php
+++ b/tests/Feature/Http/Api/Wiki/ExternalResource/ExternalResourceShowTest.php
@@ -166,7 +166,7 @@ class ExternalResourceShowTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'season' => $seasonFilter->key,
+                'season' => $seasonFilter->description,
             ],
             IncludeParser::$param => 'anime',
         ];

--- a/tests/Feature/Http/Api/Wiki/Image/ImageIndexTest.php
+++ b/tests/Feature/Http/Api/Wiki/Image/ImageIndexTest.php
@@ -482,7 +482,7 @@ class ImageIndexTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'facet' => $facetFilter->key,
+                'facet' => $facetFilter->description,
             ],
         ];
 
@@ -517,7 +517,7 @@ class ImageIndexTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'season' => $seasonFilter->key,
+                'season' => $seasonFilter->description,
             ],
             IncludeParser::$param => 'anime',
         ];

--- a/tests/Feature/Http/Api/Wiki/Image/ImageShowTest.php
+++ b/tests/Feature/Http/Api/Wiki/Image/ImageShowTest.php
@@ -166,7 +166,7 @@ class ImageShowTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'season' => $seasonFilter->key,
+                'season' => $seasonFilter->description,
             ],
             IncludeParser::$param => 'anime',
         ];

--- a/tests/Feature/Http/Api/Wiki/Series/SeriesIndexTest.php
+++ b/tests/Feature/Http/Api/Wiki/Series/SeriesIndexTest.php
@@ -494,7 +494,7 @@ class SeriesIndexTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'season' => $seasonFilter->key,
+                'season' => $seasonFilter->description,
             ],
             IncludeParser::$param => 'anime',
         ];

--- a/tests/Feature/Http/Api/Wiki/Series/SeriesShowTest.php
+++ b/tests/Feature/Http/Api/Wiki/Series/SeriesShowTest.php
@@ -169,7 +169,7 @@ class SeriesShowTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'season' => $seasonFilter->key,
+                'season' => $seasonFilter->description,
             ],
             IncludeParser::$param => 'anime',
         ];

--- a/tests/Feature/Http/Api/Wiki/Song/SongIndexTest.php
+++ b/tests/Feature/Http/Api/Wiki/Song/SongIndexTest.php
@@ -595,7 +595,7 @@ class SongIndexTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'type' => $typeFilter->key,
+                'type' => $typeFilter->description,
             ],
             IncludeParser::$param => 'themes',
         ];
@@ -637,7 +637,7 @@ class SongIndexTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'season' => $seasonFilter->key,
+                'season' => $seasonFilter->description,
             ],
             IncludeParser::$param => 'themes.anime',
         ];

--- a/tests/Feature/Http/Api/Wiki/Song/SongShowTest.php
+++ b/tests/Feature/Http/Api/Wiki/Song/SongShowTest.php
@@ -272,7 +272,7 @@ class SongShowTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'type' => $typeFilter->key,
+                'type' => $typeFilter->description,
             ],
             IncludeParser::$param => 'themes',
         ];
@@ -313,7 +313,7 @@ class SongShowTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'season' => $seasonFilter->key,
+                'season' => $seasonFilter->description,
             ],
             IncludeParser::$param => 'themes.anime',
         ];

--- a/tests/Feature/Http/Api/Wiki/Synonym/SynonymIndexTest.php
+++ b/tests/Feature/Http/Api/Wiki/Synonym/SynonymIndexTest.php
@@ -518,7 +518,7 @@ class SynonymIndexTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'season' => $seasonFilter->key,
+                'season' => $seasonFilter->description,
             ],
             IncludeParser::$param => 'anime',
         ];

--- a/tests/Feature/Http/Api/Wiki/Synonym/SynonymShowTest.php
+++ b/tests/Feature/Http/Api/Wiki/Synonym/SynonymShowTest.php
@@ -163,7 +163,7 @@ class SynonymShowTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'season' => $seasonFilter->key,
+                'season' => $seasonFilter->description,
             ],
             IncludeParser::$param => 'anime',
         ];

--- a/tests/Feature/Http/Api/Wiki/Theme/ThemeIndexTest.php
+++ b/tests/Feature/Http/Api/Wiki/Theme/ThemeIndexTest.php
@@ -622,7 +622,7 @@ class ThemeIndexTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'type' => $typeFilter->key,
+                'type' => $typeFilter->description,
             ],
         ];
 
@@ -658,7 +658,7 @@ class ThemeIndexTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'season' => $seasonFilter->key,
+                'season' => $seasonFilter->description,
             ],
             IncludeParser::$param => 'anime',
         ];
@@ -748,7 +748,7 @@ class ThemeIndexTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'facet' => $facetFilter->key,
+                'facet' => $facetFilter->description,
             ],
             IncludeParser::$param => 'anime.images',
         ];
@@ -1024,7 +1024,7 @@ class ThemeIndexTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'overlap' => $overlapFilter->key,
+                'overlap' => $overlapFilter->description,
             ],
             IncludeParser::$param => 'entries.videos',
         ];
@@ -1126,7 +1126,7 @@ class ThemeIndexTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'source' => $sourceFilter->key,
+                'source' => $sourceFilter->description,
             ],
             IncludeParser::$param => 'entries.videos',
         ];

--- a/tests/Feature/Http/Api/Wiki/Theme/ThemeShowTest.php
+++ b/tests/Feature/Http/Api/Wiki/Theme/ThemeShowTest.php
@@ -189,7 +189,7 @@ class ThemeShowTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'season' => $seasonFilter->key,
+                'season' => $seasonFilter->description,
             ],
             IncludeParser::$param => 'anime',
         ];
@@ -277,7 +277,7 @@ class ThemeShowTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'facet' => $facetFilter->key,
+                'facet' => $facetFilter->description,
             ],
             IncludeParser::$param => 'anime.images',
         ];
@@ -547,7 +547,7 @@ class ThemeShowTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'overlap' => $overlapFilter->key,
+                'overlap' => $overlapFilter->description,
             ],
             IncludeParser::$param => 'entries.videos',
         ];
@@ -647,7 +647,7 @@ class ThemeShowTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'source' => $sourceFilter->key,
+                'source' => $sourceFilter->description,
             ],
             IncludeParser::$param => 'entries.videos',
         ];

--- a/tests/Feature/Http/Api/Wiki/Video/VideoIndexTest.php
+++ b/tests/Feature/Http/Api/Wiki/Video/VideoIndexTest.php
@@ -608,7 +608,7 @@ class VideoIndexTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'overlap' => $overlapFilter->key,
+                'overlap' => $overlapFilter->description,
             ],
         ];
 
@@ -687,7 +687,7 @@ class VideoIndexTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'source' => $sourceFilter->key,
+                'source' => $sourceFilter->description,
             ],
         ];
 
@@ -1045,7 +1045,7 @@ class VideoIndexTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'type' => $typeFilter->key,
+                'type' => $typeFilter->description,
             ],
             IncludeParser::$param => 'entries.theme',
         ];
@@ -1091,7 +1091,7 @@ class VideoIndexTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'season' => $seasonFilter->key,
+                'season' => $seasonFilter->description,
             ],
             IncludeParser::$param => 'entries.theme.anime',
         ];

--- a/tests/Feature/Http/Api/Wiki/Video/VideoShowTest.php
+++ b/tests/Feature/Http/Api/Wiki/Video/VideoShowTest.php
@@ -429,7 +429,7 @@ class VideoShowTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'type' => $typeFilter->key,
+                'type' => $typeFilter->description,
             ],
             IncludeParser::$param => 'entries.theme',
         ];
@@ -474,7 +474,7 @@ class VideoShowTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                'season' => $seasonFilter->key,
+                'season' => $seasonFilter->description,
             ],
             IncludeParser::$param => 'entries.theme.anime',
         ];

--- a/tests/Unit/Enums/BaseEnumTest.php
+++ b/tests/Unit/Enums/BaseEnumTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Enums;
+
+use App\Enums\BaseEnum;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+/**
+ * Class BaseEnumTest.
+ */
+class BaseEnumTest extends TestCase
+{
+    use WithFaker;
+
+    /**
+     * An enum instance shall be resolved by description.
+     *
+     * @return void
+     */
+    public function testFromDescriptionInstance()
+    {
+        $enum = new class($this->faker->numberBetween(0, 2)) extends BaseEnum
+        {
+            public const ZERO = 0;
+            public const ONE = 1;
+            public const TWO = 2;
+        };
+
+        $fromDescription = $enum::fromDescription($enum->description);
+
+        static::assertInstanceOf(get_class($enum), $fromDescription);
+    }
+
+    /**
+     * If the provided description does not match an instance, an enum instance shall not be resolved.
+     *
+     * @return void
+     */
+    public function testFromDescriptionNullable()
+    {
+        $enum = new class($this->faker->numberBetween(0, 2)) extends BaseEnum
+        {
+            public const ZERO = 0;
+            public const ONE = 1;
+            public const TWO = 2;
+        };
+
+        $fromDescription = $enum::fromDescription(Str::random());
+
+        static::assertNull($fromDescription);
+    }
+}

--- a/tests/Unit/Http/Api/Filter/EnumFilterTest.php
+++ b/tests/Unit/Http/Api/Filter/EnumFilterTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Http\Api\Filter;
 
+use App\Enums\BaseEnum;
 use App\Http\Api\Filter\EnumFilter;
 use App\Http\Api\Parser\FilterParser;
 use App\Http\Api\Query;
-use BenSampo\Enum\Enum;
 use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
@@ -37,7 +37,7 @@ class EnumFilterTest extends TestCase
 
         $query = Query::make($parameters);
 
-        $enum = new class($this->faker->numberBetween(0, 2)) extends Enum
+        $enum = new class($this->faker->numberBetween(0, 2)) extends BaseEnum
         {
             public const ZERO = 0;
             public const ONE = 1;
@@ -63,7 +63,7 @@ class EnumFilterTest extends TestCase
     {
         $filterField = $this->faker->word();
 
-        $enum = new class($this->faker->numberBetween(0, 2)) extends Enum
+        $enum = new class($this->faker->numberBetween(0, 2)) extends BaseEnum
         {
             public const ZERO = 0;
             public const ONE = 1;
@@ -99,7 +99,7 @@ class EnumFilterTest extends TestCase
     {
         $filterField = $this->faker->word();
 
-        $enum = new class($this->faker->numberBetween(0, 2)) extends Enum
+        $enum = new class($this->faker->numberBetween(0, 2)) extends BaseEnum
         {
             public const ZERO = 0;
             public const ONE = 1;
@@ -108,7 +108,7 @@ class EnumFilterTest extends TestCase
 
         $parameters = [
             FilterParser::$param => [
-                $filterField => $enum->key,
+                $filterField => $enum->description,
             ],
         ];
 

--- a/tests/Unit/Services/Discord/DiscordEmbedFieldTest.php
+++ b/tests/Unit/Services/Discord/DiscordEmbedFieldTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Services\Discord;
 
+use App\Enums\BaseEnum;
 use App\Services\Discord\DiscordEmbedField;
-use BenSampo\Enum\Enum;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Arr;
 use stdClass;
@@ -25,7 +25,7 @@ class DiscordEmbedFieldTest extends TestCase
      */
     public function testDiscordEmbedFormatEnum()
     {
-        $enum = new class($this->faker->numberBetween(0, 2)) extends Enum
+        $enum = new class($this->faker->numberBetween(0, 2)) extends BaseEnum
         {
             public const ZERO = 0;
             public const ONE = 1;


### PR DESCRIPTION
Addressing an issue reported in the discord server. Resource attributes use the description of enum instances. Previously, enum filters used the key of the instance to retrieve the value that is used in the database. This fix changes the behavior of enum filters to instead use the description to parse an instance so that filter values can match the resource attribute values.