### PR TITLE
chore: apply select binding to query builder to reduce memory footprint

### DIFF
--- a/app/Concerns/Reconcile/Billing/ReconcilesBalanceRepositories.php
+++ b/app/Concerns/Reconcile/Billing/ReconcilesBalanceRepositories.php
@@ -19,6 +19,16 @@ trait ReconcilesBalanceRepositories
     use ReconcilesRepositories;
 
     /**
+     * The columns used for create and delete set operations.
+     *
+     * @return array
+     */
+    protected function columnsForCreateDelete(): array
+    {
+        return ['balance_id', 'date', 'service'];
+    }
+
+    /**
      * Callback for create and delete set operation item comparison.
      *
      * @return Closure
@@ -26,6 +36,16 @@ trait ReconcilesBalanceRepositories
     protected function diffCallbackForCreateDelete(): Closure
     {
         return fn (Balance $first, Balance $second) => $first->date->format(AllowedDateFormat::YM) <=> $second->date->format(AllowedDateFormat::YM);
+    }
+
+    /**
+     * The columns used for update set operation.
+     *
+     * @return array
+     */
+    protected function columnsForUpdate(): array
+    {
+        return ['balance_id', 'date', 'usage', 'balance', 'service'];
     }
 
     /**

--- a/app/Concerns/Reconcile/Billing/ReconcilesTransactionRepositories.php
+++ b/app/Concerns/Reconcile/Billing/ReconcilesTransactionRepositories.php
@@ -17,6 +17,16 @@ trait ReconcilesTransactionRepositories
     use ReconcilesRepositories;
 
     /**
+     * The columns used for create and delete set operations.
+     *
+     * @return array
+     */
+    protected function columnsForCreateDelete(): array
+    {
+        return ['transaction_id', 'external_id', 'date', 'amount', 'service'];
+    }
+
+    /**
      * Callback for create and delete set operation item comparison.
      *
      * @return Closure

--- a/app/Concerns/Reconcile/ReconcilesRepositories.php
+++ b/app/Concerns/Reconcile/ReconcilesRepositories.php
@@ -187,13 +187,13 @@ trait ReconcilesRepositories
         try {
             $sourceModels = $source->all();
 
-            $destinationModels = $destination->all();
+            $destinationModels = $destination->all($this->columnsForCreateDelete());
 
             $this->createModelsFromSource($destination, $sourceModels, $destinationModels);
 
             $this->deleteModelsFromDestination($destination, $sourceModels, $destinationModels);
 
-            $destinationModels = $destination->all();
+            $destinationModels = $destination->all($this->columnsForUpdate());
 
             $this->updateDestinationModels($destination, $sourceModels, $destinationModels);
         } catch (Exception $exception) {
@@ -201,6 +201,16 @@ trait ReconcilesRepositories
         } finally {
             $this->postReconciliationTask();
         }
+    }
+
+    /**
+     * The columns used for create and delete set operations.
+     *
+     * @return array
+     */
+    protected function columnsForCreateDelete(): array
+    {
+        return ['*'];
     }
 
     /**
@@ -265,6 +275,16 @@ trait ReconcilesRepositories
                 $this->handleFailedDeletion($deleteModel);
             }
         }
+    }
+
+    /**
+     * The columns used for update set operation.
+     *
+     * @return array
+     */
+    protected function columnsForUpdate(): array
+    {
+        return ['*'];
     }
 
     /**

--- a/app/Concerns/Reconcile/Wiki/ReconcilesVideoRepositories.php
+++ b/app/Concerns/Reconcile/Wiki/ReconcilesVideoRepositories.php
@@ -18,6 +18,16 @@ trait ReconcilesVideoRepositories
     use ReconcilesRepositories;
 
     /**
+     * The columns used for create and delete set operations.
+     *
+     * @return array
+     */
+    protected function columnsForCreateDelete(): array
+    {
+        return ['video_id', 'basename'];
+    }
+
+    /**
      * Callback for create and delete set operation item comparison.
      *
      * @return Closure
@@ -25,6 +35,16 @@ trait ReconcilesVideoRepositories
     protected function diffCallbackForCreateDelete(): Closure
     {
         return fn (Video $first, Video $second) => $first->basename <=> $second->basename;
+    }
+
+    /**
+     * The columns used for update set operation.
+     *
+     * @return array
+     */
+    protected function columnsForUpdate(): array
+    {
+        return ['video_id', 'basename', 'path', 'size'];
     }
 
     /**

--- a/app/Contracts/Repositories/Repository.php
+++ b/app/Contracts/Repositories/Repository.php
@@ -15,9 +15,10 @@ interface Repository
     /**
      * Get all models from the repository.
      *
+     * @param array $columns
      * @return Collection
      */
