### PR TITLE
test: restore quietly

### DIFF
--- a/app/Http/Controllers/Document/DocumentController.php
+++ b/app/Http/Controllers/Document/DocumentController.php
@@ -61,7 +61,7 @@ abstract class DocumentController extends Controller
         $converter = new MarkdownConverter($environment);
 
         return view('document', [
-            'document' => $converter->convertToHtml(file_get_contents($document)),
+            'document' => $converter->convert(file_get_contents($document)),
         ]);
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -114,16 +114,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.209.15",
+            "version": "3.209.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "8656babb2e58ea3e7c9a40724e8a545ce40bb622"
+                "reference": "5c128ac9a1513bed9b8975fb66821724d0f80ebe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/8656babb2e58ea3e7c9a40724e8a545ce40bb622",
-                "reference": "8656babb2e58ea3e7c9a40724e8a545ce40bb622",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/5c128ac9a1513bed9b8975fb66821724d0f80ebe",
+                "reference": "5c128ac9a1513bed9b8975fb66821724d0f80ebe",
                 "shasum": ""
             },
             "require": {
@@ -167,12 +167,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Aws\\": "src/"
-                },
                 "files": [
                     "src/functions.php"
-                ]
+                ],
+                "psr-4": {
+                    "Aws\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -199,9 +199,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.209.15"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.209.16"
             },
-            "time": "2022-01-28T19:14:57+00:00"
+            "time": "2022-02-02T19:17:06+00:00"
         },
         {
             "name": "babenkoivan/elastic-adapter",
@@ -2919,16 +2919,16 @@
         },
         {
             "name": "fakerphp/faker",
-            "version": "v1.18.0",
+            "version": "v1.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FakerPHP/Faker.git",
-                "reference": "2e77a868f6540695cf5ebf21e5ab472c65f47567"
+                "reference": "d7f08a622b3346766325488aa32ddc93ccdecc75"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/2e77a868f6540695cf5ebf21e5ab472c65f47567",
-                "reference": "2e77a868f6540695cf5ebf21e5ab472c65f47567",
+                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/d7f08a622b3346766325488aa32ddc93ccdecc75",
+                "reference": "d7f08a622b3346766325488aa32ddc93ccdecc75",
                 "shasum": ""
             },
             "require": {
@@ -2941,10 +2941,12 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.4.1",
+                "doctrine/persistence": "^1.3 || ^2.0",
                 "ext-intl": "*",
                 "symfony/phpunit-bridge": "^4.4 || ^5.2"
             },
             "suggest": {
+                "doctrine/orm": "Required to use Faker\\ORM\\Doctrine",
                 "ext-curl": "Required by Faker\\Provider\\Image to download images.",
                 "ext-dom": "Required by Faker\\Provider\\HtmlLorem for generating random HTML.",
                 "ext-iconv": "Required by Faker\\Provider\\ru_RU\\Text::realText() for generating real Russian text.",
@@ -2953,7 +2955,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "v1.18-dev"
+                    "dev-main": "v1.19-dev"
                 }
             },
             "autoload": {
@@ -2978,9 +2980,9 @@
             ],
             "support": {
                 "issues": "https://github.com/FakerPHP/Faker/issues",
-                "source": "https://github.com/FakerPHP/Faker/tree/v1.18.0"
+                "source": "https://github.com/FakerPHP/Faker/tree/v1.19.0"
             },
-            "time": "2022-01-23T17:56:23+00:00"
+            "time": "2022-02-02T17:38:57+00:00"
         },
         {
             "name": "fruitcake/laravel-cors",
@@ -6286,29 +6288,30 @@
         },
         {
             "name": "owen-it/laravel-auditing",
-            "version": "v12.0.0",
+            "version": "12.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/owen-it/laravel-auditing.git",
-                "reference": "5659c736f17aa75805b60c0d0a23783f3bf5c2a1"
+                "reference": "4b6398683859c240b6b7136ef60215698d897f3d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/owen-it/laravel-auditing/zipball/5659c736f17aa75805b60c0d0a23783f3bf5c2a1",
-                "reference": "5659c736f17aa75805b60c0d0a23783f3bf5c2a1",
+                "url": "https://api.github.com/repos/owen-it/laravel-auditing/zipball/4b6398683859c240b6b7136ef60215698d897f3d",
+                "reference": "4b6398683859c240b6b7136ef60215698d897f3d",
                 "shasum": ""
             },
             "require": {
-                "illuminate/console": "^6.0|^7.0|^8.0",
-                "illuminate/database": "^6.0|^7.0|^8.0",
-                "illuminate/filesystem": "^6.0|^7.0|^8.0",
+                "ext-json": "*",
+                "illuminate/console": "^6.0|^7.0|^8.0|^9.0",
+                "illuminate/database": "^6.0|^7.0|^8.0|^9.0",
+                "illuminate/filesystem": "^6.0|^7.0|^8.0|^9.0",
                 "php": "^7.3|^8.0"
             },
             "require-dev": {
+                "laravel/legacy-factories": "*",
                 "mockery/mockery": "^1.0",
-                "orchestra/testbench": "^4.0",
-                "phpunit/phpunit": "^9.0",
-                "ramsey/uuid": "^3.0"
+                "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0",
+                "phpunit/phpunit": "^9.0"
             },
             "suggest": {
                 "laravelista/lumen-vendor-publish": "Needed to publish the package configuration in Lumen"
@@ -6339,10 +6342,6 @@
                     "email": "anteriovieira@gmail.com"
                 },
                 {
-                    "name": "Quetzy Garcia",
-                    "email": "quetzyg@altek.org"
-                },
-                {
                     "name": "Raphael França",
                     "email": "raphaelfrancabsb@gmail.com"
                 }
@@ -6369,7 +6368,7 @@
                 "issues": "https://github.com/owen-it/laravel-auditing/issues",
                 "source": "https://github.com/owen-it/laravel-auditing"
             },
-            "time": "2020-12-15T19:19:43+00:00"
+            "time": "2022-02-02T11:09:52+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,20 @@
                 "tailwindcss": "^3.0.18"
             }
         },
