### PR TITLE
fix(admin): check feature flags before handling jobs or notifications

### DIFF
--- a/app/Events/Wiki/Anime/AnimeCreated.php
+++ b/app/Events/Wiki/Anime/AnimeCreated.php
@@ -7,6 +7,7 @@ namespace App\Events\Wiki\Anime;
 use App\Contracts\Events\DiscordMessageEvent;
 use App\Contracts\Events\UpdateRelatedIndicesEvent;
 use App\Enums\Services\Discord\EmbedColor;
+use App\Models\Wiki\Anime;
 use App\Models\Wiki\Anime\AnimeTheme;
 use App\Models\Wiki\Anime\Theme\AnimeThemeEntry;
 use App\Models\Wiki\Video;
@@ -55,7 +56,7 @@ class AnimeCreated extends AnimeEvent implements DiscordMessageEvent, UpdateRela
      */
     public function updateRelatedIndices()
     {
-        $anime = $this->getAnime()->load('animethemes.animethemeentries.videos');
+        $anime = $this->getAnime()->load(Anime::RELATION_VIDEOS);
 
         $anime->animethemes->each(function (AnimeTheme $theme) {
             $theme->searchable();

--- a/app/Events/Wiki/Anime/AnimeDeleting.php
+++ b/app/Events/Wiki/Anime/AnimeDeleting.php
@@ -6,6 +6,7 @@ namespace App\Events\Wiki\Anime;
 
 use App\Contracts\Events\CascadesDeletesEvent;
 use App\Events\Wiki\Anime\Theme\ThemeDeleting;
+use App\Models\Wiki\Anime;
 use App\Models\Wiki\Anime\AnimeSynonym;
 use App\Models\Wiki\Anime\AnimeTheme;
 use Illuminate\Support\Facades\Event;
@@ -22,7 +23,7 @@ class AnimeDeleting extends AnimeEvent implements CascadesDeletesEvent
      */
     public function cascadeDeletes()
     {
-        $anime = $this->getAnime()->load(['animesynonyms', 'animethemes.animethemeentries.videos']);
+        $anime = $this->getAnime()->load([Anime::RELATION_SYNONYMS, Anime::RELATION_VIDEOS]);
 
         $anime->animesynonyms->each(function (AnimeSynonym $synonym) {
             AnimeSynonym::withoutEvents(function () use ($synonym) {

--- a/app/Events/Wiki/Anime/AnimeUpdated.php
+++ b/app/Events/Wiki/Anime/AnimeUpdated.php
@@ -69,7 +69,7 @@ class AnimeUpdated extends AnimeEvent implements DiscordMessageEvent, UpdateRela
      */
     public function updateRelatedIndices()
     {
-        $anime = $this->getAnime()->load('animethemes.animethemeentries.videos');
+        $anime = $this->getAnime()->load(Anime::RELATION_VIDEOS);
 
         $anime->animethemes->each(function (AnimeTheme $theme) {
             $theme->searchable();

--- a/app/Events/Wiki/Anime/Synonym/SynonymCreated.php
+++ b/app/Events/Wiki/Anime/Synonym/SynonymCreated.php
@@ -7,6 +7,7 @@ namespace App\Events\Wiki\Anime\Synonym;
 use App\Contracts\Events\DiscordMessageEvent;
 use App\Contracts\Events\UpdateRelatedIndicesEvent;
 use App\Enums\Services\Discord\EmbedColor;
+use App\Models\Wiki\Anime\AnimeSynonym;
 use App\Models\Wiki\Anime\AnimeTheme;
 use App\Models\Wiki\Anime\Theme\AnimeThemeEntry;
 use App\Models\Wiki\Video;
@@ -56,7 +57,7 @@ class SynonymCreated extends SynonymEvent implements DiscordMessageEvent, Update
      */
     public function updateRelatedIndices()
     {
-        $synonym = $this->getSynonym()->load('anime.animethemes.animethemeentries.videos');
+        $synonym = $this->getSynonym()->load(AnimeSynonym::RELATION_VIDEOS);
 
         $synonym->anime->searchable();
         $synonym->anime->animethemes->each(function (AnimeTheme $theme) {

--- a/app/Events/Wiki/Anime/Synonym/SynonymDeleted.php
+++ b/app/Events/Wiki/Anime/Synonym/SynonymDeleted.php
@@ -7,6 +7,7 @@ namespace App\Events\Wiki\Anime\Synonym;
 use App\Contracts\Events\DiscordMessageEvent;
 use App\Contracts\Events\UpdateRelatedIndicesEvent;
 use App\Enums\Services\Discord\EmbedColor;
+use App\Models\Wiki\Anime;
 use App\Models\Wiki\Anime\AnimeTheme;
 use App\Models\Wiki\Anime\Theme\AnimeThemeEntry;
 use App\Models\Wiki\Video;
@@ -54,7 +55,7 @@ class SynonymDeleted extends SynonymEvent implements DiscordMessageEvent, Update
      */
     public function updateRelatedIndices()
     {
-        $anime = $this->getAnime()->load('animethemes.animethemeentries.videos');
+        $anime = $this->getAnime()->load(Anime::RELATION_VIDEOS);
 
         $anime->searchable();
         $anime->animethemes->each(function (AnimeTheme $theme) {

--- a/app/Events/Wiki/Anime/Synonym/SynonymRestored.php
+++ b/app/Events/Wiki/Anime/Synonym/SynonymRestored.php
@@ -7,6 +7,7 @@ namespace App\Events\Wiki\Anime\Synonym;
 use App\Contracts\Events\DiscordMessageEvent;
 use App\Contracts\Events\UpdateRelatedIndicesEvent;
 use App\Enums\Services\Discord\EmbedColor;
+use App\Models\Wiki\Anime\AnimeSynonym;
 use App\Models\Wiki\Anime\AnimeTheme;
 use App\Models\Wiki\Anime\Theme\AnimeThemeEntry;
 use App\Models\Wiki\Video;
@@ -56,7 +57,7 @@ class SynonymRestored extends SynonymEvent implements DiscordMessageEvent, Updat
      */
     public function updateRelatedIndices()
     {
-        $synonym = $this->getSynonym()->load('anime.animethemes.animethemeentries.videos');
+        $synonym = $this->getSynonym()->load(AnimeSynonym::RELATION_VIDEOS);
 
         $synonym->anime->searchable();
         $synonym->anime->animethemes->each(function (AnimeTheme $theme) {

--- a/app/Events/Wiki/Anime/Synonym/SynonymUpdated.php
+++ b/app/Events/Wiki/Anime/Synonym/SynonymUpdated.php
@@ -70,7 +70,7 @@ class SynonymUpdated extends SynonymEvent implements DiscordMessageEvent, Update
      */
     public function updateRelatedIndices()
     {
-        $synonym = $this->getSynonym()->load('anime.animethemes.animethemeentries.videos');
+        $synonym = $this->getSynonym()->load(AnimeSynonym::RELATION_VIDEOS);
 
         $synonym->anime->searchable();
         $synonym->anime->animethemes->each(function (AnimeTheme $theme) {

--- a/app/Events/Wiki/Anime/Theme/ThemeCreated.php
+++ b/app/Events/Wiki/Anime/Theme/ThemeCreated.php
@@ -7,6 +7,7 @@ namespace App\Events\Wiki\Anime\Theme;
 use App\Contracts\Events\DiscordMessageEvent;
 use App\Contracts\Events\UpdateRelatedIndicesEvent;
 use App\Enums\Services\Discord\EmbedColor;
+use App\Models\Wiki\Anime\AnimeTheme;
 use App\Models\Wiki\Anime\Theme\AnimeThemeEntry;
 use App\Models\Wiki\Video;
 use Illuminate\Foundation\Events\Dispatchable;
@@ -55,7 +56,7 @@ class ThemeCreated extends ThemeEvent implements DiscordMessageEvent, UpdateRela
      */
     public function updateRelatedIndices()
     {
-        $theme = $this->getTheme()->load('animethemeentries.videos');
+        $theme = $this->getTheme()->load(AnimeTheme::RELATION_VIDEOS);
 
         $theme->animethemeentries->each(function (AnimeThemeEntry $entry) {
             $entry->searchable();

--- a/app/Events/Wiki/Anime/Theme/ThemeDeleting.php
+++ b/app/Events/Wiki/Anime/Theme/ThemeDeleting.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Events\Wiki\Anime\Theme;
 
 use App\Contracts\Events\CascadesDeletesEvent;
+use App\Models\Wiki\Anime\AnimeTheme;
 use App\Models\Wiki\Anime\Theme\AnimeThemeEntry;
 use App\Models\Wiki\Video;
 
@@ -20,7 +21,7 @@ class ThemeDeleting extends ThemeEvent implements CascadesDeletesEvent
      */
     public function cascadeDeletes()
     {
-        $theme = $this->getTheme()->load('animethemeentries.videos');
+        $theme = $this->getTheme()->load(AnimeTheme::RELATION_VIDEOS);
 
         $theme->animethemeentries->each(function (AnimeThemeEntry $entry) {
             AnimeThemeEntry::withoutEvents(function () use ($entry) {

--- a/app/Events/Wiki/Anime/Theme/ThemeUpdated.php
+++ b/app/Events/Wiki/Anime/Theme/ThemeUpdated.php
@@ -69,7 +69,7 @@ class ThemeUpdated extends ThemeEvent implements DiscordMessageEvent, UpdateRela
      */
     public function updateRelatedIndices()
     {
-        $theme = $this->getTheme()->load('animethemeentries.videos');
+        $theme = $this->getTheme()->load(AnimeTheme::RELATION_VIDEOS);
 
         $theme->animethemeentries->each(function (AnimeThemeEntry $entry) {
             $entry->searchable();

--- a/app/Events/Wiki/Song/SongCreated.php
+++ b/app/Events/Wiki/Song/SongCreated.php
@@ -10,6 +10,7 @@ use App\Enums\Services\Discord\EmbedColor;
 use App\Models\Wiki\Anime\AnimeTheme;
 use App\Models\Wiki\Anime\Theme\AnimeThemeEntry;
 use App\Models\Wiki\Artist;
+use App\Models\Wiki\Song;
 use App\Models\Wiki\Video;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
@@ -56,7 +57,7 @@ class SongCreated extends SongEvent implements DiscordMessageEvent, UpdateRelate
      */
     public function updateRelatedIndices()
     {
-        $song = $this->getSong()->load(['artists', 'animethemes.animethemeentries.videos']);
+        $song = $this->getSong()->load([Song::RELATION_ARTISTS, Song::RELATION_VIDEOS]);
 
         $song->artists->each(fn (Artist $artist) => $artist->searchable());
 

--- a/app/Events/Wiki/Song/SongDeleted.php
+++ b/app/Events/Wiki/Song/SongDeleted.php
@@ -10,6 +10,7 @@ use App\Enums\Services\Discord\EmbedColor;
 use App\Models\Wiki\Anime\AnimeTheme;
 use App\Models\Wiki\Anime\Theme\AnimeThemeEntry;
 use App\Models\Wiki\Artist;
+use App\Models\Wiki\Song;
 use App\Models\Wiki\Video;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Support\Facades\Config;
@@ -54,7 +55,7 @@ class SongDeleted extends SongEvent implements DiscordMessageEvent, UpdateRelate
      */
     public function updateRelatedIndices()
     {
-        $song = $this->getSong()->load(['artists', 'animethemes.animethemeentries.videos']);
+        $song = $this->getSong()->load([Song::RELATION_ARTISTS, Song::RELATION_VIDEOS]);
 
         $artists = $song->artists;
         $artists->each(fn (Artist $artist) => $artist->searchable());

--- a/app/Events/Wiki/Song/SongDeleting.php
+++ b/app/Events/Wiki/Song/SongDeleting.php
@@ -8,6 +8,7 @@ use App\Contracts\Events\UpdateRelatedIndicesEvent;
 use App\Models\Wiki\Anime\AnimeTheme;
 use App\Models\Wiki\Anime\Theme\AnimeThemeEntry;
 use App\Models\Wiki\Artist;
+use App\Models\Wiki\Song;
 use App\Models\Wiki\Video;
 
 /**
@@ -22,7 +23,7 @@ class SongDeleting extends SongEvent implements UpdateRelatedIndicesEvent
      */
     public function updateRelatedIndices()
     {
-        $song = $this->getSong()->load(['artists', 'animethemes.animethemeentries.videos']);
+        $song = $this->getSong()->load([Song::RELATION_ARTISTS, Song::RELATION_VIDEOS]);
 
         if ($song->isForceDeleting()) {
             // refresh artist documents by detaching song

--- a/app/Events/Wiki/Song/SongRestored.php
+++ b/app/Events/Wiki/Song/SongRestored.php
@@ -10,6 +10,7 @@ use App\Enums\Services\Discord\EmbedColor;
 use App\Models\Wiki\Anime\AnimeTheme;
 use App\Models\Wiki\Anime\Theme\AnimeThemeEntry;
 use App\Models\Wiki\Artist;
+use App\Models\Wiki\Song;
 use App\Models\Wiki\Video;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Support\Facades\Config;
@@ -54,7 +55,7 @@ class SongRestored extends SongEvent implements DiscordMessageEvent, UpdateRelat
      */
     public function updateRelatedIndices()
     {
-        $song = $this->getSong()->load(['artists', 'animethemes.animethemeentries.videos']);
+        $song = $this->getSong()->load([Song::RELATION_ARTISTS, Song::RELATION_VIDEOS]);
 
         // refresh artist documents by detaching song
         $artists = $song->artists;

--- a/app/Events/Wiki/Song/SongUpdated.php
+++ b/app/Events/Wiki/Song/SongUpdated.php
@@ -70,7 +70,7 @@ class SongUpdated extends SongEvent implements DiscordMessageEvent, UpdateRelate
      */
     public function updateRelatedIndices()
     {
-        $song = $this->getSong()->load(['artists', 'animethemes.animethemeentries.videos']);
+        $song = $this->getSong()->load([Song::RELATION_ARTISTS, Song::RELATION_VIDEOS]);
 
         $song->artists->each(fn (Artist $artist) => $artist->searchable());
 

--- a/app/Jobs/SendDiscordNotificationJob.php
+++ b/app/Jobs/SendDiscordNotificationJob.php
@@ -13,6 +13,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Notification;
 
 /**
@@ -50,8 +51,10 @@ class SendDiscordNotificationJob implements ShouldQueue
      */
     public function handle()
     {
-        Notification::route('discord', $this->event->getDiscordChannel())
-            ->notify(new DiscordNotification($this->event->getDiscordMessage()));
+        if (Config::get('flags.allow_discord_notifications', false)) {
+            Notification::route('discord', $this->event->getDiscordChannel())
+                ->notify(new DiscordNotification($this->event->getDiscordMessage()));
+        }
     }
 
     /**

--- a/app/Models/Wiki/Anime/AnimeSynonym.php
+++ b/app/Models/Wiki/Anime/AnimeSynonym.php
@@ -36,6 +36,7 @@ class AnimeSynonym extends BaseModel
     public const ATTRIBUTE_TEXT = 'text';
 
     public const RELATION_ANIME = 'anime';
+    public const RELATION_VIDEOS = 'anime.animethemes.animethemeentries.videos';
 
     /**
      * The attributes that are mass assignable.

--- a/app/Models/Wiki/Song.php
+++ b/app/Models/Wiki/Song.php
@@ -43,6 +43,7 @@ class Song extends BaseModel
     public const RELATION_ANIME = 'animethemes.anime';
     public const RELATION_ANIMETHEMES = 'animethemes';
     public const RELATION_ARTISTS = 'artists';
+    public const RELATION_VIDEOS = 'animethemes.animethemeentries.videos';
 
     /**
      * The attributes that are mass assignable.

--- a/app/Notifications/DiscordNotification.php
+++ b/app/Notifications/DiscordNotification.php
@@ -7,6 +7,7 @@ namespace App\Notifications;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Notification;
+use Illuminate\Support\Facades\Config;
 use NotificationChannels\Discord\DiscordChannel;
 use NotificationChannels\Discord\DiscordMessage;
 
@@ -59,5 +60,19 @@ class DiscordNotification extends Notification implements ShouldQueue
     public function toDiscord(mixed $notifiable): DiscordMessage
     {
         return $this->message;
+    }
+
+    /**
+     * Determines if the notification can be sent.
+     *
+     * @param mixed $notifiable
+     * @param string $channel
+     * @return mixed
+     *
+     * @noinspection PhpUnusedParameterInspection
+     */
+    public function shouldSend(mixed $notifiable, string $channel): mixed
+    {
+        return Config::get('flags.allow_discord_notifications', false);
     }
 }

--- a/app/Notifications/DiscordNotification.php
+++ b/app/Notifications/DiscordNotification.php
@@ -65,8 +65,8 @@ class DiscordNotification extends Notification implements ShouldQueue
     /**
      * Determines if the notification can be sent.
      *
-     * @param mixed $notifiable
-     * @param string $channel
+     * @param  mixed  $notifiable
+     * @param  string  $channel
      * @return mixed
      *
      * @noinspection PhpUnusedParameterInspection

--- a/composer.lock
+++ b/composer.lock
@@ -114,16 +114,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.204.5",
+            "version": "3.204.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "1f690db4dfd66d0c729f4f8db12431bb047b4900"
+                "reference": "59d4d6a58ed7da541aa0ed75cc1944f8d6ca2d1c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/1f690db4dfd66d0c729f4f8db12431bb047b4900",
-                "reference": "1f690db4dfd66d0c729f4f8db12431bb047b4900",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/59d4d6a58ed7da541aa0ed75cc1944f8d6ca2d1c",
+                "reference": "59d4d6a58ed7da541aa0ed75cc1944f8d6ca2d1c",
                 "shasum": ""
             },
             "require": {
@@ -199,9 +199,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.204.5"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.204.6"
             },
-            "time": "2021-11-24T19:13:34+00:00"
+            "time": "2021-11-26T19:18:52+00:00"
         },
         {
             "name": "babenkoivan/elastic-adapter",
@@ -1883,16 +1883,16 @@
         },
         {
             "name": "doctrine/dbal",
-            "version": "2.13.5",
+            "version": "2.13.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "d92ddb260547c2a7b650ff140f744eb6f395d8fc"
+                "reference": "67ef6d0327ccbab1202b39e0222977a47ed3ef2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/d92ddb260547c2a7b650ff140f744eb6f395d8fc",
-                "reference": "d92ddb260547c2a7b650ff140f744eb6f395d8fc",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/67ef6d0327ccbab1202b39e0222977a47ed3ef2f",
+                "reference": "67ef6d0327ccbab1202b39e0222977a47ed3ef2f",
                 "shasum": ""
             },
             "require": {
@@ -1905,13 +1905,13 @@
             "require-dev": {
                 "doctrine/coding-standard": "9.0.0",
                 "jetbrains/phpstorm-stubs": "2021.1",
-                "phpstan/phpstan": "1.1.1",
+                "phpstan/phpstan": "1.2.0",
                 "phpunit/phpunit": "^7.5.20|^8.5|9.5.10",
                 "psalm/plugin-phpunit": "0.16.1",
                 "squizlabs/php_codesniffer": "3.6.1",
                 "symfony/cache": "^4.4",
                 "symfony/console": "^2.0.5|^3.0|^4.0|^5.0",
-                "vimeo/psalm": "4.12.0"
+                "vimeo/psalm": "4.13.0"
             },
             "suggest": {
                 "symfony/console": "For helpful console commands such as SQL execution and import of files."
@@ -1972,7 +1972,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/dbal/issues",
-                "source": "https://github.com/doctrine/dbal/tree/2.13.5"
+                "source": "https://github.com/doctrine/dbal/tree/2.13.6"
             },
             "funding": [
                 {
@@ -1988,7 +1988,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-11T16:27:36+00:00"
+            "time": "2021-11-26T20:11:05+00:00"
         },
         {
             "name": "doctrine/deprecations",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3079,13 +3079,13 @@
             "dev": true
         },
         "node_modules/color": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/color/-/color-4.0.1.tgz",
-            "integrity": "sha512-rpZjOKN5O7naJxkH2Rx1sZzzBgaiWECc6BYXjeCE6kF0kcASJYbUq02u7JqIHwCb/j3NhV+QhRL2683aICeGZA==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/color/-/color-4.0.2.tgz",
+            "integrity": "sha512-fSu0jW2aKQG2FHlDywqdFPdabJHsUdZ0xabSt3wFZdcgRKtLnUHs19nUtuFuLGVMFhINGgfZEIjbUOsGZXGu7Q==",
             "dev": true,
             "dependencies": {
                 "color-convert": "^2.0.1",
-                "color-string": "^1.6.0"
+                "color-string": "^1.7.4"
             }
         },
         "node_modules/color-convert": {
@@ -3107,9 +3107,9 @@
             "dev": true
         },
         "node_modules/color-string": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.6.0.tgz",
-            "integrity": "sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==",
+            "version": "1.7.4",
+            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.7.4.tgz",
+            "integrity": "sha512-nVdUvPVgZMpRQad5dcsCMOSB5BXLljklTiaxS6ehhKxDsAI5sD7k5VmFuBt1y3Rlym8uulc/ANUN/bMWtBu6Sg==",
             "dev": true,
             "dependencies": {
                 "color-name": "^1.0.0",
@@ -4051,9 +4051,9 @@
             "dev": true
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.3.tgz",
-            "integrity": "sha512-hfpppjYhqIZB8jrNb0rNceQRkSnBN7QJl3W26O1jUv3F3BkQknqy1YTqVXkFnIcFtBc3Qnv5M7r5Lez2iOLgZA==",
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.4.tgz",
+            "integrity": "sha512-teHtgwcmVcL46jlFvAaqjyiTLWuMrUQO1JqV303JKB4ysXG6m8fXSFhbjal9st0r9mNskI22AraJZorb1VcLVg==",
             "dev": true
         },
         "node_modules/elliptic": {
@@ -5116,9 +5116,9 @@
             "dev": true
         },
         "node_modules/http-parser-js": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.3.tgz",
-            "integrity": "sha512-t7hjvef/5HEK7RWTdUzVUhl8zkEu+LlaE0IYzdMuvbSDipxBRpOn4Uhw8ZyECEa808iVT8XCjzo6xmYt4CiLZg==",
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.4.tgz",
+            "integrity": "sha512-Qn1yyi10ipcylSSqlTFsj7bhimACWbFm5w5JNMxhLKfcJAeWFBc+/VBv4mu5qlWSKr0cjXqtwM6HISZkESUILA==",
             "dev": true
         },
         "node_modules/http-proxy": {
@@ -6937,9 +6937,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.4.1",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.1.tgz",
-            "integrity": "sha512-WqLs/TTzXdG+/A4ZOOK9WDZiikrRaiA+eoEb/jz2DT9KUhMNHgP7yKPO8vwi62ZCsb703Gwb7BMZwDzI54Y2Ag==",
+            "version": "8.4.3",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.3.tgz",
+            "integrity": "sha512-d5gVKo8ekrircqHOQNvSQk8dhGOuAfu1iP6dzfAlnAmcu7EBJ9cFuZG8B1KZK362aaEO3L1H+WM3ny9xQ29tFw==",
             "dev": true,
             "dependencies": {
                 "nanoid": "^3.1.30",
@@ -7109,13 +7109,13 @@
             }
         },
         "node_modules/postcss-loader": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-6.2.0.tgz",
-            "integrity": "sha512-H9hv447QjQJVDbHj3OUdciyAXY3v5+UDduzEytAlZCVHCpNAAg/mCSwhYYqZr9BiGYhmYspU8QXxZwiHTLn3yA==",
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-6.2.1.tgz",
+            "integrity": "sha512-WbbYpmAaKcux/P66bZ40bpWsBucjx/TTgVVzRZ9yUO8yQfVBlameJ0ZGVaPfH64hNSBh63a+ICP5nqOpBA0w+Q==",
             "dev": true,
             "dependencies": {
                 "cosmiconfig": "^7.0.0",
-                "klona": "^2.0.4",
+                "klona": "^2.0.5",
                 "semver": "^7.3.5"
             },
             "engines": {
@@ -11976,13 +11976,13 @@
             "dev": true
         },
         "color": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/color/-/color-4.0.1.tgz",
-            "integrity": "sha512-rpZjOKN5O7naJxkH2Rx1sZzzBgaiWECc6BYXjeCE6kF0kcASJYbUq02u7JqIHwCb/j3NhV+QhRL2683aICeGZA==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/color/-/color-4.0.2.tgz",
+            "integrity": "sha512-fSu0jW2aKQG2FHlDywqdFPdabJHsUdZ0xabSt3wFZdcgRKtLnUHs19nUtuFuLGVMFhINGgfZEIjbUOsGZXGu7Q==",
             "dev": true,
             "requires": {
                 "color-convert": "^2.0.1",
-                "color-string": "^1.6.0"
+                "color-string": "^1.7.4"
             }
         },
         "color-convert": {
@@ -12001,9 +12001,9 @@
             "dev": true
         },
         "color-string": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.6.0.tgz",
-            "integrity": "sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==",
+            "version": "1.7.4",
+            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.7.4.tgz",
+            "integrity": "sha512-nVdUvPVgZMpRQad5dcsCMOSB5BXLljklTiaxS6ehhKxDsAI5sD7k5VmFuBt1y3Rlym8uulc/ANUN/bMWtBu6Sg==",
             "dev": true,
             "requires": {
                 "color-name": "^1.0.0",
@@ -12754,9 +12754,9 @@
             "dev": true
         },
         "electron-to-chromium": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.3.tgz",
-            "integrity": "sha512-hfpppjYhqIZB8jrNb0rNceQRkSnBN7QJl3W26O1jUv3F3BkQknqy1YTqVXkFnIcFtBc3Qnv5M7r5Lez2iOLgZA==",
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.4.tgz",
+            "integrity": "sha512-teHtgwcmVcL46jlFvAaqjyiTLWuMrUQO1JqV303JKB4ysXG6m8fXSFhbjal9st0r9mNskI22AraJZorb1VcLVg==",
             "dev": true
         },
         "elliptic": {
@@ -13583,9 +13583,9 @@
             }
         },
         "http-parser-js": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.3.tgz",
-            "integrity": "sha512-t7hjvef/5HEK7RWTdUzVUhl8zkEu+LlaE0IYzdMuvbSDipxBRpOn4Uhw8ZyECEa808iVT8XCjzo6xmYt4CiLZg==",
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.4.tgz",
+            "integrity": "sha512-Qn1yyi10ipcylSSqlTFsj7bhimACWbFm5w5JNMxhLKfcJAeWFBc+/VBv4mu5qlWSKr0cjXqtwM6HISZkESUILA==",
             "dev": true
         },
         "http-proxy": {
@@ -14959,9 +14959,9 @@
             }
         },
         "postcss": {
-            "version": "8.4.1",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.1.tgz",
-            "integrity": "sha512-WqLs/TTzXdG+/A4ZOOK9WDZiikrRaiA+eoEb/jz2DT9KUhMNHgP7yKPO8vwi62ZCsb703Gwb7BMZwDzI54Y2Ag==",
+            "version": "8.4.3",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.3.tgz",
+            "integrity": "sha512-d5gVKo8ekrircqHOQNvSQk8dhGOuAfu1iP6dzfAlnAmcu7EBJ9cFuZG8B1KZK362aaEO3L1H+WM3ny9xQ29tFw==",
             "dev": true,
             "requires": {
                 "nanoid": "^3.1.30",
@@ -15061,13 +15061,13 @@
             }
         },
         "postcss-loader": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-6.2.0.tgz",
-            "integrity": "sha512-H9hv447QjQJVDbHj3OUdciyAXY3v5+UDduzEytAlZCVHCpNAAg/mCSwhYYqZr9BiGYhmYspU8QXxZwiHTLn3yA==",
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-6.2.1.tgz",
+            "integrity": "sha512-WbbYpmAaKcux/P66bZ40bpWsBucjx/TTgVVzRZ9yUO8yQfVBlameJ0ZGVaPfH64hNSBh63a+ICP5nqOpBA0w+Q==",
             "dev": true,
             "requires": {
                 "cosmiconfig": "^7.0.0",
-                "klona": "^2.0.4",
+                "klona": "^2.0.5",
                 "semver": "^7.3.5"
             }
         },

--- a/tests/Feature/Jobs/SendDiscordNotificationTest.php
+++ b/tests/Feature/Jobs/SendDiscordNotificationTest.php
@@ -10,6 +10,7 @@ use App\Jobs\SendDiscordNotificationJob;
 use App\Notifications\DiscordNotification;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Notifications\AnonymousNotifiable;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Notification;
 use NotificationChannels\Discord\DiscordMessage;
 use Tests\TestCase;
@@ -26,6 +27,7 @@ class SendDiscordNotificationTest extends TestCase
      */
     public function testSendDiscordNotificationJobSendsNotification()
     {
+        Config::set('flags.allow_discord_notifications', true);
         Notification::fake();
 
         $event = new class implements DiscordMessageEvent


### PR DESCRIPTION
* Check feature flags before handling jobs or notifications. This is an attempt to address staging exceptions, and theoretically I think it's more sound to prevent handling of jobs and notifications as soon as the feature flag is toggled rather than letting queued jobs continue to be processed.
* Use relation constants for event eager loads.
* Bump dependencies.