-    public function all(): Collection;
+    public function all(array $columns = ['*']): Collection;
 
     /**
      * Save model to the repository.

--- a/app/Http/Controllers/WelcomeController.php
+++ b/app/Http/Controllers/WelcomeController.php
@@ -21,7 +21,7 @@ class WelcomeController extends Controller
     public function show(): View | Factory
     {
         return view('welcome', [
-            'announcements' => Announcement::all(),
+            'announcements' => Announcement::all(['content']),
         ]);
     }
 }

--- a/app/Http/Requests/TransparencyRequest.php
+++ b/app/Http/Requests/TransparencyRequest.php
@@ -123,6 +123,7 @@ class TransparencyRequest extends FormRequest
         }
 
         return Balance::query()
+            ->select(['service', 'frequency', 'usage', 'balance'])
             ->whereMonth('date', ComparisonOperator::EQ, $date)
             ->whereYear('date', ComparisonOperator::EQ, $date)
             ->orderBy('usage', 'desc')
@@ -143,6 +144,7 @@ class TransparencyRequest extends FormRequest
         }
 
         return Transaction::query()
+            ->select(['date', 'service', 'amount', 'description'])
             ->whereMonth('date', ComparisonOperator::EQ, $date)
             ->whereYear('date', ComparisonOperator::EQ, $date)
             ->orderBy('date', 'desc')

--- a/app/Models/Wiki/Video.php
+++ b/app/Models/Wiki/Video.php
@@ -194,7 +194,7 @@ class Video extends BaseModel implements Streamable, Viewable
      */
     public function getName(): string
     {
-        return $this->filename;
+        return $this->basename;
     }
 
     /**

--- a/app/Repositories/Eloquent/Billing/DigitalOceanBalanceRepository.php
+++ b/app/Repositories/Eloquent/Billing/DigitalOceanBalanceRepository.php
@@ -19,13 +19,15 @@ class DigitalOceanBalanceRepository extends EloquentRepository
     /**
      * Get all models from the repository.
      *
+     * @param array $columns
      * @return Collection
      */
-    public function all(): Collection
+    public function all(array $columns = ['*']): Collection
     {
         $now = Date::now();
 
         return Balance::query()
+            ->select($columns)
             ->where('service', Service::DIGITALOCEAN)
             ->whereMonth('date', ComparisonOperator::EQ, $now)
             ->whereYear('date', ComparisonOperator::EQ, $now)

--- a/app/Repositories/Eloquent/Billing/DigitalOceanTransactionRepository.php
+++ b/app/Repositories/Eloquent/Billing/DigitalOceanTransactionRepository.php
@@ -17,11 +17,13 @@ class DigitalOceanTransactionRepository extends EloquentRepository
     /**
      * Get all models from the repository.
      *
+     * @param array $columns
      * @return Collection
      */
-    public function all(): Collection
+    public function all(array $columns = ['*']): Collection
     {
         return Transaction::query()
+            ->select($columns)
             ->where('service', Service::DIGITALOCEAN)
             ->get();
     }

--- a/app/Repositories/Eloquent/Wiki/VideoRepository.php
+++ b/app/Repositories/Eloquent/Wiki/VideoRepository.php
@@ -16,10 +16,11 @@ class VideoRepository extends EloquentRepository
     /**
      * Get all models from the repository.
      *
+     * @param array $columns
      * @return Collection
      */
-    public function all(): Collection
+    public function all(array $columns = ['*']): Collection
     {
-        return Video::all();
+        return Video::all($columns);
     }
 }

--- a/app/Repositories/Service/DigitalOcean/Billing/DigitalOceanBalanceRepository.php
+++ b/app/Repositories/Service/DigitalOcean/Billing/DigitalOceanBalanceRepository.php
@@ -26,9 +26,10 @@ class DigitalOceanBalanceRepository implements Repository
     /**
      * Get all models from the repository.
      *
+     * @param array $columns
      * @return Collection
      */