+        "node_modules/@ampproject/remapping": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.0.1.tgz",
+            "integrity": "sha512-EldHF4Ufj3NL9yCAmYrPzY+3/Yqrzxu24F4Mu4nRjK3w70AKYRmhuLwGZdA9JeoDsbIwkgGkbqUK2INuF582Og==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.0.3",
+                "@jridgewell/trace-mapping": "^0.2.2",
+                "sourcemap-codec": "1.4.8"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
         "node_modules/@babel/code-frame": {
             "version": "7.16.7",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
@@ -29,35 +43,35 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.16.8",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.16.8.tgz",
-            "integrity": "sha512-m7OkX0IdKLKPpBlJtF561YJal5y/jyI5fNfWbPxh2D/nbzzGI4qRyrD8xO2jB24u7l+5I2a43scCG2IrfjC50Q==",
+            "version": "7.17.0",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.0.tgz",
+            "integrity": "sha512-392byTlpGWXMv4FbyWw3sAZ/FrW/DrwqLGXpy0mbyNe9Taqv1mg9yON5/o0cnr8XYCkFTZbC1eV+c+LAROgrng==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.16.12",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.12.tgz",
-            "integrity": "sha512-dK5PtG1uiN2ikk++5OzSYsitZKny4wOCD0nrO4TqnW4BVBTQ2NGS3NgilvT/TEyxTST7LNyWV/T4tXDoD3fOgg==",
+            "version": "7.17.0",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.0.tgz",
+            "integrity": "sha512-x/5Ea+RO5MvF9ize5DeVICJoVrNv0Mi2RnIABrZEKYvPEpldXwauPkgvYA17cKa6WpU3LoYvYbuEMFtSNFsarA==",
             "dev": true,
             "dependencies": {
+                "@ampproject/remapping": "^2.0.0",
                 "@babel/code-frame": "^7.16.7",
-                "@babel/generator": "^7.16.8",
+                "@babel/generator": "^7.17.0",
                 "@babel/helper-compilation-targets": "^7.16.7",
                 "@babel/helper-module-transforms": "^7.16.7",
-                "@babel/helpers": "^7.16.7",
-                "@babel/parser": "^7.16.12",
+                "@babel/helpers": "^7.17.0",
+                "@babel/parser": "^7.17.0",
                 "@babel/template": "^7.16.7",
-                "@babel/traverse": "^7.16.10",
-                "@babel/types": "^7.16.8",
+                "@babel/traverse": "^7.17.0",
+                "@babel/types": "^7.17.0",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
                 "json5": "^2.1.2",
-                "semver": "^6.3.0",
-                "source-map": "^0.5.0"
+                "semver": "^6.3.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -77,12 +91,12 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.16.8",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.8.tgz",
-            "integrity": "sha512-1ojZwE9+lOXzcWdWmO6TbUzDfqLD39CmEhN8+2cX9XkDo5yW1OpgfejfliysR2AWLpMamTiOiAp/mtroaymhpw==",
+            "version": "7.17.0",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.0.tgz",
+            "integrity": "sha512-I3Omiv6FGOC29dtlZhkfXO6pgkmukJSlT26QjVvS1DGZe/NzSVCPG41X0tS21oZkJYlovfj9qDWgKP+Cn4bXxw==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.16.8",
+                "@babel/types": "^7.17.0",
                 "jsesc": "^2.5.1",
                 "source-map": "^0.5.0"
             },
@@ -143,9 +157,9 @@
             }
         },
         "node_modules/@babel/helper-create-class-features-plugin": {
-            "version": "7.16.10",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.16.10.tgz",
-            "integrity": "sha512-wDeej0pu3WN/ffTxMNCPW5UCiOav8IcLRxSIyp/9+IF2xJUM9h/OYjg0IJLHaL6F8oU8kqMz9nc1vryXhMsgXg==",
+            "version": "7.17.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.17.0.tgz",
+            "integrity": "sha512-S3+IHG72pJFb0RmJgeXg/TjVKt641ZsLla028haXJjdqCf9eccE5r1JsdO//L7nzTDzXjtC+hwV/lrkEb2+t0Q==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-annotate-as-pure": "^7.16.7",
@@ -164,13 +178,13 @@
             }
         },
         "node_modules/@babel/helper-create-regexp-features-plugin": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.16.7.tgz",
-            "integrity": "sha512-fk5A6ymfp+O5+p2yCkXAu5Kyj6v0xh0RBeNcAkYUMDvvAAoxvSKXn+Jb37t/yWFiQVDFK1ELpUTD8/aLhCPu+g==",
+            "version": "7.17.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.17.0.tgz",
+            "integrity": "sha512-awO2So99wG6KnlE+TPs6rn83gCz5WlEePJDTnLEqbchMVrBeAujURVphRdigsk094VhvZehFoNOihSlcBjwsXA==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-annotate-as-pure": "^7.16.7",
-                "regexpu-core": "^4.7.1"
+                "regexpu-core": "^5.0.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -433,14 +447,14 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.16.7.tgz",
-            "integrity": "sha512-9ZDoqtfY7AuEOt3cxchfii6C7GDyyMBffktR5B2jvWv8u2+efwvpnVKXMWzNehqy68tKgAfSwfdw/lWpthS2bw==",
+            "version": "7.17.0",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.0.tgz",
+            "integrity": "sha512-Xe/9NFxjPwELUvW2dsukcMZIp6XwPSbI4ojFBJuX5ramHuVE22SVcZIwqzdWo5uCgeTXW8qV97lMvSOjq+1+nQ==",
             "dev": true,
             "dependencies": {
                 "@babel/template": "^7.16.7",
-                "@babel/traverse": "^7.16.7",
-                "@babel/types": "^7.16.7"
+                "@babel/traverse": "^7.17.0",
+                "@babel/types": "^7.17.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -523,9 +537,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.16.12",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.12.tgz",
-            "integrity": "sha512-VfaV15po8RiZssrkPweyvbGVSe4x2y+aciFCgn0n0/SJMR22cwofRV1mtnJQYcSB1wUTaA/X1LnA3es66MCO5A==",
+            "version": "7.17.0",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.0.tgz",
+            "integrity": "sha512-VKXSCQx5D8S04ej+Dqsr1CzYvvWgf20jIw2D+YhQCrIlr2UZGaDds23Y0xg75/skOxpLCRpUZvk/1EAVkGoDOw==",
             "dev": true,
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -1391,9 +1405,9 @@
             }
         },
         "node_modules/@babel/plugin-transform-runtime": {
-            "version": "7.16.10",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.16.10.tgz",
-            "integrity": "sha512-9nwTiqETv2G7xI4RvXHNfpGdr8pAA+Q/YtN3yLK7OoK7n9OibVm/xymJ838a9A6E/IciOLPj82lZk0fW6O4O7w==",
+            "version": "7.17.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.17.0.tgz",
+            "integrity": "sha512-fr7zPWnKXNc1xoHfrIU9mN/4XKX4VLZ45Q+oMhfsYIaHvg7mHgmhfOy/ckRWqDK7XF3QDigRpkh5DKq6+clE8A==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-module-imports": "^7.16.7",
@@ -1640,9 +1654,9 @@
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-            "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
+            "version": "7.17.0",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.0.tgz",
+            "integrity": "sha512-etcO/ohMNaNA2UBdaXBBSX/3aEzFMRrVfaPv8Ptc0k+cWpWW0QFiGZ2XnVqQZI1Cf734LbPGmqBKWESfW4x/dQ==",
             "dev": true,
             "dependencies": {
                 "regenerator-runtime": "^0.13.4"
@@ -1666,19 +1680,19 @@
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.16.10",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.10.tgz",
-            "integrity": "sha512-yzuaYXoRJBGMlBhsMJoUW7G1UmSb/eXr/JHYM/MsOJgavJibLwASijW7oXBdw3NQ6T0bW7Ty5P/VarOs9cHmqw==",
+            "version": "7.17.0",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.0.tgz",
+            "integrity": "sha512-fpFIXvqD6kC7c7PUNnZ0Z8cQXlarCLtCUpt2S1Dx7PjoRtCFffvOkHHSom+m5HIxMZn5bIBVb71lhabcmjEsqg==",
             "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.16.7",
-                "@babel/generator": "^7.16.8",
+                "@babel/generator": "^7.17.0",
                 "@babel/helper-environment-visitor": "^7.16.7",
                 "@babel/helper-function-name": "^7.16.7",
                 "@babel/helper-hoist-variables": "^7.16.7",
                 "@babel/helper-split-export-declaration": "^7.16.7",
-                "@babel/parser": "^7.16.10",
-                "@babel/types": "^7.16.8",
+                "@babel/parser": "^7.17.0",
+                "@babel/types": "^7.17.0",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
             },
@@ -1687,9 +1701,9 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.16.8",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.8.tgz",
-            "integrity": "sha512-smN2DQc5s4M7fntyjGtyIPbRJv6wW4rU/94fmYJ7PKQuZkC0qGMHXJbg6sNGt12JmVr4k5YaptI/XtiLJBnmIg==",
+            "version": "7.17.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+            "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-validator-identifier": "^7.16.7",
@@ -1706,6 +1720,25 @@
             "dev": true,
             "engines": {
                 "node": ">=10.0.0"
+            }
+        },
+        "node_modules/@jridgewell/resolve-uri": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.3.tgz",
+            "integrity": "sha512-fuIOnc81C5iRNevb/XPiM8Khp9bVjreydRQ37rt0C/dY0PAW1DRvEM3WrKX/5rStS5lbgwS0FCgqSndh9tvK5w==",
+            "dev": true,
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/@jridgewell/trace-mapping": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.2.2.tgz",
+            "integrity": "sha512-I9AGQzMPEzQNJgib2YSqciYWazGsXSyu1rEEeaPeM1764ZtnfNTxA5bofzG/POMI3QcvpBUxwecOPZM6ZhkEpg==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.0.3",
+                "sourcemap-codec": "1.4.8"
             }
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -2291,13 +2324,13 @@
             "dev": true
         },
         "node_modules/accepts": {
-            "version": "1.3.7",
-            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
-            "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+            "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
             "dev": true,
             "dependencies": {
-                "mime-types": "~2.1.24",
-                "negotiator": "0.6.2"
+                "mime-types": "~2.1.34",
+                "negotiator": "0.6.3"
             },
             "engines": {
                 "node": ">= 0.6"
@@ -4157,9 +4190,9 @@
             "dev": true
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.61",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.61.tgz",
-            "integrity": "sha512-kpzCOOFlx63C9qKRyIDEsKIUgzoe98ump7T4gU+/OLzj8gYkkWf2SIyBjhTSE0keAjMAp3i7C262YtkQOMYrGw==",
+            "version": "1.4.63",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.63.tgz",
+            "integrity": "sha512-e0PX/LRJPFRU4kzJKLvTobxyFdnANCvcoDCe8XcyTqP58nTWIwdsHvXLIl1RkB39X5yaosLaroMASWB0oIsgCA==",
             "dev": true
         },
         "node_modules/elliptic": {
@@ -6294,9 +6327,9 @@
             }
         },
         "node_modules/negotiator": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-            "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+            "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
             "dev": true,
             "engines": {
                 "node": ">= 0.6"
@@ -7706,9 +7739,9 @@
             "dev": true
         },
         "node_modules/regenerate-unicode-properties": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-9.0.0.tgz",
-            "integrity": "sha512-3E12UeNSPfjrgwjkR81m5J7Aw/T55Tu7nUyZVQYCKEOs+2dkxEY+DpPtZzO4YruuiPb7NkYLVcyJC4+zCbk5pA==",
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.0.1.tgz",
+            "integrity": "sha512-vn5DU6yg6h8hP/2OkQo3K7uVILvY4iu0oI4t3HFa81UPkhGJwkRwM10JEc3upjdhHjs/k8GJY1sRBhk5sr69Bw==",
             "dev": true,
             "dependencies": {
                 "regenerate": "^1.4.2"
@@ -7749,15 +7782,15 @@
             }
         },
         "node_modules/regexpu-core": {
-            "version": "4.8.0",
-            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.8.0.tgz",
-            "integrity": "sha512-1F6bYsoYiz6is+oz70NWur2Vlh9KWtswuRuzJOfeYUrfPX2o8n74AnUVaOGDbUqVGO9fNHu48/pjJO4sNVwsOg==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.0.1.tgz",
+            "integrity": "sha512-CriEZlrKK9VJw/xQGJpQM5rY88BtuL8DM+AEwvcThHilbxiTAy8vq4iJnd2tqq8wLmjbGZzP7ZcKFjbGkmEFrw==",
             "dev": true,
             "dependencies": {
                 "regenerate": "^1.4.2",
-                "regenerate-unicode-properties": "^9.0.0",
-                "regjsgen": "^0.5.2",
-                "regjsparser": "^0.7.0",
+                "regenerate-unicode-properties": "^10.0.1",
+                "regjsgen": "^0.6.0",
+                "regjsparser": "^0.8.2",
                 "unicode-match-property-ecmascript": "^2.0.0",
                 "unicode-match-property-value-ecmascript": "^2.0.0"
             },
@@ -7766,15 +7799,15 @@
             }
         },
         "node_modules/regjsgen": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.2.tgz",
-            "integrity": "sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.6.0.tgz",
+            "integrity": "sha512-ozE883Uigtqj3bx7OhL1KNbCzGyW2NQZPl6Hs09WTvCuZD5sTI4JY58bkbQWa/Y9hxIsvJ3M8Nbf7j54IqeZbA==",
             "dev": true
         },
         "node_modules/regjsparser": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.7.0.tgz",