-    public function all(): Collection
+    public function all(array $columns = ['*']): Collection
     {
         // Do not proceed if we do not have authorization to the DO API
         $doBearerToken = Config::get('services.do.token');

--- a/app/Repositories/Service/DigitalOcean/Billing/DigitalOceanTransactionRepository.php
+++ b/app/Repositories/Service/DigitalOcean/Billing/DigitalOceanTransactionRepository.php
@@ -26,9 +26,10 @@ class DigitalOceanTransactionRepository implements Repository
     /**
      * Get all models from the repository.
      *
+     * @param array $columns
      * @return Collection
      */
-    public function all(): Collection
+    public function all(array $columns = ['*']): Collection
     {
         // Do not proceed if we do not have authorization to the DO API
         $doBearerToken = Config::get('services.do.token');

--- a/app/Repositories/Service/DigitalOcean/VideoRepository.php
+++ b/app/Repositories/Service/DigitalOcean/VideoRepository.php
@@ -22,9 +22,10 @@ class VideoRepository implements Repository
     /**
      * Get all models from the repository.
      *
+     * @param array $columns
      * @return Collection
      */
-    public function all(): Collection
+    public function all(array $columns = ['*']): Collection
     {
         // Get metadata for all objects in storage
         $fs = Storage::disk('videos');

--- a/composer.lock
+++ b/composer.lock
@@ -64,16 +64,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.191.7",
+            "version": "3.191.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "c8f220112b64fbd089efead939d4fc70e794616c"
+                "reference": "67a1a0814a8e38c89d834d6cf9379752795c68fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/c8f220112b64fbd089efead939d4fc70e794616c",
-                "reference": "c8f220112b64fbd089efead939d4fc70e794616c",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/67a1a0814a8e38c89d834d6cf9379752795c68fe",
+                "reference": "67a1a0814a8e38c89d834d6cf9379752795c68fe",
                 "shasum": ""
             },
             "require": {
@@ -148,9 +148,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.191.7"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.191.9"
             },
-            "time": "2021-08-30T18:41:03+00:00"
+            "time": "2021-09-01T18:19:52+00:00"
         },
         {
             "name": "babenkoivan/elastic-adapter",
@@ -4052,16 +4052,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v8.57.0",
+            "version": "v8.58.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "6de01746680d7bc7e239b20ec5cdfe70ce586235"
+                "reference": "1b819bf99d87bd543a4d4895e5b3350f61ea7a23"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/6de01746680d7bc7e239b20ec5cdfe70ce586235",
-                "reference": "6de01746680d7bc7e239b20ec5cdfe70ce586235",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/1b819bf99d87bd543a4d4895e5b3350f61ea7a23",
+                "reference": "1b819bf99d87bd543a4d4895e5b3350f61ea7a23",
                 "shasum": ""
             },
             "require": {
@@ -4216,20 +4216,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2021-08-27T13:34:11+00:00"
+            "time": "2021-08-31T13:55:57+00:00"
         },
         {
             "name": "laravel/horizon",
-            "version": "v5.7.11",
+            "version": "v5.7.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/horizon.git",
-                "reference": "d0a7fd91f26e95b1b941b33af36a736b70a29505"
+                "reference": "98e2a6efac1a79ae08a9cce84bef32f236f6f800"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/horizon/zipball/d0a7fd91f26e95b1b941b33af36a736b70a29505",
-                "reference": "d0a7fd91f26e95b1b941b33af36a736b70a29505",
+                "url": "https://api.github.com/repos/laravel/horizon/zipball/98e2a6efac1a79ae08a9cce84bef32f236f6f800",
+                "reference": "98e2a6efac1a79ae08a9cce84bef32f236f6f800",
                 "shasum": ""
             },
             "require": {
@@ -4291,22 +4291,22 @@
             ],
             "support": {
                 "issues": "https://github.com/laravel/horizon/issues",
-                "source": "https://github.com/laravel/horizon/tree/v5.7.11"
+                "source": "https://github.com/laravel/horizon/tree/v5.7.12"
             },
-            "time": "2021-08-17T15:30:59+00:00"
+            "time": "2021-08-31T14:56:54+00:00"
         },
         {
             "name": "laravel/jetstream",
-            "version": "v2.3.15",
+            "version": "v2.3.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/jetstream.git",
-                "reference": "6318fc4a734ef894f38d0298f2dee42f7ee0e90c"
+                "reference": "c4bdd9939c18785a03627e7bab540c5acd588602"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/jetstream/zipball/6318fc4a734ef894f38d0298f2dee42f7ee0e90c",
-                "reference": "6318fc4a734ef894f38d0298f2dee42f7ee0e90c",
+                "url": "https://api.github.com/repos/laravel/jetstream/zipball/c4bdd9939c18785a03627e7bab540c5acd588602",
+                "reference": "c4bdd9939c18785a03627e7bab540c5acd588602",
                 "shasum": ""
             },
             "require": {
@@ -4359,7 +4359,7 @@
                 "issues": "https://github.com/laravel/jetstream/issues",
                 "source": "https://github.com/laravel/jetstream"
             },
-            "time": "2021-08-17T15:53:22+00:00"
+            "time": "2021-08-31T15:00:06+00:00"
         },
         {
             "name": "laravel/nova",
@@ -4522,16 +4522,16 @@
         },
         {
             "name": "laravel/scout",
-            "version": "v9.2.7",
+            "version": "v9.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/scout.git",
-                "reference": "0c2e25a431113cc0510ddc9680cdec6ef115be4e"
+                "reference": "0db23cc68de62b3b25b909c0d57b33c4ed585af4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/scout/zipball/0c2e25a431113cc0510ddc9680cdec6ef115be4e",
-                "reference": "0c2e25a431113cc0510ddc9680cdec6ef115be4e",
+                "url": "https://api.github.com/repos/laravel/scout/zipball/0db23cc68de62b3b25b909c0d57b33c4ed585af4",
+                "reference": "0db23cc68de62b3b25b909c0d57b33c4ed585af4",
                 "shasum": ""
             },
             "require": {
@@ -4545,7 +4545,7 @@
                 "php": "^7.3|^8.0"
             },
             "require-dev": {
-                "meilisearch/meilisearch-php": "^0.17",
+                "meilisearch/meilisearch-php": "^0.19",
                 "mockery/mockery": "^1.0",
                 "orchestra/testbench": "^6.17",
                 "phpunit/phpunit": "^9.3"
@@ -4590,7 +4590,7 @@
                 "issues": "https://github.com/laravel/scout/issues",
                 "source": "https://github.com/laravel/scout"
             },