-            "integrity": "sha512-A4pcaORqmNMDVwUjWoTzuhwMGpP+NykpfqAsEgI1FSH/EzC7lrN5TMd+kN8YCovX+jMpu8eaqXgXPCa0g8FQNQ==",
+            "version": "0.8.4",
+            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.8.4.tgz",
+            "integrity": "sha512-J3LABycON/VNEu3abOviqGHuB/LOtOQj8SKmfP9anY5GfAVw/SPjwzSjxGjbZXIxbGfqTHtJw58C2Li/WkStmA==",
             "dev": true,
             "dependencies": {
                 "jsesc": "~0.5.0"
@@ -8272,6 +8305,12 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/sourcemap-codec": {
+            "version": "1.4.8",
+            "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+            "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+            "dev": true
         },
         "node_modules/spdy": {
             "version": "4.0.2",
@@ -9129,19 +9168,20 @@
             }
         },
         "node_modules/webpack-dev-server": {
-            "version": "4.7.3",
-            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.7.3.tgz",
-            "integrity": "sha512-mlxq2AsIw2ag016nixkzUkdyOE8ST2GTy34uKSABp1c4nhjZvH90D5ZRR+UOLSsG4Z3TFahAi72a3ymRtfRm+Q==",
+            "version": "4.7.4",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.7.4.tgz",
+            "integrity": "sha512-nfdsb02Zi2qzkNmgtZjkrMOcXnYZ6FLKcQwpxT7MvmHKc+oTtDsBju8j+NMyAygZ9GW1jMEUpy3itHtqgEhe1A==",
             "dev": true,
             "dependencies": {
                 "@types/bonjour": "^3.5.9",
                 "@types/connect-history-api-fallback": "^1.3.5",
+                "@types/express": "^4.17.13",
                 "@types/serve-index": "^1.9.1",
                 "@types/sockjs": "^0.3.33",
                 "@types/ws": "^8.2.2",
                 "ansi-html-community": "^0.0.8",
                 "bonjour": "^3.5.0",
-                "chokidar": "^3.5.2",
+                "chokidar": "^3.5.3",
                 "colorette": "^2.0.10",
                 "compression": "^1.7.4",
                 "connect-history-api-fallback": "^1.6.0",
@@ -9161,8 +9201,8 @@
                 "sockjs": "^0.3.21",
                 "spdy": "^4.0.2",
                 "strip-ansi": "^7.0.0",
-                "webpack-dev-middleware": "^5.3.0",
-                "ws": "^8.1.0"
+                "webpack-dev-middleware": "^5.3.1",
+                "ws": "^8.4.2"
             },
             "bin": {
                 "webpack-dev-server": "bin/webpack-dev-server.js"
@@ -9504,6 +9544,17 @@
         }
     },
     "dependencies": {
+        "@ampproject/remapping": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.0.1.tgz",
+            "integrity": "sha512-EldHF4Ufj3NL9yCAmYrPzY+3/Yqrzxu24F4Mu4nRjK3w70AKYRmhuLwGZdA9JeoDsbIwkgGkbqUK2INuF582Og==",
+            "dev": true,
+            "requires": {
+                "@jridgewell/resolve-uri": "^3.0.3",
+                "@jridgewell/trace-mapping": "^0.2.2",
+                "sourcemap-codec": "1.4.8"
+            }
+        },
         "@babel/code-frame": {
             "version": "7.16.7",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
@@ -9514,32 +9565,32 @@
             }
         },
         "@babel/compat-data": {
-            "version": "7.16.8",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.16.8.tgz",
-            "integrity": "sha512-m7OkX0IdKLKPpBlJtF561YJal5y/jyI5fNfWbPxh2D/nbzzGI4qRyrD8xO2jB24u7l+5I2a43scCG2IrfjC50Q==",
+            "version": "7.17.0",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.0.tgz",
+            "integrity": "sha512-392byTlpGWXMv4FbyWw3sAZ/FrW/DrwqLGXpy0mbyNe9Taqv1mg9yON5/o0cnr8XYCkFTZbC1eV+c+LAROgrng==",
             "dev": true
         },
         "@babel/core": {
-            "version": "7.16.12",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.12.tgz",
-            "integrity": "sha512-dK5PtG1uiN2ikk++5OzSYsitZKny4wOCD0nrO4TqnW4BVBTQ2NGS3NgilvT/TEyxTST7LNyWV/T4tXDoD3fOgg==",
+            "version": "7.17.0",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.0.tgz",
+            "integrity": "sha512-x/5Ea+RO5MvF9ize5DeVICJoVrNv0Mi2RnIABrZEKYvPEpldXwauPkgvYA17cKa6WpU3LoYvYbuEMFtSNFsarA==",
             "dev": true,
             "requires": {
+                "@ampproject/remapping": "^2.0.0",
                 "@babel/code-frame": "^7.16.7",
-                "@babel/generator": "^7.16.8",
+                "@babel/generator": "^7.17.0",
                 "@babel/helper-compilation-targets": "^7.16.7",
                 "@babel/helper-module-transforms": "^7.16.7",
-                "@babel/helpers": "^7.16.7",
-                "@babel/parser": "^7.16.12",
+                "@babel/helpers": "^7.17.0",
+                "@babel/parser": "^7.17.0",
                 "@babel/template": "^7.16.7",
-                "@babel/traverse": "^7.16.10",
-                "@babel/types": "^7.16.8",
+                "@babel/traverse": "^7.17.0",
+                "@babel/types": "^7.17.0",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
                 "json5": "^2.1.2",
-                "semver": "^6.3.0",
-                "source-map": "^0.5.0"
+                "semver": "^6.3.0"
             },
             "dependencies": {
                 "semver": {
@@ -9551,12 +9602,12 @@
             }
         },
         "@babel/generator": {
-            "version": "7.16.8",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.8.tgz",
-            "integrity": "sha512-1ojZwE9+lOXzcWdWmO6TbUzDfqLD39CmEhN8+2cX9XkDo5yW1OpgfejfliysR2AWLpMamTiOiAp/mtroaymhpw==",
+            "version": "7.17.0",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.0.tgz",
+            "integrity": "sha512-I3Omiv6FGOC29dtlZhkfXO6pgkmukJSlT26QjVvS1DGZe/NzSVCPG41X0tS21oZkJYlovfj9qDWgKP+Cn4bXxw==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.16.8",
+                "@babel/types": "^7.17.0",
                 "jsesc": "^2.5.1",
                 "source-map": "^0.5.0"
             }
@@ -9601,9 +9652,9 @@
             }
         },
         "@babel/helper-create-class-features-plugin": {
-            "version": "7.16.10",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.16.10.tgz",
-            "integrity": "sha512-wDeej0pu3WN/ffTxMNCPW5UCiOav8IcLRxSIyp/9+IF2xJUM9h/OYjg0IJLHaL6F8oU8kqMz9nc1vryXhMsgXg==",
+            "version": "7.17.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.17.0.tgz",
+            "integrity": "sha512-S3+IHG72pJFb0RmJgeXg/TjVKt641ZsLla028haXJjdqCf9eccE5r1JsdO//L7nzTDzXjtC+hwV/lrkEb2+t0Q==",
             "dev": true,
             "requires": {
                 "@babel/helper-annotate-as-pure": "^7.16.7",
@@ -9616,13 +9667,13 @@
             }
         },
         "@babel/helper-create-regexp-features-plugin": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.16.7.tgz",
-            "integrity": "sha512-fk5A6ymfp+O5+p2yCkXAu5Kyj6v0xh0RBeNcAkYUMDvvAAoxvSKXn+Jb37t/yWFiQVDFK1ELpUTD8/aLhCPu+g==",
+            "version": "7.17.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.17.0.tgz",
+            "integrity": "sha512-awO2So99wG6KnlE+TPs6rn83gCz5WlEePJDTnLEqbchMVrBeAujURVphRdigsk094VhvZehFoNOihSlcBjwsXA==",
             "dev": true,
             "requires": {
                 "@babel/helper-annotate-as-pure": "^7.16.7",
-                "regexpu-core": "^4.7.1"
+                "regexpu-core": "^5.0.1"
             }
         },
         "@babel/helper-define-polyfill-provider": {
@@ -9821,14 +9872,14 @@
             }
         },
         "@babel/helpers": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.16.7.tgz",
-            "integrity": "sha512-9ZDoqtfY7AuEOt3cxchfii6C7GDyyMBffktR5B2jvWv8u2+efwvpnVKXMWzNehqy68tKgAfSwfdw/lWpthS2bw==",
+            "version": "7.17.0",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.0.tgz",
+            "integrity": "sha512-Xe/9NFxjPwELUvW2dsukcMZIp6XwPSbI4ojFBJuX5ramHuVE22SVcZIwqzdWo5uCgeTXW8qV97lMvSOjq+1+nQ==",
             "dev": true,
             "requires": {
                 "@babel/template": "^7.16.7",
-                "@babel/traverse": "^7.16.7",
-                "@babel/types": "^7.16.7"
+                "@babel/traverse": "^7.17.0",
+                "@babel/types": "^7.17.0"
             }
         },
         "@babel/highlight": {
@@ -9895,9 +9946,9 @@
             }
         },
         "@babel/parser": {
-            "version": "7.16.12",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.12.tgz",
-            "integrity": "sha512-VfaV15po8RiZssrkPweyvbGVSe4x2y+aciFCgn0n0/SJMR22cwofRV1mtnJQYcSB1wUTaA/X1LnA3es66MCO5A==",
+            "version": "7.17.0",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.0.tgz",
+            "integrity": "sha512-VKXSCQx5D8S04ej+Dqsr1CzYvvWgf20jIw2D+YhQCrIlr2UZGaDds23Y0xg75/skOxpLCRpUZvk/1EAVkGoDOw==",
             "dev": true
         },
         "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
@@ -10454,9 +10505,9 @@
             }
         },
         "@babel/plugin-transform-runtime": {
-            "version": "7.16.10",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.16.10.tgz",
-            "integrity": "sha512-9nwTiqETv2G7xI4RvXHNfpGdr8pAA+Q/YtN3yLK7OoK7n9OibVm/xymJ838a9A6E/IciOLPj82lZk0fW6O4O7w==",
+            "version": "7.17.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.17.0.tgz",
+            "integrity": "sha512-fr7zPWnKXNc1xoHfrIU9mN/4XKX4VLZ45Q+oMhfsYIaHvg7mHgmhfOy/ckRWqDK7XF3QDigRpkh5DKq6+clE8A==",
             "dev": true,
             "requires": {
                 "@babel/helper-module-imports": "^7.16.7",
@@ -10644,9 +10695,9 @@
             }
         },
         "@babel/runtime": {
-            "version": "7.16.7",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-            "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
+            "version": "7.17.0",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.0.tgz",
+            "integrity": "sha512-etcO/ohMNaNA2UBdaXBBSX/3aEzFMRrVfaPv8Ptc0k+cWpWW0QFiGZ2XnVqQZI1Cf734LbPGmqBKWESfW4x/dQ==",
             "dev": true,
             "requires": {
                 "regenerator-runtime": "^0.13.4"
@@ -10664,27 +10715,27 @@
             }
         },
         "@babel/traverse": {
-            "version": "7.16.10",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.10.tgz",
-            "integrity": "sha512-yzuaYXoRJBGMlBhsMJoUW7G1UmSb/eXr/JHYM/MsOJgavJibLwASijW7oXBdw3NQ6T0bW7Ty5P/VarOs9cHmqw==",
+            "version": "7.17.0",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.0.tgz",
+            "integrity": "sha512-fpFIXvqD6kC7c7PUNnZ0Z8cQXlarCLtCUpt2S1Dx7PjoRtCFffvOkHHSom+m5HIxMZn5bIBVb71lhabcmjEsqg==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.16.7",
-                "@babel/generator": "^7.16.8",
+                "@babel/generator": "^7.17.0",
                 "@babel/helper-environment-visitor": "^7.16.7",
                 "@babel/helper-function-name": "^7.16.7",
                 "@babel/helper-hoist-variables": "^7.16.7",
                 "@babel/helper-split-export-declaration": "^7.16.7",
-                "@babel/parser": "^7.16.10",
-                "@babel/types": "^7.16.8",
+                "@babel/parser": "^7.17.0",
+                "@babel/types": "^7.17.0",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
             }
         },
         "@babel/types": {
-            "version": "7.16.8",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.8.tgz",
-            "integrity": "sha512-smN2DQc5s4M7fntyjGtyIPbRJv6wW4rU/94fmYJ7PKQuZkC0qGMHXJbg6sNGt12JmVr4k5YaptI/XtiLJBnmIg==",
+            "version": "7.17.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+            "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
             "dev": true,
             "requires": {
                 "@babel/helper-validator-identifier": "^7.16.7",
@@ -10696,6 +10747,22 @@
             "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.6.tgz",
             "integrity": "sha512-ws57AidsDvREKrZKYffXddNkyaF14iHNHm8VQnZH6t99E8gczjNN0GpvcGny0imC80yQ0tHz1xVUKk/KFQSUyA==",
             "dev": true
+        },
+        "@jridgewell/resolve-uri": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.3.tgz",
+            "integrity": "sha512-fuIOnc81C5iRNevb/XPiM8Khp9bVjreydRQ37rt0C/dY0PAW1DRvEM3WrKX/5rStS5lbgwS0FCgqSndh9tvK5w==",
+            "dev": true
+        },
+        "@jridgewell/trace-mapping": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.2.2.tgz",
+            "integrity": "sha512-I9AGQzMPEzQNJgib2YSqciYWazGsXSyu1rEEeaPeM1764ZtnfNTxA5bofzG/POMI3QcvpBUxwecOPZM6ZhkEpg==",
+            "dev": true,
+            "requires": {
+                "@jridgewell/resolve-uri": "^3.0.3",
+                "sourcemap-codec": "1.4.8"
+            }
         },
         "@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -11248,13 +11315,13 @@
             "dev": true
         },
         "accepts": {
-            "version": "1.3.7",
-            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
-            "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+            "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
             "dev": true,
             "requires": {
-                "mime-types": "~2.1.24",
-                "negotiator": "0.6.2"
+                "mime-types": "~2.1.34",
+                "negotiator": "0.6.3"
             }
         },
         "acorn": {
@@ -12724,9 +12791,9 @@
             "dev": true
         },
         "electron-to-chromium": {
-            "version": "1.4.61",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.61.tgz",
-            "integrity": "sha512-kpzCOOFlx63C9qKRyIDEsKIUgzoe98ump7T4gU+/OLzj8gYkkWf2SIyBjhTSE0keAjMAp3i7C262YtkQOMYrGw==",
+            "version": "1.4.63",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.63.tgz",
+            "integrity": "sha512-e0PX/LRJPFRU4kzJKLvTobxyFdnANCvcoDCe8XcyTqP58nTWIwdsHvXLIl1RkB39X5yaosLaroMASWB0oIsgCA==",
             "dev": true
         },
         "elliptic": {
@@ -14333,9 +14400,9 @@
             "dev": true
         },
         "negotiator": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-            "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+            "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
             "dev": true
         },
         "neo-async": {
@@ -15324,9 +15391,9 @@
             "dev": true
         },
         "regenerate-unicode-properties": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-9.0.0.tgz",