-            "time": "2021-08-24T12:57:33+00:00"
+            "time": "2021-08-31T15:13:52+00:00"
         },
         {
             "name": "laravel/telescope",
@@ -6568,16 +6568,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.96",
+            "version": "0.12.97",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "a98bdc51318f20fcae8c953d266f81a70254917f"
+                "reference": "a8867e63a00e606589faf8d3613164f20722c4ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/a98bdc51318f20fcae8c953d266f81a70254917f",
-                "reference": "a98bdc51318f20fcae8c953d266f81a70254917f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/a8867e63a00e606589faf8d3613164f20722c4ee",
+                "reference": "a8867e63a00e606589faf8d3613164f20722c4ee",
                 "shasum": ""
             },
             "require": {
@@ -6608,7 +6608,7 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/0.12.96"
+                "source": "https://github.com/phpstan/phpstan/tree/0.12.97"
             },
             "funding": [
                 {
@@ -6628,7 +6628,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-08-21T11:55:13+00:00"
+            "time": "2021-09-01T10:51:52+00:00"
         },
         {
             "name": "pragmarx/google2fa",
@@ -11983,16 +11983,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.8",
+            "version": "9.5.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "191768ccd5c85513b4068bdbe99bb6390c7d54fb"
+                "reference": "ea8c2dfb1065eb35a79b3681eee6e6fb0a6f273b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/191768ccd5c85513b4068bdbe99bb6390c7d54fb",
-                "reference": "191768ccd5c85513b4068bdbe99bb6390c7d54fb",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/ea8c2dfb1065eb35a79b3681eee6e6fb0a6f273b",
+                "reference": "ea8c2dfb1065eb35a79b3681eee6e6fb0a6f273b",
                 "shasum": ""
             },
             "require": {
@@ -12070,7 +12070,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.8"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.9"
             },
             "funding": [
                 {
@@ -12082,7 +12082,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-07-31T15:17:34+00:00"
+            "time": "2021-08-31T06:47:40+00:00"
         },
         {
             "name": "predis/predis",

--- a/database/seeders/AniDbResourceSeeder.php
+++ b/database/seeders/AniDbResourceSeeder.php
@@ -29,6 +29,7 @@ class AniDbResourceSeeder extends Seeder
     {
         // Get anime that have MAL resource but do not have AniDB resource
         $animes = Anime::query()
+            ->select(['anime_id', 'name'])
             ->whereHas('resources', function (Builder $resourceQuery) {
                 $resourceQuery->where('site', ResourceSite::MAL);
             })->whereDoesntHave('resources', function (Builder $resourceQuery) {
@@ -61,6 +62,7 @@ class AniDbResourceSeeder extends Seeder
                     if ($anidbId !== null) {
                         // Check if AniDB resource already exists
                         $anidbResource = ExternalResource::query()
+                            ->select(['resource_id', 'link'])
                             ->where('site', ResourceSite::ANIDB)
                             ->where('external_id', $anidbId)
                             ->first();

--- a/database/seeders/AnilistAnimeResourceSeeder.php
+++ b/database/seeders/AnilistAnimeResourceSeeder.php
@@ -29,6 +29,7 @@ class AnilistAnimeResourceSeeder extends Seeder
     {
         // Get anime that have MAL resource but do not have Anilist resource
         $animes = Anime::query()
+            ->select(['anime_id', 'name'])
             ->whereHas('resources', function (Builder $resourceQuery) {
                 $resourceQuery->where('site', ResourceSite::MAL);
             })->whereDoesntHave('resources', function (Builder $resourceQuery) {
@@ -73,6 +74,7 @@ class AnilistAnimeResourceSeeder extends Seeder
 
                     // Check if Anilist resource already exists
                     $anilistResource = ExternalResource::query()
+                        ->select(['resource_id', 'link'])
                         ->where('site', ResourceSite::ANILIST)
                         ->where('external_id', $anilistId)
                         ->first();

--- a/database/seeders/AnilistArtistResourceSeeder.php
+++ b/database/seeders/AnilistArtistResourceSeeder.php
@@ -29,6 +29,7 @@ class AnilistArtistResourceSeeder extends Seeder
     {
         // Get artists that have MAL resource but do not have Anilist resource
         $artists = Artist::query()
+            ->select(['artist_id', 'name'])
             ->whereDoesntHave('resources', function (Builder $resourceQuery) {
                 $resourceQuery->where('site', ResourceSite::ANILIST);
             })
@@ -69,6 +70,7 @@ class AnilistArtistResourceSeeder extends Seeder
 
                 // Check if Anilist resource already exists
                 $anilistResource = ExternalResource::query()
+                    ->select(['resource_id', 'link'])
                     ->where('site', ResourceSite::ANILIST)
                     ->where('external_id', $anilistId)
                     ->first();

--- a/database/seeders/AnimeResourceSeeder.php
+++ b/database/seeders/AnimeResourceSeeder.php
@@ -50,6 +50,7 @@ class AnimeResourceSeeder extends Seeder
 
                 // Create Resource Model with link and derived site if it doesn't already exist
                 $resource = ExternalResource::query()
+                    ->select(['resource_id', 'site', 'link'])
                     ->where('site', ResourceSite::valueOf($resourceLink))
                     ->where('link', $resourceLink)
                     ->first();

--- a/database/seeders/AnimeSeasonSeeder.php
+++ b/database/seeders/AnimeSeasonSeeder.php
@@ -57,6 +57,7 @@ class AnimeSeasonSeeder extends Seeder
                         // Set season if we have a definitive match
                         // This is not guaranteed as an Anime Name may be inconsistent between indices
                         $matchingAnime = Anime::query()
+                            ->select(['anime_id', 'season', 'name'])
                             ->where('name', html_entity_decode($animeName[1]))
                             ->where('year', $year)
                             ->get();

--- a/database/seeders/AnimeThemeSeeder.php
+++ b/database/seeders/AnimeThemeSeeder.php
@@ -72,8 +72,10 @@ class AnimeThemeSeeder extends Seeder
                     try {
                         // Set current Anime if we have a definitive match
                         // This is not guaranteed as an Anime Name may be inconsistent between indices
-                        $matchingAnime = Anime::query()->where('name', html_entity_decode($animeName[1]));
-                        $matchingAnime = $matchingAnime->whereIn('year', $years);
+                        $matchingAnime = Anime::query()
+                            ->select(['anime_id', 'name'])
+                            ->where('name', html_entity_decode($animeName[1]))
+                            ->whereIn('year', $years);
                         if (is_int($season)) {
                             $matchingAnime = $matchingAnime->where('season', $season);
                         }
@@ -148,6 +150,7 @@ class AnimeThemeSeeder extends Seeder
                     if ($version === null || $version === 1) {
                         // Create Theme if it doesn't exist
                         $theme = AnimeTheme::query()
+                            ->select(['theme_id', 'sequence', 'slug'])
                             ->where('anime_id', $anime->anime_id)
                             ->where('group', $group)
                             ->where('type', $themeType)

--- a/database/seeders/ArtistCoverSeeder.php
+++ b/database/seeders/ArtistCoverSeeder.php
@@ -32,6 +32,7 @@ class ArtistCoverSeeder extends Seeder
     {
         // Get artists that have MAL resource but not both cover images
         $artists = Artist::query()
+            ->select(['artist_id', 'name'])
             ->whereHas('resources', function (Builder $resourceQuery) {
                 $resourceQuery->where('site', ResourceSite::ANILIST);
             })->whereDoesntHave('images', function (Builder $imageQuery) {

--- a/database/seeders/ArtistSeeder.php
+++ b/database/seeders/ArtistSeeder.php
@@ -43,7 +43,12 @@ class ArtistSeeder extends Seeder
             $artistSlug = html_entity_decode($artistWikiEntry[2]);
 
             // Create artist if it doesn't already exist
-            $artist = Artist::query()->where('name', $artistName)->where('slug', $artistSlug)->first();
+            $artist = Artist::query()
+                ->select(['artist_id', 'name'])
+                ->where('name', $artistName)
+                ->where('slug', $artistSlug)
+                ->first();
+
             if ($artist === null) {
                 Log::info("Creating artist with name '{$artistName}' and slug '{$artistSlug}'");
 
@@ -72,6 +77,7 @@ class ArtistSeeder extends Seeder
 
             // Create Resource Model with link and derived site
             $resource = ExternalResource::query()
+                ->select(['resource_id', 'link'])
                 ->where('site', $resourceSite)
                 ->where('link', $artistResourceLink)
                 ->first();

--- a/database/seeders/ArtistSongSeeder.php
+++ b/database/seeders/ArtistSongSeeder.php
@@ -82,7 +82,7 @@ class ArtistSongSeeder extends Seeder
                         // Set current Anime if we have a definitive match
                         // This is not guaranteed as an Anime Name may be inconsistent between indices
                         $matchingAnime = Anime::query()
-                            ->select(['anime_id'])
+                            ->select(['anime_id', 'name'])
                             ->where('name', html_entity_decode($animeName[1]));
 
                         if ($matchingAnime->count() === 1) {
@@ -106,7 +106,7 @@ class ArtistSongSeeder extends Seeder
 
                     if ($version === null || $version === 1) {
                         $matchingThemes = AnimeTheme::query()
-                            ->select(['theme_id'])
+                            ->select(['theme_id', 'slug'])
                             ->where('anime_id', $anime->anime_id)
                             ->where('type', $themeType)
                             ->where(function (Builder $query) use ($sequence) {

--- a/database/seeders/ArtistSongSeeder.php
+++ b/database/seeders/ArtistSongSeeder.php
@@ -46,7 +46,12 @@ class ArtistSongSeeder extends Seeder
             $artistName = html_entity_decode($artistWikiEntry[1]);
             $artistSlug = html_entity_decode($artistWikiEntry[2]);
 
-            $artist = Artist::query()->where('name', $artistName)->where('slug', $artistSlug)->first();
+            $artist = Artist::query()
+                ->select(['artist_id', 'name'])
+                ->where('name', $artistName)
+                ->where('slug', $artistSlug)
+                ->first();
+
             if (! $artist instanceof Artist) {
                 continue;
             }
@@ -76,7 +81,10 @@ class ArtistSongSeeder extends Seeder
                     try {
                         // Set current Anime if we have a definitive match
                         // This is not guaranteed as an Anime Name may be inconsistent between indices
-                        $matchingAnime = Anime::query()->where('name', html_entity_decode($animeName[1]));
+                        $matchingAnime = Anime::query()
+                            ->select(['anime_id'])
+                            ->where('name', html_entity_decode($animeName[1]));
+
                         if ($matchingAnime->count() === 1) {
                             $anime = $matchingAnime->first();
                             continue;
@@ -98,6 +106,7 @@ class ArtistSongSeeder extends Seeder
 
                     if ($version === null || $version === 1) {
                         $matchingThemes = AnimeTheme::query()
+                            ->select(['theme_id'])
                             ->where('anime_id', $anime->anime_id)
                             ->where('type', $themeType)
                             ->where(function (Builder $query) use ($sequence) {

--- a/database/seeders/KitsuResourceSeeder.php
+++ b/database/seeders/KitsuResourceSeeder.php
@@ -29,6 +29,7 @@ class KitsuResourceSeeder extends Seeder
     {
         // Get anime that have MAL resource but do not have Kitsu resource
         $animes = Anime::query()
+            ->select(['anime_id', 'name'])
             ->whereHas('resources', function (Builder $resourceQuery) {
                 $resourceQuery->where('site', ResourceSite::MAL);
             })->whereDoesntHave('resources', function (Builder $resourceQuery) {
@@ -70,6 +71,7 @@ class KitsuResourceSeeder extends Seeder
 
                         // Check if Kitsu resource already exists
                         $kitsuResource = ExternalResource::query()
+                            ->select(['resource_id', 'link'])
                             ->where('site', ResourceSite::KITSU)
                             ->where('external_id', $kitsuId)
                             ->first();

--- a/database/seeders/MalSeasonYearSeeder.php
+++ b/database/seeders/MalSeasonYearSeeder.php
@@ -49,6 +49,7 @@ class MalSeasonYearSeeder extends Seeder
 
         // Get anime that have MAL resource but do not have the season attribute set
         $animes = Anime::query()
+            ->select(['anime_id', 'name', 'year', 'season'])
             ->whereNull('season')
             ->whereHas('resources', function (Builder $resourceQuery) {
                 $resourceQuery->where('site', ResourceSite::MAL);

--- a/database/seeders/SeriesSeeder.php
+++ b/database/seeders/SeriesSeeder.php
@@ -42,7 +42,12 @@ class SeriesSeeder extends Seeder
             $seriesSlug = $seriesWikiEntry[2];
 
             // Create series if it doesn't already exist
-            $series = Series::query()->where('name', $seriesName)->where('slug', $seriesSlug)->first();
+            $series = Series::query()
+                ->select(['series_id', 'name'])
+                ->where('name', $seriesName)
+                ->where('slug', $seriesSlug)
+                ->first();
+
             if ($series === null) {
                 Log::info("Creating series with name '{$seriesName}' and slug '{$seriesSlug}'");
 
@@ -78,7 +83,11 @@ class SeriesSeeder extends Seeder
             // Attach Anime to Series by Name
             // Note: We are not concerned about Name collision here.
             // It's more likely that collisions occur within a series.
-            $animes = Anime::query()->whereIn('name', $seriesAnimeNames)->get();
+            $animes = Anime::query()
+                ->select(['anime_id', 'name'])
+                ->whereIn('name', $seriesAnimeNames)
+                ->get();
+
             foreach ($animes as $anime) {
                 if ($anime instanceof Anime
                     && AnimeSeries::query()

--- a/database/seeders/StudioSeeder.php
+++ b/database/seeders/StudioSeeder.php
@@ -48,6 +48,7 @@ class StudioSeeder extends Seeder
         }
 
         $animes = Anime::query()
+            ->select(['anime_id', 'name'])
             ->whereDoesntHave('studios')
             ->whereHas('resources', function (Builder $resourceQuery) {
                 $resourceQuery->where('site', ResourceSite::MAL);

--- a/database/seeders/SynopsisCoverSeeder.php
+++ b/database/seeders/SynopsisCoverSeeder.php
@@ -32,6 +32,7 @@ class SynopsisCoverSeeder extends Seeder
     {
         // Get anime that have MAL resource but not both cover images
         $animes = Anime::query()
+            ->select(['anime_id', 'name', 'synopsis'])
             ->whereHas('resources', function (Builder $resourceQuery) {
                 $resourceQuery->where('site', ResourceSite::ANILIST);
             })->whereDoesntHave('images', function (Builder $imageQuery) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,13 +14,13 @@
                 "alpinejs": "^3.2.4",
                 "axios": "^0.21.1",
                 "cross-env": "^7.0.3",
-                "laravel-mix": "^6.0.28",
+                "laravel-mix": "^6.0.29",
                 "lodash": "^4.17.21",
                 "postcss-import": "^14.0.2",
                 "resolve-url-loader": "^4.0.0",
                 "sass": "^1.38.2",
                 "sass-loader": "^12.1.0",
-                "tailwindcss": "^2.2.8",
+                "tailwindcss": "^2.2.9",
                 "vue-template-compiler": "^2.6.14"
             }
         },
@@ -1918,9 +1918,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "16.7.8",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.8.tgz",
-            "integrity": "sha512-8upnoQU0OPzbIkm+ZMM0zCeFCkw2s3mS0IWdx0+AAaWqm4fkBb0UJp8Edl7FVKRamYbpJC/aVsHpKWBIbiC7Zg==",
+            "version": "16.7.10",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.10.tgz",
+            "integrity": "sha512-S63Dlv4zIPb8x6MMTgDq5WWRJQe56iBEY0O3SOFA9JrRienkOVDXSXBjjJw6HTNQYSE2JI6GMCR6LVbIMHJVvA==",
             "dev": true
         },
         "node_modules/@types/parse-json": {
@@ -3278,9 +3278,9 @@
             "dev": true
         },
         "node_modules/core-js-compat": {
-            "version": "3.16.4",
-            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.16.4.tgz",
-            "integrity": "sha512-IzCSomxRdahCYb6G3HiN6pl3JCiM0NMunRcNa1pIeC7g17Vd6Ue3AT9anQiENPIm/svThUVer1pIbLMDERIsFw==",
+            "version": "3.17.1",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.17.1.tgz",
+            "integrity": "sha512-Oqp6qybMdCFcWSroh/6Q8j7YNOjRD0ThY02cAd6rugr//FCkMYonizLV8AryLU5wNJOweauIBxQYCZoV3emfcw==",
             "dev": true,
             "dependencies": {
                 "browserslist": "^4.16.8",
@@ -3301,9 +3301,9 @@
             }
         },
         "node_modules/core-util-is": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
             "dev": true
         },
         "node_modules/cosmiconfig": {
@@ -4046,9 +4046,9 @@
             "dev": true
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.3.824",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.824.tgz",
-            "integrity": "sha512-Fk+5aD0HDi9i9ZKt9n2VPOZO1dQy7PV++hz2wJ/KIn+CvVfu4fny39squHtyVDPuHNuoJGAZIbuReEklqYIqfA==",
+            "version": "1.3.826",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.826.tgz",
+            "integrity": "sha512-bpLc4QU4B8PYmdO4MSu2ZBTMD8lAaEXRS43C09lB31BvYwuk9UxgBRXbY5OJBw7VuMGcg2MZG5FyTaP9u4PQnw==",
             "dev": true
         },
         "node_modules/elliptic": {
@@ -6066,9 +6066,9 @@
             }
         },
         "node_modules/memfs": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.2.2.tgz",
-            "integrity": "sha512-RE0CwmIM3CEvpcdK3rZ19BC4E6hv9kADkMN5rPduRak58cNArWLi/9jFLsa4rhsjfVxMP3v0jO7FHXq7SvFY5Q==",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.2.3.tgz",
+            "integrity": "sha512-vDKa1icg0KDNzcOPBPAduFFb3YL+pLbQ/3hW7rRgUKpoliTAkPmVV7r/3qJ6YqKyIXEDhzsdSvLlEh137AfWUA==",
             "dev": true,
             "dependencies": {
                 "fs-monkey": "1.0.3"
@@ -8952,17 +8952,17 @@
             }
         },
         "node_modules/terser-webpack-plugin": {
-            "version": "5.1.4",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.1.4.tgz",
-            "integrity": "sha512-C2WkFwstHDhVEmsmlCxrXUtVklS+Ir1A7twrYzrDrQQOIMOaVAYykaoo/Aq1K0QRkMoY2hhvDQY1cm4jnIMFwA==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.2.0.tgz",
+            "integrity": "sha512-FpR4Qe0Yt4knSQ5u2bA1wkM0R8VlVsvhyfSHvomXRivS4vPLk0dJV2IhRBIHRABh7AFutdMeElIA5y1dETwMBg==",
             "dev": true,
             "dependencies": {
-                "jest-worker": "^27.0.2",
+                "jest-worker": "^27.0.6",
                 "p-limit": "^3.1.0",
-                "schema-utils": "^3.0.0",
+                "schema-utils": "^3.1.1",
                 "serialize-javascript": "^6.0.0",
                 "source-map": "^0.6.1",
-                "terser": "^5.7.0"
+                "terser": "^5.7.2"
             },
             "engines": {
                 "node": ">= 10.13.0"
@@ -8973,6 +8973,17 @@
             },
             "peerDependencies": {
                 "webpack": "^5.1.0"
+            },
+            "peerDependenciesMeta": {
+                "@swc/core": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "uglify-js": {
+                    "optional": true
+                }
             }
         },
         "node_modules/terser-webpack-plugin/node_modules/p-limit": {
@@ -11242,9 +11253,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "16.7.8",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.8.tgz",
-            "integrity": "sha512-8upnoQU0OPzbIkm+ZMM0zCeFCkw2s3mS0IWdx0+AAaWqm4fkBb0UJp8Edl7FVKRamYbpJC/aVsHpKWBIbiC7Zg==",
+            "version": "16.7.10",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.10.tgz",
+            "integrity": "sha512-S63Dlv4zIPb8x6MMTgDq5WWRJQe56iBEY0O3SOFA9JrRienkOVDXSXBjjJw6HTNQYSE2JI6GMCR6LVbIMHJVvA==",
             "dev": true
         },
         "@types/parse-json": {
@@ -12382,9 +12393,9 @@
             "dev": true
         },
         "core-js-compat": {
-            "version": "3.16.4",
-            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.16.4.tgz",
-            "integrity": "sha512-IzCSomxRdahCYb6G3HiN6pl3JCiM0NMunRcNa1pIeC7g17Vd6Ue3AT9anQiENPIm/svThUVer1pIbLMDERIsFw==",
+            "version": "3.17.1",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.17.1.tgz",
+            "integrity": "sha512-Oqp6qybMdCFcWSroh/6Q8j7YNOjRD0ThY02cAd6rugr//FCkMYonizLV8AryLU5wNJOweauIBxQYCZoV3emfcw==",
             "dev": true,
             "requires": {
                 "browserslist": "^4.16.8",
@@ -12400,9 +12411,9 @@
             }
         },
         "core-util-is": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
             "dev": true
         },
         "cosmiconfig": {
@@ -12979,9 +12990,9 @@
             "dev": true
         },
         "electron-to-chromium": {
-            "version": "1.3.824",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.824.tgz",
-            "integrity": "sha512-Fk+5aD0HDi9i9ZKt9n2VPOZO1dQy7PV++hz2wJ/KIn+CvVfu4fny39squHtyVDPuHNuoJGAZIbuReEklqYIqfA==",
+            "version": "1.3.826",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.826.tgz",
+            "integrity": "sha512-bpLc4QU4B8PYmdO4MSu2ZBTMD8lAaEXRS43C09lB31BvYwuk9UxgBRXbY5OJBw7VuMGcg2MZG5FyTaP9u4PQnw==",
             "dev": true
         },
         "elliptic": {
@@ -14522,9 +14533,9 @@
             }
         },
         "memfs": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.2.2.tgz",
-            "integrity": "sha512-RE0CwmIM3CEvpcdK3rZ19BC4E6hv9kADkMN5rPduRak58cNArWLi/9jFLsa4rhsjfVxMP3v0jO7FHXq7SvFY5Q==",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.2.3.tgz",
+            "integrity": "sha512-vDKa1icg0KDNzcOPBPAduFFb3YL+pLbQ/3hW7rRgUKpoliTAkPmVV7r/3qJ6YqKyIXEDhzsdSvLlEh137AfWUA==",
             "dev": true,
             "requires": {
                 "fs-monkey": "1.0.3"
@@ -16666,17 +16677,17 @@
             }
         },
         "terser-webpack-plugin": {
-            "version": "5.1.4",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.1.4.tgz",
-            "integrity": "sha512-C2WkFwstHDhVEmsmlCxrXUtVklS+Ir1A7twrYzrDrQQOIMOaVAYykaoo/Aq1K0QRkMoY2hhvDQY1cm4jnIMFwA==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.2.0.tgz",
+            "integrity": "sha512-FpR4Qe0Yt4knSQ5u2bA1wkM0R8VlVsvhyfSHvomXRivS4vPLk0dJV2IhRBIHRABh7AFutdMeElIA5y1dETwMBg==",
             "dev": true,
             "requires": {
-                "jest-worker": "^27.0.2",
+                "jest-worker": "^27.0.6",
                 "p-limit": "^3.1.0",
-                "schema-utils": "^3.0.0",
+                "schema-utils": "^3.1.1",
                 "serialize-javascript": "^6.0.0",
                 "source-map": "^0.6.1",
-                "terser": "^5.7.0"
+                "terser": "^5.7.2"
             },
             "dependencies": {
                 "p-limit": {

--- a/package.json
+++ b/package.json
@@ -13,13 +13,13 @@
         "alpinejs": "^3.2.4",
         "axios": "^0.21.1",
         "cross-env": "^7.0.3",
-        "laravel-mix": "^6.0.28",
+        "laravel-mix": "^6.0.29",
         "lodash": "^4.17.21",
         "postcss-import": "^14.0.2",
         "resolve-url-loader": "^4.0.0",
         "sass": "^1.38.2",
         "sass-loader": "^12.1.0",
-        "tailwindcss": "^2.2.8",
+        "tailwindcss": "^2.2.9",
         "vue-template-compiler": "^2.6.14"
     },
     "dependencies": {


### PR DESCRIPTION
Addressing an item taken from a laravel clean coding shortlist: we don't need to load all attributes into memory, especially for processes like reconciliation where we are working with datasets on the order of 15,000 objects. This was removed from reconciliation in an earlier refactor, but did have a nontrivial impact on the performance of the command.

For other processes like seeding and the transparency page, this may not have a great impact, but IMO this is good practice that should be observed.

I would like to do this for API queries as well, but at this point I believe better validation for the API is a prerequisite.

Arguably we should take this a step further for reconciliation and chunk the destination repository, but that is work for another day.