-            "integrity": "sha512-3E12UeNSPfjrgwjkR81m5J7Aw/T55Tu7nUyZVQYCKEOs+2dkxEY+DpPtZzO4YruuiPb7NkYLVcyJC4+zCbk5pA==",
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.0.1.tgz",
+            "integrity": "sha512-vn5DU6yg6h8hP/2OkQo3K7uVILvY4iu0oI4t3HFa81UPkhGJwkRwM10JEc3upjdhHjs/k8GJY1sRBhk5sr69Bw==",
             "dev": true,
             "requires": {
                 "regenerate": "^1.4.2"
@@ -15358,29 +15425,29 @@
             }
         },
         "regexpu-core": {
-            "version": "4.8.0",
-            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.8.0.tgz",
-            "integrity": "sha512-1F6bYsoYiz6is+oz70NWur2Vlh9KWtswuRuzJOfeYUrfPX2o8n74AnUVaOGDbUqVGO9fNHu48/pjJO4sNVwsOg==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.0.1.tgz",
+            "integrity": "sha512-CriEZlrKK9VJw/xQGJpQM5rY88BtuL8DM+AEwvcThHilbxiTAy8vq4iJnd2tqq8wLmjbGZzP7ZcKFjbGkmEFrw==",
             "dev": true,
             "requires": {
                 "regenerate": "^1.4.2",
-                "regenerate-unicode-properties": "^9.0.0",
-                "regjsgen": "^0.5.2",
-                "regjsparser": "^0.7.0",
+                "regenerate-unicode-properties": "^10.0.1",
+                "regjsgen": "^0.6.0",
+                "regjsparser": "^0.8.2",
                 "unicode-match-property-ecmascript": "^2.0.0",
                 "unicode-match-property-value-ecmascript": "^2.0.0"
             }
         },
         "regjsgen": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.2.tgz",
-            "integrity": "sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.6.0.tgz",
+            "integrity": "sha512-ozE883Uigtqj3bx7OhL1KNbCzGyW2NQZPl6Hs09WTvCuZD5sTI4JY58bkbQWa/Y9hxIsvJ3M8Nbf7j54IqeZbA==",
             "dev": true
         },
         "regjsparser": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.7.0.tgz",
-            "integrity": "sha512-A4pcaORqmNMDVwUjWoTzuhwMGpP+NykpfqAsEgI1FSH/EzC7lrN5TMd+kN8YCovX+jMpu8eaqXgXPCa0g8FQNQ==",
+            "version": "0.8.4",
+            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.8.4.tgz",
+            "integrity": "sha512-J3LABycON/VNEu3abOviqGHuB/LOtOQj8SKmfP9anY5GfAVw/SPjwzSjxGjbZXIxbGfqTHtJw58C2Li/WkStmA==",
             "dev": true,
             "requires": {
                 "jsesc": "~0.5.0"
@@ -15778,6 +15845,12 @@
                     "dev": true
                 }
             }
+        },
+        "sourcemap-codec": {
+            "version": "1.4.8",
+            "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+            "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+            "dev": true
         },
         "spdy": {
             "version": "4.0.2",
@@ -16426,19 +16499,20 @@
             }
         },
         "webpack-dev-server": {
-            "version": "4.7.3",
-            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.7.3.tgz",
-            "integrity": "sha512-mlxq2AsIw2ag016nixkzUkdyOE8ST2GTy34uKSABp1c4nhjZvH90D5ZRR+UOLSsG4Z3TFahAi72a3ymRtfRm+Q==",
+            "version": "4.7.4",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.7.4.tgz",
+            "integrity": "sha512-nfdsb02Zi2qzkNmgtZjkrMOcXnYZ6FLKcQwpxT7MvmHKc+oTtDsBju8j+NMyAygZ9GW1jMEUpy3itHtqgEhe1A==",
             "dev": true,
             "requires": {
                 "@types/bonjour": "^3.5.9",
                 "@types/connect-history-api-fallback": "^1.3.5",
+                "@types/express": "^4.17.13",
                 "@types/serve-index": "^1.9.1",
                 "@types/sockjs": "^0.3.33",
                 "@types/ws": "^8.2.2",
                 "ansi-html-community": "^0.0.8",
                 "bonjour": "^3.5.0",
-                "chokidar": "^3.5.2",
+                "chokidar": "^3.5.3",
                 "colorette": "^2.0.10",
                 "compression": "^1.7.4",
                 "connect-history-api-fallback": "^1.6.0",
@@ -16458,8 +16532,8 @@
                 "sockjs": "^0.3.21",
                 "spdy": "^4.0.2",
                 "strip-ansi": "^7.0.0",
-                "webpack-dev-middleware": "^5.3.0",
-                "ws": "^8.1.0"
+                "webpack-dev-middleware": "^5.3.1",
+                "ws": "^8.4.2"
             },
             "dependencies": {
                 "ajv": {

--- a/tests/Feature/Events/Admin/AnnouncementTest.php
+++ b/tests/Feature/Events/Admin/AnnouncementTest.php
@@ -64,6 +64,24 @@ class AnnouncementTest extends TestCase
     }
 
     /**
+     * When an Announcement is restored, an AnnouncementUpdated event shall not be dispatched.
+     * Note: This is a customization that overrides default framework behavior.
+     * An updated event is fired on restore.
+     *
+     * @return void
+     */
+    public function testAnnouncementRestoresQuietly()
+    {
+        Event::fake();
+
+        $announcement = Announcement::factory()->createOne();
+
+        $announcement->restore();
+
+        Event::assertNotDispatched(AnnouncementUpdated::class);
+    }
+
+    /**
      * When an Announcement is updated, an AnnouncementUpdated event shall be dispatched.
      *
      * @return void

--- a/tests/Feature/Events/Auth/InvitationTest.php
+++ b/tests/Feature/Events/Auth/InvitationTest.php
@@ -64,6 +64,24 @@ class InvitationTest extends TestCase
     }
 
     /**
+     * When an Invitation is restored, an InvitationUpdated event shall not be dispatched.
+     * Note: This is a customization that overrides default framework behavior.
+     * An updated event is fired on restore.
+     *
+     * @return void
+     */
+    public function testInvitationRestoresQuietly()
+    {
+        Event::fake();
+
+        $invitation = Invitation::factory()->createOne();
+
+        $invitation->restore();
+
+        Event::assertNotDispatched(InvitationUpdated::class);
+    }
+
+    /**
      * When an Invitation is updated, an InvitationUpdated event shall be dispatched.
      *
      * @return void

--- a/tests/Feature/Events/Auth/UserTest.php
+++ b/tests/Feature/Events/Auth/UserTest.php
@@ -64,6 +64,24 @@ class UserTest extends TestCase
     }
 
     /**
+     * When a User is restored, a UserUpdated event shall not be dispatched.
+     * Note: This is a customization that overrides default framework behavior.
+     * An updated event is fired on restore.
+     *
+     * @return void
+     */
+    public function testUserRestoresQuietly()
+    {
+        Event::fake();
+
+        $user = User::factory()->createOne();
+
+        $user->restore();
+
+        Event::assertNotDispatched(UserUpdated::class);
+    }
+
+    /**
      * When a User is updated, a UserUpdated event shall be dispatched.
      *
      * @return void

--- a/tests/Feature/Events/Billing/BalanceTest.php
+++ b/tests/Feature/Events/Billing/BalanceTest.php
@@ -64,6 +64,24 @@ class BalanceTest extends TestCase
     }
 
     /**
+     * When a Balance is restored, a BalanceUpdated event shall not be dispatched.
+     * Note: This is a customization that overrides default framework behavior.
+     * An updated event is fired on restore.
+     *
+     * @return void
+     */
+    public function testBalanceRestoresQuietly()
+    {
+        Event::fake();
+
+        $balance = Balance::factory()->createOne();
+
+        $balance->restore();
+
+        Event::assertNotDispatched(BalanceUpdated::class);
+    }
+
+    /**
      * When an Balance is updated, an BalanceUpdated event shall be dispatched.
      *
      * @return void

--- a/tests/Feature/Events/Billing/TransactionTest.php
+++ b/tests/Feature/Events/Billing/TransactionTest.php
@@ -64,6 +64,24 @@ class TransactionTest extends TestCase
     }
 
     /**
+     * When a Transaction is restored, a TransactionUpdated event shall not be dispatched.
+     * Note: This is a customization that overrides default framework behavior.
+     * An updated event is fired on restore.
+     *
+     * @return void
+     */
+    public function testTransactionRestoresQuietly()
+    {
+        Event::fake();
+
+        $transaction = Transaction::factory()->createOne();
+
+        $transaction->restore();
+
+        Event::assertNotDispatched(TransactionUpdated::class);
+    }
+
+    /**
      * When an Transaction is updated, an TransactionUpdated event shall be dispatched.
      *
      * @return void

--- a/tests/Feature/Events/Wiki/Anime/SynonymTest.php
+++ b/tests/Feature/Events/Wiki/Anime/SynonymTest.php
@@ -71,6 +71,26 @@ class SynonymTest extends TestCase
     }
 
     /**
+     * When a Synonym is restored, a SynonymUpdated event shall not be dispatched.
+     * Note: This is a customization that overrides default framework behavior.
+     * An updated event is fired on restore.
+     *
+     * @return void
+     */
+    public function testSynonymRestoresQuietly()
+    {
+        Event::fake();
+
+        $synonym = AnimeSynonym::factory()
+            ->for(Anime::factory())
+            ->createOne();
+
+        $synonym->restore();
+
+        Event::assertNotDispatched(SynonymUpdated::class);
+    }
+
+    /**
      * When a Synonym is updated, a SynonymUpdated event shall be dispatched.
      *
      * @return void

--- a/tests/Feature/Events/Wiki/Anime/Theme/EntryTest.php
+++ b/tests/Feature/Events/Wiki/Anime/Theme/EntryTest.php
@@ -8,6 +8,7 @@ use App\Events\Wiki\Anime\Theme\Entry\EntryCreated;
 use App\Events\Wiki\Anime\Theme\Entry\EntryDeleted;
 use App\Events\Wiki\Anime\Theme\Entry\EntryRestored;
 use App\Events\Wiki\Anime\Theme\Entry\EntryUpdated;
+use App\Events\Wiki\Anime\Theme\ThemeCreating;
 use App\Models\Wiki\Anime;
 use App\Models\Wiki\Anime\AnimeTheme;
 use App\Models\Wiki\Anime\Theme\AnimeThemeEntry;
@@ -26,7 +27,7 @@ class EntryTest extends TestCase
      */
     public function testEntryCreatedEventDispatched()
     {
-        Event::fake(EntryCreated::class);
+        Event::fakeExcept(ThemeCreating::class);
 
         AnimeThemeEntry::factory()
             ->for(AnimeTheme::factory()->for(Anime::factory()))
@@ -42,7 +43,7 @@ class EntryTest extends TestCase
      */
     public function testEntryDeletedEventDispatched()
     {
-        Event::fake(EntryDeleted::class);
+        Event::fakeExcept(ThemeCreating::class);
 
         $entry = AnimeThemeEntry::factory()
             ->for(AnimeTheme::factory()->for(Anime::factory()))
@@ -60,7 +61,7 @@ class EntryTest extends TestCase
      */
     public function testEntryRestoredEventDispatched()
     {
-        Event::fake(EntryRestored::class);
+        Event::fakeExcept(ThemeCreating::class);
 
         $entry = AnimeThemeEntry::factory()
             ->for(AnimeTheme::factory()->for(Anime::factory()))
@@ -72,13 +73,33 @@ class EntryTest extends TestCase
     }
 
     /**
+     * When an Entry is restored, an EntryUpdated event shall not be dispatched.
+     * Note: This is a customization that overrides default framework behavior.
+     * An updated event is fired on restore.
+     *
+     * @return void
+     */
+    public function testEntryRestoresQuietly()
+    {
+        Event::fakeExcept(ThemeCreating::class);
+
+        $entry = AnimeThemeEntry::factory()
+            ->for(AnimeTheme::factory()->for(Anime::factory()))
+            ->createOne();
+
+        $entry->restore();
+
+        Event::assertNotDispatched(EntryUpdated::class);
+    }
+
+    /**
      * When an Entry is updated, an EntryUpdated event shall be dispatched.
      *
      * @return void
      */
     public function testEntryUpdatedEventDispatched()
     {
-        Event::fake(EntryUpdated::class);
+        Event::fakeExcept(ThemeCreating::class);
 
         $entry = AnimeThemeEntry::factory()
             ->for(AnimeTheme::factory()->for(Anime::factory()))

--- a/tests/Feature/Events/Wiki/Anime/ThemeTest.php
+++ b/tests/Feature/Events/Wiki/Anime/ThemeTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature\Events\Wiki\Anime;
 
 use App\Events\Wiki\Anime\Theme\ThemeCreated;
+use App\Events\Wiki\Anime\Theme\ThemeCreating;
 use App\Events\Wiki\Anime\Theme\ThemeDeleted;
 use App\Events\Wiki\Anime\Theme\ThemeRestored;
 use App\Events\Wiki\Anime\Theme\ThemeUpdated;
@@ -25,7 +26,7 @@ class ThemeTest extends TestCase
      */
     public function testThemeCreatedEventDispatched()
     {
-        Event::fake(ThemeCreated::class);
+        Event::fakeExcept(ThemeCreating::class);
 
         AnimeTheme::factory()
             ->for(Anime::factory())
@@ -41,7 +42,7 @@ class ThemeTest extends TestCase
      */
     public function testThemeDeletedEventDispatched()
     {
-        Event::fake(ThemeDeleted::class);
+        Event::fakeExcept(ThemeCreating::class);
 
         $theme = AnimeTheme::factory()
             ->for(Anime::factory())
@@ -59,7 +60,7 @@ class ThemeTest extends TestCase
      */
     public function testThemeRestoredEventDispatched()
     {
-        Event::fake(ThemeRestored::class);
+        Event::fakeExcept(ThemeCreating::class);
 
         $theme = AnimeTheme::factory()
             ->for(Anime::factory())
@@ -71,13 +72,33 @@ class ThemeTest extends TestCase
     }
 
     /**
+     * When a Theme is restored, a ThemeUpdated event shall not be dispatched.
+     * Note: This is a customization that overrides default framework behavior.
+     * An updated event is fired on restore.
+     *
+     * @return void
+     */
+    public function testThemeRestoresQuietly()
+    {
+        Event::fakeExcept(ThemeCreating::class);
+
+        $theme = AnimeTheme::factory()
+            ->for(Anime::factory())
+            ->createOne();
+
+        $theme->restore();
+
+        Event::assertNotDispatched(ThemeUpdated::class);
+    }
+
+    /**
      * When a Theme is updated, a ThemeUpdated event shall be dispatched.
      *
      * @return void
      */
     public function testThemeUpdatedEventDispatched()
     {
-        Event::fake(ThemeUpdated::class);
+        Event::fakeExcept(ThemeCreating::class);
 
         $theme = AnimeTheme::factory()
             ->for(Anime::factory())

--- a/tests/Feature/Events/Wiki/AnimeTest.php
+++ b/tests/Feature/Events/Wiki/AnimeTest.php
@@ -64,6 +64,24 @@ class AnimeTest extends TestCase
     }
 
     /**
+     * When an Anime is restored, an AnimeUpdated event shall not be dispatched.
+     * Note: This is a customization that overrides default framework behavior.
+     * An updated event is fired on restore.
+     *
+     * @return void
+     */
+    public function testAnimeRestoresQuietly()
+    {
+        Event::fake();
+
+        $anime = Anime::factory()->createOne();
+
+        $anime->restore();
+
+        Event::assertNotDispatched(AnimeUpdated::class);
+    }
+
+    /**
      * When an Anime is updated, an AnimeUpdated event shall be dispatched.
      *
      * @return void

--- a/tests/Feature/Events/Wiki/ArtistTest.php
+++ b/tests/Feature/Events/Wiki/ArtistTest.php
@@ -64,6 +64,24 @@ class ArtistTest extends TestCase
     }
 
     /**
+     * When an Artist is restored, an ArtistUpdated event shall not be dispatched.
+     * Note: This is a customization that overrides default framework behavior.
+     * An updated event is fired on restore.
+     *
+     * @return void
+     */
+    public function testArtistRestoresQuietly()
+    {
+        Event::fake();
+
+        $artist = Artist::factory()->createOne();
+
+        $artist->restore();
+
+        Event::assertNotDispatched(ArtistUpdated::class);
+    }
+
+    /**
      * When an Artist is updated, an ArtistUpdated event shall be dispatched.
      *
      * @return void

--- a/tests/Feature/Events/Wiki/ExternalResourceTest.php
+++ b/tests/Feature/Events/Wiki/ExternalResourceTest.php
@@ -64,6 +64,24 @@ class ExternalResourceTest extends TestCase
     }
 
     /**
+     * When a Resource is restored, an ExternalResourceUpdated event shall not be dispatched.
+     * Note: This is a customization that overrides default framework behavior.
+     * An updated event is fired on restore.
+     *
+     * @return void
+     */
+    public function testExternalResourceRestoresQuietly()
+    {
+        Event::fake();
+
+        $resource = ExternalResource::factory()->createOne();
+
+        $resource->restore();
+
+        Event::assertNotDispatched(ExternalResourceUpdated::class);
+    }
+
+    /**
      * When an ExternalResource is updated, an ExternalResourceUpdated event shall be dispatched.
      *
      * @return void

--- a/tests/Feature/Events/Wiki/ImageTest.php
+++ b/tests/Feature/Events/Wiki/ImageTest.php
@@ -64,6 +64,24 @@ class ImageTest extends TestCase
     }
 
     /**
+     * When an Image is restored, an ImageUpdated event shall not be dispatched.
+     * Note: This is a customization that overrides default framework behavior.
+     * An updated event is fired on restore.
+     *
+     * @return void
+     */
+    public function testImageRestoresQuietly()
+    {
+        Event::fake();
+
+        $image = Image::factory()->createOne();
+
+        $image->restore();
+
+        Event::assertNotDispatched(ImageUpdated::class);
+    }
+
+    /**
      * When an Image is updated, an ImageUpdated event shall be dispatched.
      *
      * @return void

--- a/tests/Feature/Events/Wiki/SeriesTest.php
+++ b/tests/Feature/Events/Wiki/SeriesTest.php
@@ -64,6 +64,24 @@ class SeriesTest extends TestCase
     }
 
     /**
+     * When a Series is restored, a SeriesUpdated event shall not be dispatched.
+     * Note: This is a customization that overrides default framework behavior.
+     * An updated event is fired on restore.
+     *
+     * @return void
+     */
+    public function testSeriesRestoresQuietly()
+    {
+        Event::fake();
+
+        $series = Series::factory()->createOne();
+
+        $series->restore();
+
+        Event::assertNotDispatched(SeriesUpdated::class);
+    }
+
+    /**
      * When a Series is updated, a SeriesUpdated event shall be dispatched.
      *
      * @return void

--- a/tests/Feature/Events/Wiki/SongTest.php
+++ b/tests/Feature/Events/Wiki/SongTest.php
@@ -64,6 +64,24 @@ class SongTest extends TestCase
     }
 
     /**
+     * When a Song is restored, a SongUpdated event shall not be dispatched.
+     * Note: This is a customization that overrides default framework behavior.
+     * An updated event is fired on restore.
+     *
+     * @return void
+     */
+    public function testSongRestoresQuietly()
+    {
+        Event::fake();
+
+        $song = Song::factory()->createOne();
+
+        $song->restore();
+
+        Event::assertNotDispatched(SongUpdated::class);
+    }
+
+    /**
      * When a Song is updated, a SongUpdated event shall be dispatched.
      *
      * @return void

--- a/tests/Feature/Events/Wiki/StudioTest.php
+++ b/tests/Feature/Events/Wiki/StudioTest.php
@@ -64,6 +64,24 @@ class StudioTest extends TestCase
     }
 
     /**
+     * When a Studio is restored, a StudioUpdated event shall not be dispatched.
+     * Note: This is a customization that overrides default framework behavior.
+     * An updated event is fired on restore.
+     *
+     * @return void
+     */
+    public function testStudioRestoresQuietly()
+    {
+        Event::fake();
+
+        $studio = Studio::factory()->createOne();
+
+        $studio->restore();
+
+        Event::assertNotDispatched(StudioUpdated::class);
+    }
+
+    /**
      * When a Studio is updated, a StudioUpdated event shall be dispatched.
      *
      * @return void

--- a/tests/Feature/Events/Wiki/VideoTest.php
+++ b/tests/Feature/Events/Wiki/VideoTest.php
@@ -64,6 +64,24 @@ class VideoTest extends TestCase
     }
 
     /**
+     * When a Video is restored, a VideoUpdated event shall not be dispatched.
+     * Note: This is a customization that overrides default framework behavior.
+     * An updated event is fired on restore.
+     *
+     * @return void
+     */
+    public function testVideoRestoresQuietly()
+    {
+        Event::fake();
+
+        $video = Video::factory()->createOne();
+
+        $video->restore();
+
+        Event::assertNotDispatched(VideoUpdated::class);
+    }
+
+    /**
      * When a Video is updated, a VideoUpdated event shall be dispatched.
      *
      * @return void


### PR DESCRIPTION
Small addition to fill a gap in test coverage relating to the framework customization that suppresses the firing of updated events on restore.

Fixed a deprecation warning in commonmark.

Bumping dependencies.