### PR TITLE
fix: prefer raising exceptions to failing silently or exiting early [incremental]

### DIFF
--- a/app/Console/Commands/Billing/BalanceReconcileCommand.php
+++ b/app/Console/Commands/Billing/BalanceReconcileCommand.php
@@ -11,15 +11,13 @@ use App\Models\BaseModel;
 use App\Repositories\Eloquent\Billing\DigitalOceanBalanceRepository as DigitalOceanDestinationRepository;
 use App\Repositories\Service\DigitalOcean\Billing\DigitalOceanBalanceRepository as DigitalOceanSourceRepository;
 use Exception;
-use Illuminate\Console\Command;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Str;
 
 /**
  * Class BalanceReconcileCommand.
  */
-class BalanceReconcileCommand extends Command
+class BalanceReconcileCommand extends ServiceReconcileCommand
 {
     use ReconcilesBalanceRepositories;
 
@@ -36,44 +34,6 @@ class BalanceReconcileCommand extends Command
      * @var string
      */
     protected $description = 'Perform set reconciliation between vendor billing API and balance database';
-
-    /**
-     * Execute the console command.
-     *
-     * @return int
-     */
-    public function handle(): int
-    {
-        $key = $this->argument('service');
-        $service = Service::coerce(Str::upper($key));
-
-        if ($service === null) {
-            Log::error("Invalid Service '$key'");
-            $this->error("Invalid Service '$key'");
-
-            return 1;
-        }
-
-        $sourceRepository = $this->getSourceRepository($service);
-        if ($sourceRepository === null) {
-            Log::error("No source repository implemented for Service '$key'");
-            $this->error("No source repository implemented for Service '$key'");
-
-            return 1;
-        }
-
-        $destinationRepository = $this->getDestinationRepository($service);
-        if ($destinationRepository === null) {
-            Log::error("No destination repository implemented for Service '$key'");
-            $this->error("No destination repository implemented for Service '$key'");
-
-            return 1;
-        }
-
-        $this->reconcileRepositories($sourceRepository, $destinationRepository);
-
-        return 0;
-    }
 
     /**
      * Print the result to console and log the results to the app log.

--- a/app/Console/Commands/Billing/ServiceReconcileCommand.php
+++ b/app/Console/Commands/Billing/ServiceReconcileCommand.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Billing;
+
+use App\Contracts\Repositories\Repository;
+use App\Enums\Models\Billing\Service;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+/**
+ * Class ServiceReconcileCommand.
+ */
+abstract class ServiceReconcileCommand extends Command
+{
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle(): int
+    {
+        $key = $this->argument('service');
+        $service = Service::coerce(Str::upper($key));
+
+        if ($service === null) {
+            Log::error("Invalid Service '$key'");
+            $this->error("Invalid Service '$key'");
+
+            return 1;
+        }
+
+        $sourceRepository = $this->getSourceRepository($service);
+        if ($sourceRepository === null) {
+            Log::error("No source repository implemented for Service '$key'");
+            $this->error("No source repository implemented for Service '$key'");
+
+            return 1;
+        }
+
+        $destinationRepository = $this->getDestinationRepository($service);
+        if ($destinationRepository === null) {
+            Log::error("No destination repository implemented for Service '$key'");
+            $this->error("No destination repository implemented for Service '$key'");
+
+            return 1;
+        }
+
+        $this->reconcileRepositories($sourceRepository, $destinationRepository);
+
+        return 0;
+    }
+
+    /**
+     * Perform set reconciliation between source and destination repositories.
+     *
+     * @param  Repository  $source
+     * @param  Repository  $destination
+     * @return void
+     */
+    abstract public function reconcileRepositories(Repository $source, Repository $destination): void;
+
+    /**
+     * Get source repository for service.
+     *
+     * @param  Service  $service
+     * @return Repository|null
+     */
+    abstract protected function getSourceRepository(Service $service): ?Repository;
+
+    /**
+     * Get destination repository for service.
+     *
+     * @param  Service  $service
+     * @return Repository|null
+     */
+    abstract protected function getDestinationRepository(Service $service): ?Repository;
+}

--- a/app/Console/Commands/Billing/TransactionReconcileCommand.php
+++ b/app/Console/Commands/Billing/TransactionReconcileCommand.php
@@ -11,15 +11,13 @@ use App\Models\BaseModel;
 use App\Repositories\Eloquent\Billing\DigitalOceanTransactionRepository as DigitalOceanDestinationRepository;
 use App\Repositories\Service\DigitalOcean\Billing\DigitalOceanTransactionRepository as DigitalOceanSourceRepository;
 use Exception;
-use Illuminate\Console\Command;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Str;
 
 /**
  * Class TransactionReconcileCommand.
  */
-class TransactionReconcileCommand extends Command
+class TransactionReconcileCommand extends ServiceReconcileCommand
 {
     use ReconcilesTransactionRepositories;
 
@@ -36,44 +34,6 @@ class TransactionReconcileCommand extends Command
      * @var string
      */
     protected $description = 'Perform set reconciliation between vendor billing API and transaction database';
-
-    /**
-     * Execute the console command.
-     *
-     * @return int
-     */
-    public function handle(): int
-    {
-        $key = $this->argument('service');
-        $service = Service::coerce(Str::upper($key));
-
-        if ($service === null) {
-            Log::error("Invalid Service '$key'");
-            $this->error("Invalid Service '$key'");
-
-            return 1;
-        }
-
-        $sourceRepository = $this->getSourceRepository($service);
-        if ($sourceRepository === null) {
-            Log::error("No source repository implemented for Service '$key'");
-            $this->error("No source repository implemented for Service '$key'");
-
-            return 1;
-        }
-
-        $destinationRepository = $this->getDestinationRepository($service);
-        if ($destinationRepository === null) {
-            Log::error("No destination repository implemented for Service '$key'");
-            $this->error("No destination repository implemented for Service '$key'");
-
-            return 1;
-        }
-
-        $this->reconcileRepositories($sourceRepository, $destinationRepository);
-
-        return 0;
-    }
 
     /**
      * Print the result to console and log the results to the app log.

--- a/app/Console/Commands/Wiki/DatabaseDumpCommand.php
+++ b/app/Console/Commands/Wiki/DatabaseDumpCommand.php
@@ -193,6 +193,7 @@ class DatabaseDumpCommand extends Command
         // Sqlite version 3.32.0 is required when using the includeTables option
         if ($connection instanceof SQLiteConnection) {
             Log::warning('SQLite version does not support includeTables option');
+
             return version_compare($connection->getPdo()->getAttribute(PDO::ATTR_SERVER_VERSION), '3.32.0', '>=');
         }
 

--- a/app/Http/Api/Criteria/Paging/OffsetCriteria.php
+++ b/app/Http/Api/Criteria/Paging/OffsetCriteria.php
@@ -40,12 +40,12 @@ class OffsetCriteria extends Criteria
      */
     public function paginate(Builder $builder): Collection|Paginator
     {
-        $pageNameQuery = Str::of(PagingParser::$param)
+        $pageNameQuery = Str::of(PagingParser::param())
             ->append('.')
             ->append(self::NUMBER_PARAM)
             ->__toString();
 
-        $pageNameLink = Str::of(PagingParser::$param)
+        $pageNameLink = Str::of(PagingParser::param())
             ->append('[')
             ->append(self::NUMBER_PARAM)
             ->append(']')

--- a/app/Http/Api/Parser/FieldParser.php
+++ b/app/Http/Api/Parser/FieldParser.php
@@ -16,9 +16,12 @@ class FieldParser extends Parser
     /**
      * The parameter to parse.
      *
-     * @var string|null
+     * @return string
      */
-    public static ?string $param = 'fields';
+    public static function param(): string
+    {
+        return 'fields';
+    }
 
     /**
      * Parse sparse fieldsets from parameters.
@@ -30,8 +33,8 @@ class FieldParser extends Parser
     {
         $criteria = [];
 
-        if (Arr::exists($parameters, static::$param)) {
-            $fieldsParam = $parameters[static::$param];
+        if (Arr::exists($parameters, static::param())) {
+            $fieldsParam = $parameters[static::param()];
             if (Arr::accessible($fieldsParam) && Arr::isAssoc($fieldsParam)) {
                 foreach ($fieldsParam as $type => $fieldList) {
                     if ($fieldList !== null && ! Arr::accessible($fieldList)) {

--- a/app/Http/Api/Parser/FilterParser.php
+++ b/app/Http/Api/Parser/FilterParser.php
@@ -20,9 +20,12 @@ class FilterParser extends Parser
     /**
      * The parameter to parse.
      *
-     * @var string|null
+     * @return string
      */
-    public static ?string $param = 'filter';
+    public static function param(): string
+    {
+        return 'filter';
+    }
 
     /**
      * Parse filter criteria from parameters.
@@ -34,8 +37,8 @@ class FilterParser extends Parser
     {
         $criteria = [];
 
-        if (Arr::exists($parameters, static::$param)) {
-            $filterParam = $parameters[static::$param];
+        if (Arr::exists($parameters, static::param())) {
+            $filterParam = $parameters[static::param()];
             if (Arr::accessible($filterParam) && Arr::isAssoc($filterParam)) {
                 foreach (Arr::dot($filterParam) as $filterCriteria => $filterValues) {
                     if ($filterValues !== null) {

--- a/app/Http/Api/Parser/IncludeParser.php
+++ b/app/Http/Api/Parser/IncludeParser.php
@@ -17,9 +17,12 @@ class IncludeParser extends Parser
     /**
      * The parameter to parse.
      *
-     * @var string|null
+     * @return string
      */
-    public static ?string $param = 'include';
+    public static function param(): string
+    {
+        return 'include';
+    }
 
     /**
      * Parse includes from parameters.
@@ -31,8 +34,8 @@ class IncludeParser extends Parser
     {
         $criteria = [];
 
-        if (Arr::exists($parameters, static::$param)) {
-            $includeParam = $parameters[static::$param];
+        if (Arr::exists($parameters, static::param())) {
+            $includeParam = $parameters[static::param()];
             if ($includeParam !== null && ! Arr::accessible($includeParam)) {
                 $criteria[] = static::parseCriteria($includeParam);
             }

--- a/app/Http/Api/Parser/PagingParser.php
+++ b/app/Http/Api/Parser/PagingParser.php
@@ -17,9 +17,12 @@ class PagingParser extends Parser
     /**
      * The parameter to parse.
      *
-     * @var string|null
+     * @return string
      */
-    public static ?string $param = 'page';
+    public static function param(): string
+    {
+        return 'page';
+    }
 
     /**
      * Parse paging from parameters.
@@ -31,7 +34,7 @@ class PagingParser extends Parser
     {
         $criteria = [];
 
-        $pagingParam = Arr::get($parameters, static::$param, []);
+        $pagingParam = Arr::get($parameters, static::param(), []);
         $criteria[] = static::parseLimitCriteria($pagingParam);
         $criteria[] = static::parseOffsetCriteria($pagingParam);
 

--- a/app/Http/Api/Parser/Parser.php
+++ b/app/Http/Api/Parser/Parser.php
@@ -12,9 +12,9 @@ abstract class Parser
     /**
      * The parameter to parse.
      *
-     * @var string|null
+     * @return string
      */
-    public static ?string $param = null;
+    abstract public static function param(): string;
 
     /**
      * Parse parameters to collection.

--- a/app/Http/Api/Parser/SearchParser.php
+++ b/app/Http/Api/Parser/SearchParser.php
@@ -15,9 +15,12 @@ class SearchParser extends Parser
     /**
      * The parameter to parse.
      *
-     * @var string|null
+     * @return string
      */
-    public static ?string $param = 'q';
+    public static function param(): string
+    {
+        return 'q';
+    }
 
     /**
      * Parse search from parameters.
@@ -29,8 +32,8 @@ class SearchParser extends Parser
     {
         $criteria = [];
 
-        if (Arr::exists($parameters, static::$param)) {
-            $searchParam = $parameters[static::$param];
+        if (Arr::exists($parameters, static::param())) {
+            $searchParam = $parameters[static::param()];
             if ($searchParam !== null && ! Arr::accessible($searchParam)) {
                 $criteria[] = static::parseCriteria($searchParam);
             }

--- a/app/Http/Api/Parser/SortParser.php
+++ b/app/Http/Api/Parser/SortParser.php
@@ -20,9 +20,12 @@ class SortParser extends Parser
     /**
      * The parameter to parse.
      *
-     * @var string|null
+     * @return string
      */
-    public static ?string $param = 'sort';
+    public static function param(): string
+    {
+        return 'sort';
+    }
 
     /**
      * Parse sorts from parameters.
@@ -34,8 +37,8 @@ class SortParser extends Parser
     {
         $criteria = [];
 
-        if (Arr::exists($parameters, static::$param)) {
-            $sortParam = $parameters[static::$param];
+        if (Arr::exists($parameters, static::param())) {
+            $sortParam = $parameters[static::param()];
             if ($sortParam !== null && ! Arr::accessible($sortParam)) {
                 $sortValues = Str::of($sortParam)->explode(',');
                 foreach ($sortValues as $sortValue) {

--- a/app/Http/Api/Query/Admin/AnnouncementQuery.php
+++ b/app/Http/Api/Query/Admin/AnnouncementQuery.php
@@ -32,9 +32,9 @@ class AnnouncementQuery extends EloquentQuery
     /**
      * Get the query builder of the resource.
      *
-     * @return Builder|null
+     * @return Builder
      */
-    public function builder(): ?Builder
+    public function builder(): Builder
     {
         return Announcement::query();
     }

--- a/app/Http/Api/Query/Billing/BalanceQuery.php
+++ b/app/Http/Api/Query/Billing/BalanceQuery.php
@@ -32,9 +32,9 @@ class BalanceQuery extends EloquentQuery
     /**
      * Get the query builder of the resource.
      *
-     * @return Builder|null
+     * @return Builder
      */
-    public function builder(): ?Builder
+    public function builder(): Builder
     {
         return Balance::query();
     }

--- a/app/Http/Api/Query/Billing/TransactionQuery.php
+++ b/app/Http/Api/Query/Billing/TransactionQuery.php
@@ -32,9 +32,9 @@ class TransactionQuery extends EloquentQuery
     /**
      * Get the query builder of the resource.
      *
-     * @return Builder|null
+     * @return Builder
      */
-    public function builder(): ?Builder
+    public function builder(): Builder
     {
         return Transaction::query();
     }

--- a/app/Http/Api/Query/Wiki/Anime/SynonymQuery.php
+++ b/app/Http/Api/Query/Wiki/Anime/SynonymQuery.php
@@ -32,9 +32,9 @@ class SynonymQuery extends EloquentQuery
     /**
      * Get the query builder of the resource.
      *
-     * @return Builder|null
+     * @return Builder
      */
-    public function builder(): ?Builder
+    public function builder(): Builder
     {
         return AnimeSynonym::query();
     }

--- a/app/Http/Api/Query/Wiki/Anime/Theme/EntryQuery.php
+++ b/app/Http/Api/Query/Wiki/Anime/Theme/EntryQuery.php
@@ -32,9 +32,9 @@ class EntryQuery extends EloquentQuery
     /**
      * Get the query builder of the resource.
      *
-     * @return Builder|null
+     * @return Builder
      */
-    public function builder(): ?Builder
+    public function builder(): Builder
     {
         return AnimeThemeEntry::query();
     }

--- a/app/Http/Api/Query/Wiki/Anime/ThemeQuery.php
+++ b/app/Http/Api/Query/Wiki/Anime/ThemeQuery.php
@@ -32,9 +32,9 @@ class ThemeQuery extends EloquentQuery
     /**
      * Get the query builder of the resource.
      *
-     * @return Builder|null
+     * @return Builder
      */
-    public function builder(): ?Builder
+    public function builder(): Builder
     {
         return AnimeTheme::query();
     }

--- a/app/Http/Api/Query/Wiki/AnimeQuery.php
+++ b/app/Http/Api/Query/Wiki/AnimeQuery.php
@@ -32,9 +32,9 @@ class AnimeQuery extends EloquentQuery
     /**
      * Get the query builder of the resource.
      *
-     * @return Builder|null
+     * @return Builder
      */
-    public function builder(): ?Builder
+    public function builder(): Builder
     {
         return Anime::query();
     }

--- a/app/Http/Api/Query/Wiki/ArtistQuery.php
+++ b/app/Http/Api/Query/Wiki/ArtistQuery.php
@@ -32,9 +32,9 @@ class ArtistQuery extends EloquentQuery
     /**
      * Get the query builder of the resource.
      *
-     * @return Builder|null
+     * @return Builder
      */
-    public function builder(): ?Builder
+    public function builder(): Builder
     {
         return Artist::query();
     }

--- a/app/Http/Api/Query/Wiki/ExternalResourceQuery.php
+++ b/app/Http/Api/Query/Wiki/ExternalResourceQuery.php
@@ -32,9 +32,9 @@ class ExternalResourceQuery extends EloquentQuery
     /**
      * Get the query builder of the resource.
      *
-     * @return Builder|null
+     * @return Builder
      */
-    public function builder(): ?Builder
+    public function builder(): Builder
     {
         return ExternalResource::query();
     }

--- a/app/Http/Api/Query/Wiki/ImageQuery.php
+++ b/app/Http/Api/Query/Wiki/ImageQuery.php
@@ -32,9 +32,9 @@ class ImageQuery extends EloquentQuery
     /**
      * Get the query builder of the resource.
      *
-     * @return Builder|null
+     * @return Builder
      */
-    public function builder(): ?Builder
+    public function builder(): Builder
     {
         return Image::query();
     }

--- a/app/Http/Api/Query/Wiki/SeriesQuery.php
+++ b/app/Http/Api/Query/Wiki/SeriesQuery.php
@@ -32,9 +32,9 @@ class SeriesQuery extends EloquentQuery
     /**
      * Get the query builder of the resource.
      *
-     * @return Builder|null
+     * @return Builder
      */
-    public function builder(): ?Builder
+    public function builder(): Builder
     {
         return Series::query();
     }

--- a/app/Http/Api/Query/Wiki/SongQuery.php
+++ b/app/Http/Api/Query/Wiki/SongQuery.php
@@ -32,9 +32,9 @@ class SongQuery extends EloquentQuery
     /**
      * Get the query builder of the resource.
      *
-     * @return Builder|null
+     * @return Builder
      */
-    public function builder(): ?Builder
+    public function builder(): Builder
     {
         return Song::query();
     }

--- a/app/Http/Api/Query/Wiki/StudioQuery.php
+++ b/app/Http/Api/Query/Wiki/StudioQuery.php
@@ -32,9 +32,9 @@ class StudioQuery extends EloquentQuery
     /**
      * Get the query builder of the resource.
      *
-     * @return Builder|null
+     * @return Builder
      */
-    public function builder(): ?Builder
+    public function builder(): Builder
     {
         return Studio::query();
     }

--- a/app/Http/Api/Query/Wiki/VideoQuery.php
+++ b/app/Http/Api/Query/Wiki/VideoQuery.php
@@ -32,9 +32,9 @@ class VideoQuery extends EloquentQuery
     /**
      * Get the query builder of the resource.
      *
-     * @return Builder|null
+     * @return Builder
      */
-    public function builder(): ?Builder
+    public function builder(): Builder
     {
         return Video::query();
     }

--- a/app/Http/Middleware/HasOpenInvitation.php
+++ b/app/Http/Middleware/HasOpenInvitation.php
@@ -7,6 +7,9 @@ namespace App\Http\Middleware;
 use App\Models\Auth\Invitation;
 use Closure;
 use Illuminate\Http\Request;
+use RuntimeException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * Class HasOpenInvitation.
@@ -19,13 +22,21 @@ class HasOpenInvitation
      * @param  Request  $request
      * @param  Closure  $next
      * @return mixed
+     *
+     * @throws HttpException
+     * @throws NotFoundHttpException
+     * @throws RuntimeException
      */
     public function handle(Request $request, Closure $next): mixed
     {
         $invitation = $request->route('invitation');
 
-        if (! $invitation instanceof Invitation || ! $invitation->isOpen()) {
-            return redirect(route('welcome'));
+        if (! $invitation instanceof Invitation) {
+            throw new RuntimeException('has_open_invitation should only be configured for invitations');
+        }
+
+        if (! $invitation->isOpen()) {
+            abort(403, 'Closed Invitation');
         }
 
         return $next($request);

--- a/app/Http/Middleware/IsVideoStreamingAllowed.php
+++ b/app/Http/Middleware/IsVideoStreamingAllowed.php
@@ -7,6 +7,8 @@ namespace App\Http\Middleware;
 use App\Constants\Config\FlagConstants;
 use Closure;
 use Illuminate\Http\Request;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * Class IsVideoStreamingAllowed.
@@ -19,11 +21,14 @@ class IsVideoStreamingAllowed
      * @param  Request  $request
      * @param  Closure  $next
      * @return mixed
+     *
+     * @throws HttpException
+     * @throws NotFoundHttpException
      */
     public function handle(Request $request, Closure $next): mixed
     {
         if (! config(FlagConstants::ALLOW_VIDEO_STREAMS_FLAG_QUALIFIED, false)) {
-            return redirect(route('welcome'));
+            abort(403, 'Video Streaming Disabled');
         }
 
         return $next($request);

--- a/app/Http/Middleware/RecordView.php
+++ b/app/Http/Middleware/RecordView.php
@@ -8,6 +8,7 @@ use App\Constants\Config\FlagConstants;
 use Closure;
 use CyrildeWit\EloquentViewable\Contracts\Viewable;
 use Illuminate\Http\Request;
+use RuntimeException;
 
 /**
  * Class RecordView.
@@ -26,7 +27,11 @@ class RecordView
     {
         $model = $request->route($modelKey);
 
-        if ($model instanceof Viewable && config(FlagConstants::ALLOW_VIEW_RECORDING_FLAG_QUALIFIED, false)) {
+        if (! $model instanceof Viewable) {
+            throw new RuntimeException('record_view should only be configured for viewable models');
+        }
+
+        if (config(FlagConstants::ALLOW_VIEW_RECORDING_FLAG_QUALIFIED, false)) {
             views($model)->cooldown(now()->addMinutes(5))->record();
         }
 

--- a/app/Http/Middleware/WithoutTrashed.php
+++ b/app/Http/Middleware/WithoutTrashed.php
@@ -7,6 +7,7 @@ namespace App\Http\Middleware;
 use App\Models\BaseModel;
 use Closure;
 use Illuminate\Http\Request;
+use RuntimeException;
 
 /**
  * Class WithoutTrashed.
@@ -25,8 +26,12 @@ class WithoutTrashed
     {
         $model = $request->route($modelKey);
 
-        if (! $model instanceof BaseModel || $model->trashed()) {
-            return redirect(route('welcome'));
+        if (! $model instanceof BaseModel) {
+            throw new RuntimeException('without_trashed should only be configured for models that can be soft deleted');
+        }
+
+        if ($model->trashed()) {
+            abort(403, 'Deleted Model');
         }
 
         return $next($request);

--- a/app/Http/Requests/Api/BaseRequest.php
+++ b/app/Http/Requests/Api/BaseRequest.php
@@ -72,7 +72,7 @@ abstract class BaseRequest extends FormRequest
         return array_merge(
             $rules,
             [
-                FieldParser::$param => [
+                FieldParser::param() => [
                     'nullable',
                     Str::of('array:')->append($types->join(','))->__toString(),
                 ],
@@ -89,7 +89,7 @@ abstract class BaseRequest extends FormRequest
     protected function getSchemaFieldRules(Schema $schema): array
     {
         return [
-            Str::of(FieldParser::$param)
+            Str::of(FieldParser::param())
                 ->append('.')
                 ->append($schema->type())
                 ->__toString() => [
@@ -109,7 +109,7 @@ abstract class BaseRequest extends FormRequest
     {
         // TODO: placeholder so that filter is passed by form request as validated to DTO
         return [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 'nullable',
             ],
         ];
@@ -128,14 +128,14 @@ abstract class BaseRequest extends FormRequest
 
         if ($allowedIncludes->isEmpty()) {
             return [
-                IncludeParser::$param => [
+                IncludeParser::param() => [
                     'prohibited',
                 ],
             ];
         }
 
         return [
-            IncludeParser::$param => [
+            IncludeParser::param() => [
                 'sometimes',
                 'required',
                 new Delimited(Rule::in($allowedIncludes->map(fn (AllowedInclude $include) => $include->path()))),

--- a/app/Http/Requests/Api/IndexRequest.php
+++ b/app/Http/Requests/Api/IndexRequest.php
@@ -31,7 +31,7 @@ abstract class IndexRequest extends BaseRequest
     protected function getPagingRules(): array
     {
         return [
-            PagingParser::$param => [
+            PagingParser::param() => [
                 'sometimes',
                 'required',
                 Str::of('array:')
@@ -40,13 +40,13 @@ abstract class IndexRequest extends BaseRequest
                     ->append(OffsetCriteria::SIZE_PARAM)
                     ->__toString(),
             ],
-            Str::of(PagingParser::$param)
+            Str::of(PagingParser::param())
                 ->append('.')
                 ->append(LimitCriteria::PARAM)
                 ->__toString() => [
                     'prohibited',
                 ],
-            Str::of(PagingParser::$param)
+            Str::of(PagingParser::param())
                 ->append('.')
                 ->append(OffsetCriteria::NUMBER_PARAM)
                 ->__toString() => [
@@ -55,7 +55,7 @@ abstract class IndexRequest extends BaseRequest
                     'integer',
                     'min:1',
                 ],
-            Str::of(PagingParser::$param)
+            Str::of(PagingParser::param())
                 ->append('.')
                 ->append(OffsetCriteria::SIZE_PARAM)
                 ->__toString() => [
@@ -77,7 +77,7 @@ abstract class IndexRequest extends BaseRequest
     {
         if ($this instanceof SearchableRequest) {
             return [
-                SearchParser::$param => [
+                SearchParser::param() => [
                     'sometimes',
                     'required',
                     'string',
@@ -86,7 +86,7 @@ abstract class IndexRequest extends BaseRequest
         }
 
         return [
-            SearchParser::$param => [
+            SearchParser::param() => [
                 'prohibited',
             ],
         ];
@@ -112,14 +112,14 @@ abstract class IndexRequest extends BaseRequest
 
         if ($allowedSorts->isEmpty()) {
             return [
-                SortParser::$param => [
+                SortParser::param() => [
                     'prohibited',
                 ],
             ];
         }
 
         return [
-            SortParser::$param => [
+            SortParser::param() => [
                 'sometimes',
                 'required',
                 new Delimited(Rule::in($allowedSorts)),

--- a/app/Http/Requests/Api/ShowRequest.php
+++ b/app/Http/Requests/Api/ShowRequest.php
@@ -21,7 +21,7 @@ abstract class ShowRequest extends BaseRequest
     protected function getPagingRules(): array
     {
         return [
-            PagingParser::$param => [
+            PagingParser::param() => [
                 'prohibited',
             ],
         ];
@@ -35,7 +35,7 @@ abstract class ShowRequest extends BaseRequest
     protected function getSearchRules(): array
     {
         return [
-            SearchParser::$param => [
+            SearchParser::param() => [
                 'prohibited',
             ],
         ];
@@ -49,7 +49,7 @@ abstract class ShowRequest extends BaseRequest
     protected function getSortRules(): array
     {
         return [
-            SortParser::$param => [
+            SortParser::param() => [
                 'prohibited',
             ],
         ];

--- a/app/Http/Requests/Api/Wiki/Anime/YearIndexRequest.php
+++ b/app/Http/Requests/Api/Wiki/Anime/YearIndexRequest.php
@@ -29,7 +29,7 @@ class YearIndexRequest extends BaseRequest
     protected function getIncludeRules(): array
     {
         return [
-            IncludeParser::$param => [
+            IncludeParser::param() => [
                 'prohibited',
             ],
         ];
@@ -43,7 +43,7 @@ class YearIndexRequest extends BaseRequest
     protected function getPagingRules(): array
     {
         return [
-            PagingParser::$param => [
+            PagingParser::param() => [
                 'prohibited',
             ],
         ];
@@ -57,7 +57,7 @@ class YearIndexRequest extends BaseRequest
     protected function getSearchRules(): array
     {
         return [
-            SearchParser::$param => [
+            SearchParser::param() => [
                 'prohibited',
             ],
         ];
@@ -71,7 +71,7 @@ class YearIndexRequest extends BaseRequest
     protected function getSortRules(): array
     {
         return [
-            SortParser::$param => [
+            SortParser::param() => [
                 'prohibited',
             ],
         ];

--- a/app/Http/Requests/Api/Wiki/SearchRequest.php
+++ b/app/Http/Requests/Api/Wiki/SearchRequest.php
@@ -53,7 +53,7 @@ class SearchRequest extends FormRequest
     protected function getFieldRules(): array
     {
         return [
-            FieldParser::$param => [
+            FieldParser::param() => [
                 'nullable',
             ],
         ];
@@ -67,7 +67,7 @@ class SearchRequest extends FormRequest
     protected function getFilterRules(): array
     {
         return [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 'nullable',
             ],
         ];
@@ -81,7 +81,7 @@ class SearchRequest extends FormRequest
     protected function getIncludeRules(): array
     {
         return [
-            IncludeParser::$param => [
+            IncludeParser::param() => [
                 'nullable',
             ],
         ];
@@ -95,7 +95,7 @@ class SearchRequest extends FormRequest
     protected function getPagingRules(): array
     {
         return [
-            PagingParser::$param => [
+            PagingParser::param() => [
                 'nullable',
             ],
         ];
@@ -109,7 +109,7 @@ class SearchRequest extends FormRequest
     protected function getSearchRules(): array
     {
         return [
-            SearchParser::$param => [
+            SearchParser::param() => [
                 'required',
             ],
         ];
@@ -123,7 +123,7 @@ class SearchRequest extends FormRequest
     protected function getSortRules(): array
     {
         return [
-            SortParser::$param => [
+            SortParser::param() => [
                 'nullable',
             ],
         ];

--- a/app/Repositories/Service/DigitalOcean/Billing/DigitalOceanBalanceRepository.php
+++ b/app/Repositories/Service/DigitalOcean/Billing/DigitalOceanBalanceRepository.php
@@ -17,6 +17,7 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use RuntimeException;
 
 /**
  * Class DigitalOceanBalanceRepository.
@@ -34,9 +35,7 @@ class DigitalOceanBalanceRepository implements Repository
         // Do not proceed if we do not have authorization to the DO API
         $doBearerToken = Config::get('services.do.token');
         if ($doBearerToken === null) {
-            Log::error('DO_BEARER_TOKEN must be configured in your env file.');
-
-            return Collection::make();
+            throw new RuntimeException('DO_BEARER_TOKEN must be configured in your env file.');
         }
 
         try {

--- a/app/Repositories/Service/DigitalOcean/Billing/DigitalOceanTransactionRepository.php
+++ b/app/Repositories/Service/DigitalOcean/Billing/DigitalOceanTransactionRepository.php
@@ -17,6 +17,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use RuntimeException;
 
 /**
  * Class DigitalOceanTransactionRepository.
@@ -34,9 +35,7 @@ class DigitalOceanTransactionRepository implements Repository
         // Do not proceed if we do not have authorization to the DO API
         $doBearerToken = Config::get('services.do.token');
         if ($doBearerToken === null) {
-            Log::error('DO_BEARER_TOKEN must be configured in your env file.');
-
-            return Collection::make();
+            throw new RuntimeException('DO_BEARER_TOKEN must be configured in your env file.');
         }
 
         $sourceTransactions = [];

--- a/app/Services/Elasticsearch/Api/Criteria/Paging/OffsetCriteria.php
+++ b/app/Services/Elasticsearch/Api/Criteria/Paging/OffsetCriteria.php
@@ -35,12 +35,12 @@ class OffsetCriteria extends Criteria
      */
     public function paginate(SearchRequestBuilder $builder): Collection|Paginator
     {
-        $pageNameQuery = Str::of(PagingParser::$param)
+        $pageNameQuery = Str::of(PagingParser::param())
             ->append('.')
             ->append(BaseCriteria::NUMBER_PARAM)
             ->__toString();
 
-        $pageNameLink = Str::of(PagingParser::$param)
+        $pageNameLink = Str::of(PagingParser::param())
             ->append('[')
             ->append(BaseCriteria::NUMBER_PARAM)
             ->append(']')

--- a/tests/Feature/Http/Api/Admin/Announcement/AnnouncementIndexTest.php
+++ b/tests/Feature/Http/Api/Admin/Announcement/AnnouncementIndexTest.php
@@ -88,7 +88,7 @@ class AnnouncementIndexTest extends TestCase
         $includedFields = $fields->random($this->faker->numberBetween(1, $fields->count()));
 
         $parameters = [
-            FieldParser::$param => [
+            FieldParser::param() => [
                 AnnouncementResource::$wrap => $includedFields->map(fn (Field $field) => $field->getKey())->join(','),
             ],
         ];
@@ -123,7 +123,7 @@ class AnnouncementIndexTest extends TestCase
         $field = $fields[array_rand($fields)];
 
         $parameters = [
-            SortParser::$param => $field->getSort()->format(Direction::getRandomInstance()),
+            SortParser::param() => $field->getSort()->format(Direction::getRandomInstance()),
         ];
 
         $query = AnnouncementQuery::make($parameters);
@@ -155,10 +155,10 @@ class AnnouncementIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_CREATED_AT => $createdFilter,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -198,10 +198,10 @@ class AnnouncementIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_UPDATED_AT => $updatedFilter,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -238,10 +238,10 @@ class AnnouncementIndexTest extends TestCase
     public function testWithoutTrashedFilter(): void
     {
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITHOUT,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -277,10 +277,10 @@ class AnnouncementIndexTest extends TestCase
     public function testWithTrashedFilter(): void
     {
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITH,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -316,10 +316,10 @@ class AnnouncementIndexTest extends TestCase
     public function testOnlyTrashedFilter(): void
     {
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::ONLY,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -358,11 +358,11 @@ class AnnouncementIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_DELETED_AT => $deletedFilter,
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITH,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];

--- a/tests/Feature/Http/Api/Admin/Announcement/AnnouncementShowTest.php
+++ b/tests/Feature/Http/Api/Admin/Announcement/AnnouncementShowTest.php
@@ -86,7 +86,7 @@ class AnnouncementShowTest extends TestCase
         $includedFields = $fields->random($this->faker->numberBetween(1, $fields->count()));
 
         $parameters = [
-            FieldParser::$param => [
+            FieldParser::param() => [
                 AnnouncementResource::$wrap => $includedFields->map(fn (Field $field) => $field->getKey())->join(','),
             ],
         ];

--- a/tests/Feature/Http/Api/Billing/Balance/BalanceIndexTest.php
+++ b/tests/Feature/Http/Api/Billing/Balance/BalanceIndexTest.php
@@ -88,7 +88,7 @@ class BalanceIndexTest extends TestCase
         $includedFields = $fields->random($this->faker->numberBetween(1, $fields->count()));
 
         $parameters = [
-            FieldParser::$param => [
+            FieldParser::param() => [
                 BalanceResource::$wrap => $includedFields->map(fn (Field $field) => $field->getKey())->join(','),
             ],
         ];
@@ -123,7 +123,7 @@ class BalanceIndexTest extends TestCase
         $field = $fields[array_rand($fields)];
 
         $parameters = [
-            SortParser::$param => $field->getSort()->format(Direction::getRandomInstance()),
+            SortParser::param() => $field->getSort()->format(Direction::getRandomInstance()),
         ];
 
         $query = BalanceQuery::make($parameters);
@@ -155,10 +155,10 @@ class BalanceIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_CREATED_AT => $createdFilter,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -198,10 +198,10 @@ class BalanceIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_UPDATED_AT => $updatedFilter,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -238,10 +238,10 @@ class BalanceIndexTest extends TestCase
     public function testWithoutTrashedFilter(): void
     {
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITHOUT,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -277,10 +277,10 @@ class BalanceIndexTest extends TestCase
     public function testWithTrashedFilter(): void
     {
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITH,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -316,10 +316,10 @@ class BalanceIndexTest extends TestCase
     public function testOnlyTrashedFilter(): void
     {
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::ONLY,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -358,11 +358,11 @@ class BalanceIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_DELETED_AT => $deletedFilter,
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITH,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];

--- a/tests/Feature/Http/Api/Billing/Balance/BalanceShowTest.php
+++ b/tests/Feature/Http/Api/Billing/Balance/BalanceShowTest.php
@@ -86,7 +86,7 @@ class BalanceShowTest extends TestCase
         $includedFields = $fields->random($this->faker->numberBetween(1, $fields->count()));
 
         $parameters = [
-            FieldParser::$param => [
+            FieldParser::param() => [
                 BalanceResource::$wrap => $includedFields->map(fn (Field $field) => $field->getKey())->join(','),
             ],
         ];

--- a/tests/Feature/Http/Api/Billing/Transaction/TransactionIndexTest.php
+++ b/tests/Feature/Http/Api/Billing/Transaction/TransactionIndexTest.php
@@ -88,7 +88,7 @@ class TransactionIndexTest extends TestCase
         $includedFields = $fields->random($this->faker->numberBetween(1, $fields->count()));
 
         $parameters = [
-            FieldParser::$param => [
+            FieldParser::param() => [
                 TransactionResource::$wrap => $includedFields->map(fn (Field $field) => $field->getKey())->join(','),
             ],
         ];
@@ -123,7 +123,7 @@ class TransactionIndexTest extends TestCase
         $field = $fields[array_rand($fields)];
 
         $parameters = [
-            SortParser::$param => $field->getSort()->format(Direction::getRandomInstance()),
+            SortParser::param() => $field->getSort()->format(Direction::getRandomInstance()),
         ];
 
         $query = TransactionQuery::make($parameters);
@@ -155,10 +155,10 @@ class TransactionIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_CREATED_AT => $createdFilter,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -198,10 +198,10 @@ class TransactionIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_UPDATED_AT => $updatedFilter,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -238,10 +238,10 @@ class TransactionIndexTest extends TestCase
     public function testWithoutTrashedFilter(): void
     {
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITHOUT,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -277,10 +277,10 @@ class TransactionIndexTest extends TestCase
     public function testWithTrashedFilter(): void
     {
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITH,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -316,10 +316,10 @@ class TransactionIndexTest extends TestCase
     public function testOnlyTrashedFilter(): void
     {
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::ONLY,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -358,11 +358,11 @@ class TransactionIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_DELETED_AT => $deletedFilter,
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITH,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];

--- a/tests/Feature/Http/Api/Billing/Transaction/TransactionShowTest.php
+++ b/tests/Feature/Http/Api/Billing/Transaction/TransactionShowTest.php
@@ -86,7 +86,7 @@ class TransactionShowTest extends TestCase
         $includedFields = $fields->random($this->faker->numberBetween(1, $fields->count()));
 
         $parameters = [
-            FieldParser::$param => [
+            FieldParser::param() => [
                 TransactionResource::$wrap => $includedFields->map(fn (Field $field) => $field->getKey())->join(','),
             ],
         ];

--- a/tests/Feature/Http/Api/Config/FlagsShowTest.php
+++ b/tests/Feature/Http/Api/Config/FlagsShowTest.php
@@ -66,7 +66,7 @@ class FlagsShowTest extends TestCase
         $includedFields = $fields->random($this->faker->numberBetween(1, $fields->count()));
 
         $parameters = [
-            FieldParser::$param => [
+            FieldParser::param() => [
                 FlagsResource::$wrap => $includedFields->map(fn (Field $field) => $field->getKey())->join(','),
             ],
         ];

--- a/tests/Feature/Http/Api/Config/WikiShowTest.php
+++ b/tests/Feature/Http/Api/Config/WikiShowTest.php
@@ -67,7 +67,7 @@ class WikiShowTest extends TestCase
         $includedFields = $fields->random($this->faker->numberBetween(1, $fields->count()));
 
         $parameters = [
-            FieldParser::$param => [
+            FieldParser::param() => [
                 WikiResource::$wrap => $includedFields->map(fn (Field $field) => $field->getKey())->join(','),
             ],
         ];

--- a/tests/Feature/Http/Api/Wiki/Anime/AnimeIndexTest.php
+++ b/tests/Feature/Http/Api/Wiki/Anime/AnimeIndexTest.php
@@ -109,7 +109,7 @@ class AnimeIndexTest extends TestCase
         $includedPaths = $selectedIncludes->map(fn (AllowedInclude $include) => $include->path());
 
         $parameters = [
-            IncludeParser::$param => $includedPaths->join(','),
+            IncludeParser::param() => $includedPaths->join(','),
         ];
 
         Anime::factory()->jsonApiResource()->count($this->faker->numberBetween(1, 3))->create();
@@ -145,7 +145,7 @@ class AnimeIndexTest extends TestCase
         $includedFields = $fields->random($this->faker->numberBetween(1, $fields->count()));
 
         $parameters = [
-            FieldParser::$param => [
+            FieldParser::param() => [
                 AnimeResource::$wrap => $includedFields->map(fn (Field $field) => $field->getKey())->join(','),
             ],
         ];
@@ -182,7 +182,7 @@ class AnimeIndexTest extends TestCase
             ->random();
 
         $parameters = [
-            SortParser::$param => $field->getSort()->format(Direction::getRandomInstance()),
+            SortParser::param() => $field->getSort()->format(Direction::getRandomInstance()),
         ];
 
         $query = AnimeQuery::make($parameters);
@@ -215,7 +215,7 @@ class AnimeIndexTest extends TestCase
         $seasonFilter = AnimeSeason::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_SEASON => $seasonFilter->description,
             ],
         ];
@@ -249,7 +249,7 @@ class AnimeIndexTest extends TestCase
         $yearFilter = $this->faker->numberBetween(2000, 2002);
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_YEAR => $yearFilter,
             ],
         ];
@@ -292,10 +292,10 @@ class AnimeIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_CREATED_AT => $createdFilter,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -337,10 +337,10 @@ class AnimeIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_UPDATED_AT => $updatedFilter,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -379,10 +379,10 @@ class AnimeIndexTest extends TestCase
         $this->withoutEvents();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITHOUT,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -420,10 +420,10 @@ class AnimeIndexTest extends TestCase
         $this->withoutEvents();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITH,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -461,10 +461,10 @@ class AnimeIndexTest extends TestCase
         $this->withoutEvents();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::ONLY,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -505,11 +505,11 @@ class AnimeIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_DELETED_AT => $deletedFilter,
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITH,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -555,10 +555,10 @@ class AnimeIndexTest extends TestCase
         $excludedGroup = $this->faker->word();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeTheme::ATTRIBUTE_GROUP => $groupFilter,
             ],
-            IncludeParser::$param => Anime::RELATION_THEMES,
+            IncludeParser::param() => Anime::RELATION_THEMES,
         ];
 
         Anime::factory()
@@ -605,10 +605,10 @@ class AnimeIndexTest extends TestCase
         $excludedSequence = $sequenceFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeTheme::ATTRIBUTE_SEQUENCE => $sequenceFilter,
             ],
-            IncludeParser::$param => Anime::RELATION_THEMES,
+            IncludeParser::param() => Anime::RELATION_THEMES,
         ];
 
         Anime::factory()
@@ -654,10 +654,10 @@ class AnimeIndexTest extends TestCase
         $typeFilter = ThemeType::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeTheme::ATTRIBUTE_TYPE => $typeFilter->description,
             ],
-            IncludeParser::$param => Anime::RELATION_THEMES,
+            IncludeParser::param() => Anime::RELATION_THEMES,
         ];
 
         Anime::factory()
@@ -696,10 +696,10 @@ class AnimeIndexTest extends TestCase
         $nsfwFilter = $this->faker->boolean();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeThemeEntry::ATTRIBUTE_NSFW => $nsfwFilter,
             ],
-            IncludeParser::$param => Anime::RELATION_ENTRIES,
+            IncludeParser::param() => Anime::RELATION_ENTRIES,
         ];
 
         Anime::factory()
@@ -742,10 +742,10 @@ class AnimeIndexTest extends TestCase
         $spoilerFilter = $this->faker->boolean();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeThemeEntry::ATTRIBUTE_SPOILER => $spoilerFilter,
             ],
-            IncludeParser::$param => Anime::RELATION_ENTRIES,
+            IncludeParser::param() => Anime::RELATION_ENTRIES,
         ];
 
         Anime::factory()
@@ -789,10 +789,10 @@ class AnimeIndexTest extends TestCase
         $excludedVersion = $versionFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeThemeEntry::ATTRIBUTE_VERSION => $versionFilter,
             ],
-            IncludeParser::$param => Anime::RELATION_ENTRIES,
+            IncludeParser::param() => Anime::RELATION_ENTRIES,
         ];
 
         Anime::factory()
@@ -842,10 +842,10 @@ class AnimeIndexTest extends TestCase
         $siteFilter = ResourceSite::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 ExternalResource::ATTRIBUTE_SITE => $siteFilter->description,
             ],
-            IncludeParser::$param => Anime::RELATION_RESOURCES,
+            IncludeParser::param() => Anime::RELATION_RESOURCES,
         ];
 
         Anime::factory()
@@ -884,10 +884,10 @@ class AnimeIndexTest extends TestCase
         $facetFilter = ImageFacet::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Image::ATTRIBUTE_FACET => $facetFilter->description,
             ],
-            IncludeParser::$param => Anime::RELATION_IMAGES,
+            IncludeParser::param() => Anime::RELATION_IMAGES,
         ];
 
         Anime::factory()
@@ -926,10 +926,10 @@ class AnimeIndexTest extends TestCase
         $lyricsFilter = $this->faker->boolean();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Video::ATTRIBUTE_LYRICS => $lyricsFilter,
             ],
-            IncludeParser::$param => Anime::RELATION_VIDEOS,
+            IncludeParser::param() => Anime::RELATION_VIDEOS,
         ];
 
         Anime::factory()->jsonApiResource()->count($this->faker->numberBetween(1, 3))->create();
@@ -965,10 +965,10 @@ class AnimeIndexTest extends TestCase
         $ncFilter = $this->faker->boolean();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Video::ATTRIBUTE_NC => $ncFilter,
             ],
-            IncludeParser::$param => Anime::RELATION_VIDEOS,
+            IncludeParser::param() => Anime::RELATION_VIDEOS,
         ];
 
         Anime::factory()->jsonApiResource()->count($this->faker->numberBetween(1, 3))->create();
@@ -1004,10 +1004,10 @@ class AnimeIndexTest extends TestCase
         $overlapFilter = VideoOverlap::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Video::ATTRIBUTE_OVERLAP => $overlapFilter->description,
             ],
-            IncludeParser::$param => Anime::RELATION_VIDEOS,
+            IncludeParser::param() => Anime::RELATION_VIDEOS,
         ];
 
         Anime::factory()->jsonApiResource()->count($this->faker->numberBetween(1, 3))->create();
@@ -1044,10 +1044,10 @@ class AnimeIndexTest extends TestCase
         $excludedResolution = $resolutionFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Video::ATTRIBUTE_RESOLUTION => $resolutionFilter,
             ],
-            IncludeParser::$param => Anime::RELATION_VIDEOS,
+            IncludeParser::param() => Anime::RELATION_VIDEOS,
         ];
 
         Anime::factory()
@@ -1101,10 +1101,10 @@ class AnimeIndexTest extends TestCase
         $sourceFilter = VideoSource::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Video::ATTRIBUTE_SOURCE => $sourceFilter->description,
             ],
-            IncludeParser::$param => Anime::RELATION_VIDEOS,
+            IncludeParser::param() => Anime::RELATION_VIDEOS,
         ];
 
         Anime::factory()->jsonApiResource()->count($this->faker->numberBetween(1, 3))->create();
@@ -1140,10 +1140,10 @@ class AnimeIndexTest extends TestCase
         $subbedFilter = $this->faker->boolean();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Video::ATTRIBUTE_SUBBED => $subbedFilter,
             ],
-            IncludeParser::$param => Anime::RELATION_VIDEOS,
+            IncludeParser::param() => Anime::RELATION_VIDEOS,
         ];
 
         Anime::factory()->jsonApiResource()->count($this->faker->numberBetween(1, 3))->create();
@@ -1179,10 +1179,10 @@ class AnimeIndexTest extends TestCase
         $uncenFilter = $this->faker->boolean();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Video::ATTRIBUTE_UNCEN => $uncenFilter,
             ],
-            IncludeParser::$param => Anime::RELATION_VIDEOS,
+            IncludeParser::param() => Anime::RELATION_VIDEOS,
         ];
 
         Anime::factory()->jsonApiResource()->count($this->faker->numberBetween(1, 3))->create();

--- a/tests/Feature/Http/Api/Wiki/Anime/AnimeShowTest.php
+++ b/tests/Feature/Http/Api/Wiki/Anime/AnimeShowTest.php
@@ -106,7 +106,7 @@ class AnimeShowTest extends TestCase
         $includedPaths = $selectedIncludes->map(fn (AllowedInclude $include) => $include->path());
 
         $parameters = [
-            IncludeParser::$param => $includedPaths->join(','),
+            IncludeParser::param() => $includedPaths->join(','),
         ];
 
         Anime::factory()->jsonApiResource()->create();
@@ -142,7 +142,7 @@ class AnimeShowTest extends TestCase
         $includedFields = $fields->random($this->faker->numberBetween(1, $fields->count()));
 
         $parameters = [
-            FieldParser::$param => [
+            FieldParser::param() => [
                 AnimeResource::$wrap => $includedFields->map(fn (Field $field) => $field->getKey())->join(','),
             ],
         ];
@@ -174,10 +174,10 @@ class AnimeShowTest extends TestCase
         $excludedGroup = $this->faker->word();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeTheme::ATTRIBUTE_GROUP => $groupFilter,
             ],
-            IncludeParser::$param => Anime::RELATION_THEMES,
+            IncludeParser::param() => Anime::RELATION_THEMES,
         ];
 
         Anime::factory()
@@ -223,10 +223,10 @@ class AnimeShowTest extends TestCase
         $excludedSequence = $sequenceFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeTheme::ATTRIBUTE_SEQUENCE => $sequenceFilter,
             ],
-            IncludeParser::$param => Anime::RELATION_THEMES,
+            IncludeParser::param() => Anime::RELATION_THEMES,
         ];
 
         Anime::factory()
@@ -271,10 +271,10 @@ class AnimeShowTest extends TestCase
         $typeFilter = ThemeType::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeTheme::ATTRIBUTE_TYPE => $typeFilter->description,
             ],
-            IncludeParser::$param => Anime::RELATION_THEMES,
+            IncludeParser::param() => Anime::RELATION_THEMES,
         ];
 
         Anime::factory()
@@ -312,10 +312,10 @@ class AnimeShowTest extends TestCase
         $nsfwFilter = $this->faker->boolean();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeThemeEntry::ATTRIBUTE_NSFW => $nsfwFilter,
             ],
-            IncludeParser::$param => Anime::RELATION_ENTRIES,
+            IncludeParser::param() => Anime::RELATION_ENTRIES,
         ];
 
         Anime::factory()
@@ -357,10 +357,10 @@ class AnimeShowTest extends TestCase
         $spoilerFilter = $this->faker->boolean();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeThemeEntry::ATTRIBUTE_SPOILER => $spoilerFilter,
             ],
-            IncludeParser::$param => Anime::RELATION_ENTRIES,
+            IncludeParser::param() => Anime::RELATION_ENTRIES,
         ];
 
         Anime::factory()
@@ -403,10 +403,10 @@ class AnimeShowTest extends TestCase
         $excludedVersion = $versionFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeThemeEntry::ATTRIBUTE_VERSION => $versionFilter,
             ],
-            IncludeParser::$param => Anime::RELATION_ENTRIES,
+            IncludeParser::param() => Anime::RELATION_ENTRIES,
         ];
 
         Anime::factory()
@@ -457,10 +457,10 @@ class AnimeShowTest extends TestCase
         $siteFilter = ResourceSite::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 ExternalResource::ATTRIBUTE_SITE => $siteFilter->description,
             ],
-            IncludeParser::$param => Anime::RELATION_RESOURCES,
+            IncludeParser::param() => Anime::RELATION_RESOURCES,
         ];
 
         Anime::factory()
@@ -500,10 +500,10 @@ class AnimeShowTest extends TestCase
         $facetFilter = ImageFacet::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Image::ATTRIBUTE_FACET => $facetFilter->description,
             ],
-            IncludeParser::$param => Anime::RELATION_IMAGES,
+            IncludeParser::param() => Anime::RELATION_IMAGES,
         ];
 
         Anime::factory()
@@ -541,10 +541,10 @@ class AnimeShowTest extends TestCase
         $lyricsFilter = $this->faker->boolean();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Video::ATTRIBUTE_LYRICS => $lyricsFilter,
             ],
-            IncludeParser::$param => Anime::RELATION_VIDEOS,
+            IncludeParser::param() => Anime::RELATION_VIDEOS,
         ];
 
         Anime::factory()->jsonApiResource()->create();
@@ -580,10 +580,10 @@ class AnimeShowTest extends TestCase
         $ncFilter = $this->faker->boolean();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Video::ATTRIBUTE_NC => $ncFilter,
             ],
-            IncludeParser::$param => Anime::RELATION_VIDEOS,
+            IncludeParser::param() => Anime::RELATION_VIDEOS,
         ];
 
         Anime::factory()->jsonApiResource()->create();
@@ -619,10 +619,10 @@ class AnimeShowTest extends TestCase
         $overlapFilter = VideoOverlap::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Video::ATTRIBUTE_OVERLAP => $overlapFilter->description,
             ],
-            IncludeParser::$param => Anime::RELATION_VIDEOS,
+            IncludeParser::param() => Anime::RELATION_VIDEOS,
         ];
 
         Anime::factory()->jsonApiResource()->create();
@@ -659,10 +659,10 @@ class AnimeShowTest extends TestCase
         $excludedResolution = $resolutionFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Video::ATTRIBUTE_RESOLUTION => $resolutionFilter,
             ],
-            IncludeParser::$param => Anime::RELATION_VIDEOS,
+            IncludeParser::param() => Anime::RELATION_VIDEOS,
         ];
 
         Anime::factory()
@@ -715,10 +715,10 @@ class AnimeShowTest extends TestCase
         $sourceFilter = VideoSource::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Video::ATTRIBUTE_SOURCE => $sourceFilter->description,
             ],
-            IncludeParser::$param => Anime::RELATION_VIDEOS,
+            IncludeParser::param() => Anime::RELATION_VIDEOS,
         ];
 
         Anime::factory()->jsonApiResource()->create();
@@ -754,10 +754,10 @@ class AnimeShowTest extends TestCase
         $subbedFilter = $this->faker->boolean();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Video::ATTRIBUTE_SUBBED => $subbedFilter,
             ],
-            IncludeParser::$param => Anime::RELATION_VIDEOS,
+            IncludeParser::param() => Anime::RELATION_VIDEOS,
         ];
 
         Anime::factory()->jsonApiResource()->create();
@@ -793,10 +793,10 @@ class AnimeShowTest extends TestCase
         $uncenFilter = $this->faker->boolean();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Video::ATTRIBUTE_UNCEN => $uncenFilter,
             ],
-            IncludeParser::$param => Anime::RELATION_VIDEOS,
+            IncludeParser::param() => Anime::RELATION_VIDEOS,
         ];
 
         Anime::factory()->jsonApiResource()->create();

--- a/tests/Feature/Http/Api/Wiki/Anime/Synonym/SynonymIndexTest.php
+++ b/tests/Feature/Http/Api/Wiki/Anime/Synonym/SynonymIndexTest.php
@@ -104,7 +104,7 @@ class SynonymIndexTest extends TestCase
         $includedPaths = $selectedIncludes->map(fn (AllowedInclude $include) => $include->path());
 
         $parameters = [
-            IncludeParser::$param => $includedPaths->join(','),
+            IncludeParser::param() => $includedPaths->join(','),
         ];
 
         AnimeSynonym::factory()
@@ -142,7 +142,7 @@ class SynonymIndexTest extends TestCase
         $includedFields = $fields->random($this->faker->numberBetween(1, $fields->count()));
 
         $parameters = [
-            FieldParser::$param => [
+            FieldParser::param() => [
                 SynonymResource::$wrap => $includedFields->map(fn (Field $field) => $field->getKey())->join(','),
             ],
         ];
@@ -182,7 +182,7 @@ class SynonymIndexTest extends TestCase
             ->random();
 
         $parameters = [
-            SortParser::$param => $field->getSort()->format(Direction::getRandomInstance()),
+            SortParser::param() => $field->getSort()->format(Direction::getRandomInstance()),
         ];
 
         $query = SynonymQuery::make($parameters);
@@ -217,10 +217,10 @@ class SynonymIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_CREATED_AT => $createdFilter,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -266,10 +266,10 @@ class SynonymIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_UPDATED_AT => $updatedFilter,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -312,10 +312,10 @@ class SynonymIndexTest extends TestCase
     public function testWithoutTrashedFilter(): void
     {
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITHOUT,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -358,10 +358,10 @@ class SynonymIndexTest extends TestCase
     public function testWithTrashedFilter(): void
     {
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITH,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -404,10 +404,10 @@ class SynonymIndexTest extends TestCase
     public function testOnlyTrashedFilter(): void
     {
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::ONLY,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -453,11 +453,11 @@ class SynonymIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_DELETED_AT => $deletedFilter,
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITH,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -502,10 +502,10 @@ class SynonymIndexTest extends TestCase
         $seasonFilter = AnimeSeason::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_SEASON => $seasonFilter->description,
             ],
-            IncludeParser::$param => AnimeSynonym::RELATION_ANIME,
+            IncludeParser::param() => AnimeSynonym::RELATION_ANIME,
         ];
 
         AnimeSynonym::factory()
@@ -545,10 +545,10 @@ class SynonymIndexTest extends TestCase
         $excludedYear = $yearFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_YEAR => $yearFilter,
             ],
-            IncludeParser::$param => AnimeSynonym::RELATION_ANIME,
+            IncludeParser::param() => AnimeSynonym::RELATION_ANIME,
         ];
 
         AnimeSynonym::factory()

--- a/tests/Feature/Http/Api/Wiki/Anime/Synonym/SynonymShowTest.php
+++ b/tests/Feature/Http/Api/Wiki/Anime/Synonym/SynonymShowTest.php
@@ -96,7 +96,7 @@ class SynonymShowTest extends TestCase
         $includedPaths = $selectedIncludes->map(fn (AllowedInclude $include) => $include->path());
 
         $parameters = [
-            IncludeParser::$param => $includedPaths->join(','),
+            IncludeParser::param() => $includedPaths->join(','),
         ];
 
         AnimeSynonym::factory()->for(Anime::factory())->create();
@@ -131,7 +131,7 @@ class SynonymShowTest extends TestCase
         $includedFields = $fields->random($this->faker->numberBetween(1, $fields->count()));
 
         $parameters = [
-            FieldParser::$param => [
+            FieldParser::param() => [
                 SynonymResource::$wrap => $includedFields->map(fn (Field $field) => $field->getKey())->join(','),
             ],
         ];
@@ -164,10 +164,10 @@ class SynonymShowTest extends TestCase
         $seasonFilter = AnimeSeason::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_SEASON => $seasonFilter->description,
             ],
-            IncludeParser::$param => AnimeSynonym::RELATION_ANIME,
+            IncludeParser::param() => AnimeSynonym::RELATION_ANIME,
         ];
 
         AnimeSynonym::factory()->for(Anime::factory())->create();
@@ -204,10 +204,10 @@ class SynonymShowTest extends TestCase
         $excludedYear = $yearFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_YEAR => $yearFilter,
             ],
-            IncludeParser::$param => AnimeSynonym::RELATION_ANIME,
+            IncludeParser::param() => AnimeSynonym::RELATION_ANIME,
         ];
 
         AnimeSynonym::factory()

--- a/tests/Feature/Http/Api/Wiki/Anime/Theme/Entry/EntryIndexTest.php
+++ b/tests/Feature/Http/Api/Wiki/Anime/Theme/Entry/EntryIndexTest.php
@@ -104,7 +104,7 @@ class EntryIndexTest extends TestCase
         $includedPaths = $selectedIncludes->map(fn (AllowedInclude $include) => $include->path());
 
         $parameters = [
-            IncludeParser::$param => $includedPaths->join(','),
+            IncludeParser::param() => $includedPaths->join(','),
         ];
 
         AnimeThemeEntry::factory()
@@ -143,7 +143,7 @@ class EntryIndexTest extends TestCase
         $includedFields = $fields->random($this->faker->numberBetween(1, $fields->count()));
 
         $parameters = [
-            FieldParser::$param => [
+            FieldParser::param() => [
                 EntryResource::$wrap => $includedFields->map(fn (Field $field) => $field->getKey())->join(','),
             ],
         ];
@@ -181,7 +181,7 @@ class EntryIndexTest extends TestCase
             ->random();
 
         $parameters = [
-            SortParser::$param => $field->getSort()->format(Direction::getRandomInstance()),
+            SortParser::param() => $field->getSort()->format(Direction::getRandomInstance()),
         ];
 
         $query = EntryQuery::make($parameters);
@@ -216,10 +216,10 @@ class EntryIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_CREATED_AT => $createdFilter,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -265,10 +265,10 @@ class EntryIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_UPDATED_AT => $updatedFilter,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -311,10 +311,10 @@ class EntryIndexTest extends TestCase
     public function testWithoutTrashedFilter(): void
     {
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITHOUT,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -357,10 +357,10 @@ class EntryIndexTest extends TestCase
     public function testWithTrashedFilter(): void
     {
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITH,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -403,10 +403,10 @@ class EntryIndexTest extends TestCase
     public function testOnlyTrashedFilter(): void
     {
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::ONLY,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -452,11 +452,11 @@ class EntryIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_DELETED_AT => $deletedFilter,
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITH,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -509,7 +509,7 @@ class EntryIndexTest extends TestCase
         $nsfwFilter = $this->faker->boolean();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeThemeEntry::ATTRIBUTE_NSFW => $nsfwFilter,
             ],
         ];
@@ -545,7 +545,7 @@ class EntryIndexTest extends TestCase
         $spoilerFilter = $this->faker->boolean();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeThemeEntry::ATTRIBUTE_SPOILER => $spoilerFilter,
             ],
         ];
@@ -582,7 +582,7 @@ class EntryIndexTest extends TestCase
         $excludedVersion = $versionFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeThemeEntry::ATTRIBUTE_VERSION => $versionFilter,
             ],
         ];
@@ -622,10 +622,10 @@ class EntryIndexTest extends TestCase
         $seasonFilter = AnimeSeason::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_SEASON => $seasonFilter->description,
             ],
-            IncludeParser::$param => AnimeThemeEntry::RELATION_ANIME,
+            IncludeParser::param() => AnimeThemeEntry::RELATION_ANIME,
         ];
 
         AnimeThemeEntry::factory()
@@ -665,10 +665,10 @@ class EntryIndexTest extends TestCase
         $excludedYear = $yearFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_YEAR => $yearFilter,
             ],
-            IncludeParser::$param => AnimeThemeEntry::RELATION_ANIME,
+            IncludeParser::param() => AnimeThemeEntry::RELATION_ANIME,
         ];
 
         AnimeThemeEntry::factory()
@@ -715,10 +715,10 @@ class EntryIndexTest extends TestCase
         $excludedGroup = $this->faker->word();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeTheme::ATTRIBUTE_GROUP => $groupFilter,
             ],
-            IncludeParser::$param => AnimeThemeEntry::RELATION_THEME,
+            IncludeParser::param() => AnimeThemeEntry::RELATION_THEME,
         ];
 
         AnimeThemeEntry::factory()
@@ -764,10 +764,10 @@ class EntryIndexTest extends TestCase
         $excludedSequence = $sequenceFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeTheme::ATTRIBUTE_SEQUENCE => $sequenceFilter,
             ],
-            IncludeParser::$param => AnimeThemeEntry::RELATION_THEME,
+            IncludeParser::param() => AnimeThemeEntry::RELATION_THEME,
         ];
 
         AnimeThemeEntry::factory()
@@ -812,10 +812,10 @@ class EntryIndexTest extends TestCase
         $typeFilter = ThemeType::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeTheme::ATTRIBUTE_TYPE => $typeFilter->description,
             ],
-            IncludeParser::$param => AnimeThemeEntry::RELATION_THEME,
+            IncludeParser::param() => AnimeThemeEntry::RELATION_THEME,
         ];
 
         AnimeThemeEntry::factory()

--- a/tests/Feature/Http/Api/Wiki/Anime/Theme/Entry/EntryShowTest.php
+++ b/tests/Feature/Http/Api/Wiki/Anime/Theme/Entry/EntryShowTest.php
@@ -99,7 +99,7 @@ class EntryShowTest extends TestCase
         $includedPaths = $selectedIncludes->map(fn (AllowedInclude $include) => $include->path());
 
         $parameters = [
-            IncludeParser::$param => $includedPaths->join(','),
+            IncludeParser::param() => $includedPaths->join(','),
         ];
 
         AnimeThemeEntry::factory()
@@ -137,7 +137,7 @@ class EntryShowTest extends TestCase
         $includedFields = $fields->random($this->faker->numberBetween(1, $fields->count()));
 
         $parameters = [
-            FieldParser::$param => [
+            FieldParser::param() => [
                 EntryResource::$wrap => $includedFields->map(fn (Field $field) => $field->getKey())->join(','),
             ],
         ];
@@ -170,10 +170,10 @@ class EntryShowTest extends TestCase
         $seasonFilter = AnimeSeason::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_SEASON => $seasonFilter->description,
             ],
-            IncludeParser::$param => AnimeThemeEntry::RELATION_ANIME,
+            IncludeParser::param() => AnimeThemeEntry::RELATION_ANIME,
         ];
 
         AnimeThemeEntry::factory()
@@ -212,10 +212,10 @@ class EntryShowTest extends TestCase
         $excludedYear = $yearFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_YEAR => $yearFilter,
             ],
-            IncludeParser::$param => AnimeThemeEntry::RELATION_ANIME,
+            IncludeParser::param() => AnimeThemeEntry::RELATION_ANIME,
         ];
 
         AnimeThemeEntry::factory()
@@ -261,10 +261,10 @@ class EntryShowTest extends TestCase
         $excludedGroup = $this->faker->word();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeTheme::ATTRIBUTE_GROUP => $groupFilter,
             ],
-            IncludeParser::$param => AnimeThemeEntry::RELATION_THEME,
+            IncludeParser::param() => AnimeThemeEntry::RELATION_THEME,
         ];
 
         AnimeThemeEntry::factory()
@@ -309,10 +309,10 @@ class EntryShowTest extends TestCase
         $excludedSequence = $sequenceFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeTheme::ATTRIBUTE_SEQUENCE => $sequenceFilter,
             ],
-            IncludeParser::$param => AnimeThemeEntry::RELATION_THEME,
+            IncludeParser::param() => AnimeThemeEntry::RELATION_THEME,
         ];
 
         AnimeThemeEntry::factory()
@@ -356,10 +356,10 @@ class EntryShowTest extends TestCase
         $typeFilter = ThemeType::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeTheme::ATTRIBUTE_TYPE => $typeFilter->description,
             ],
-            IncludeParser::$param => AnimeThemeEntry::RELATION_THEME,
+            IncludeParser::param() => AnimeThemeEntry::RELATION_THEME,
         ];
 
         AnimeThemeEntry::factory()

--- a/tests/Feature/Http/Api/Wiki/Anime/Theme/ThemeIndexTest.php
+++ b/tests/Feature/Http/Api/Wiki/Anime/Theme/ThemeIndexTest.php
@@ -114,7 +114,7 @@ class ThemeIndexTest extends TestCase
         $includedPaths = $selectedIncludes->map(fn (AllowedInclude $include) => $include->path());
 
         $parameters = [
-            IncludeParser::$param => $includedPaths->join(','),
+            IncludeParser::param() => $includedPaths->join(','),
         ];
 
         AnimeTheme::factory()
@@ -158,7 +158,7 @@ class ThemeIndexTest extends TestCase
         $includedFields = $fields->random($this->faker->numberBetween(1, $fields->count()));
 
         $parameters = [
-            FieldParser::$param => [
+            FieldParser::param() => [
                 ThemeResource::$wrap => $includedFields->map(fn (Field $field) => $field->getKey())->join(','),
             ],
         ];
@@ -198,7 +198,7 @@ class ThemeIndexTest extends TestCase
             ->random();
 
         $parameters = [
-            SortParser::$param => $field->getSort()->format(Direction::getRandomInstance()),
+            SortParser::param() => $field->getSort()->format(Direction::getRandomInstance()),
         ];
 
         $query = ThemeQuery::make($parameters);
@@ -233,10 +233,10 @@ class ThemeIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_CREATED_AT => $createdFilter,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -282,10 +282,10 @@ class ThemeIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_UPDATED_AT => $updatedFilter,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -328,10 +328,10 @@ class ThemeIndexTest extends TestCase
     public function testWithoutTrashedFilter(): void
     {
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITHOUT,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -374,10 +374,10 @@ class ThemeIndexTest extends TestCase
     public function testWithTrashedFilter(): void
     {
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITH,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -420,10 +420,10 @@ class ThemeIndexTest extends TestCase
     public function testOnlyTrashedFilter(): void
     {
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::ONLY,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -469,11 +469,11 @@ class ThemeIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_DELETED_AT => $deletedFilter,
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITH,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -519,7 +519,7 @@ class ThemeIndexTest extends TestCase
         $excludedGroup = $this->faker->word();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeTheme::ATTRIBUTE_GROUP => $groupFilter,
             ],
         ];
@@ -560,7 +560,7 @@ class ThemeIndexTest extends TestCase
         $excludedSequence = $sequenceFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeTheme::ATTRIBUTE_SEQUENCE => $sequenceFilter,
             ],
         ];
@@ -600,7 +600,7 @@ class ThemeIndexTest extends TestCase
         $typeFilter = ThemeType::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeTheme::ATTRIBUTE_TYPE => $typeFilter->description,
             ],
         ];
@@ -636,10 +636,10 @@ class ThemeIndexTest extends TestCase
         $seasonFilter = AnimeSeason::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_SEASON => $seasonFilter->description,
             ],
-            IncludeParser::$param => AnimeTheme::RELATION_ANIME,
+            IncludeParser::param() => AnimeTheme::RELATION_ANIME,
         ];
 
         AnimeTheme::factory()
@@ -679,10 +679,10 @@ class ThemeIndexTest extends TestCase
         $excludedYear = $yearFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_YEAR => $yearFilter,
             ],
-            IncludeParser::$param => AnimeTheme::RELATION_ANIME,
+            IncludeParser::param() => AnimeTheme::RELATION_ANIME,
         ];
 
         AnimeTheme::factory()
@@ -726,10 +726,10 @@ class ThemeIndexTest extends TestCase
         $facetFilter = ImageFacet::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Image::ATTRIBUTE_FACET => $facetFilter->description,
             ],
-            IncludeParser::$param => AnimeTheme::RELATION_IMAGES,
+            IncludeParser::param() => AnimeTheme::RELATION_IMAGES,
         ];
 
         AnimeTheme::factory()
@@ -771,10 +771,10 @@ class ThemeIndexTest extends TestCase
         $nsfwFilter = $this->faker->boolean();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeThemeEntry::ATTRIBUTE_NSFW => $nsfwFilter,
             ],
-            IncludeParser::$param => AnimeTheme::RELATION_ENTRIES,
+            IncludeParser::param() => AnimeTheme::RELATION_ENTRIES,
         ];
 
         AnimeTheme::factory()
@@ -814,10 +814,10 @@ class ThemeIndexTest extends TestCase
         $spoilerFilter = $this->faker->boolean();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeThemeEntry::ATTRIBUTE_SPOILER => $spoilerFilter,
             ],
-            IncludeParser::$param => AnimeTheme::RELATION_ENTRIES,
+            IncludeParser::param() => AnimeTheme::RELATION_ENTRIES,
         ];
 
         AnimeTheme::factory()
@@ -858,10 +858,10 @@ class ThemeIndexTest extends TestCase
         $excludedVersion = $versionFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeThemeEntry::ATTRIBUTE_VERSION => $versionFilter,
             ],
-            IncludeParser::$param => AnimeTheme::RELATION_ENTRIES,
+            IncludeParser::param() => AnimeTheme::RELATION_ENTRIES,
         ];
 
         AnimeTheme::factory()
@@ -908,10 +908,10 @@ class ThemeIndexTest extends TestCase
         $lyricsFilter = $this->faker->boolean();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Video::ATTRIBUTE_LYRICS => $lyricsFilter,
             ],
-            IncludeParser::$param => AnimeTheme::RELATION_VIDEOS,
+            IncludeParser::param() => AnimeTheme::RELATION_VIDEOS,
         ];
 
         AnimeTheme::factory()
@@ -955,10 +955,10 @@ class ThemeIndexTest extends TestCase
         $ncFilter = $this->faker->boolean();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Video::ATTRIBUTE_NC => $ncFilter,
             ],
-            IncludeParser::$param => AnimeTheme::RELATION_VIDEOS,
+            IncludeParser::param() => AnimeTheme::RELATION_VIDEOS,
         ];
 
         AnimeTheme::factory()
@@ -1002,10 +1002,10 @@ class ThemeIndexTest extends TestCase
         $overlapFilter = VideoOverlap::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Video::ATTRIBUTE_OVERLAP => $overlapFilter->description,
             ],
-            IncludeParser::$param => AnimeTheme::RELATION_VIDEOS,
+            IncludeParser::param() => AnimeTheme::RELATION_VIDEOS,
         ];
 
         AnimeTheme::factory()
@@ -1050,10 +1050,10 @@ class ThemeIndexTest extends TestCase
         $excludedResolution = $resolutionFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Video::ATTRIBUTE_RESOLUTION => $resolutionFilter,
             ],
-            IncludeParser::$param => AnimeTheme::RELATION_VIDEOS,
+            IncludeParser::param() => AnimeTheme::RELATION_VIDEOS,
         ];
 
         AnimeTheme::factory()
@@ -1104,10 +1104,10 @@ class ThemeIndexTest extends TestCase
         $sourceFilter = VideoSource::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Video::ATTRIBUTE_SOURCE => $sourceFilter->description,
             ],
-            IncludeParser::$param => AnimeTheme::RELATION_VIDEOS,
+            IncludeParser::param() => AnimeTheme::RELATION_VIDEOS,
         ];
 
         AnimeTheme::factory()
@@ -1151,10 +1151,10 @@ class ThemeIndexTest extends TestCase
         $subbedFilter = $this->faker->boolean();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Video::ATTRIBUTE_SUBBED => $subbedFilter,
             ],
-            IncludeParser::$param => AnimeTheme::RELATION_VIDEOS,
+            IncludeParser::param() => AnimeTheme::RELATION_VIDEOS,
         ];
 
         AnimeTheme::factory()
@@ -1198,10 +1198,10 @@ class ThemeIndexTest extends TestCase
         $uncenFilter = $this->faker->boolean();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Video::ATTRIBUTE_UNCEN => $uncenFilter,
             ],
-            IncludeParser::$param => AnimeTheme::RELATION_VIDEOS,
+            IncludeParser::param() => AnimeTheme::RELATION_VIDEOS,
         ];
 
         AnimeTheme::factory()

--- a/tests/Feature/Http/Api/Wiki/Anime/Theme/ThemeShowTest.php
+++ b/tests/Feature/Http/Api/Wiki/Anime/Theme/ThemeShowTest.php
@@ -108,7 +108,7 @@ class ThemeShowTest extends TestCase
         $includedPaths = $selectedIncludes->map(fn (AllowedInclude $include) => $include->path());
 
         $parameters = [
-            IncludeParser::$param => $includedPaths->join(','),
+            IncludeParser::param() => $includedPaths->join(','),
         ];
 
         AnimeTheme::factory()
@@ -151,7 +151,7 @@ class ThemeShowTest extends TestCase
         $includedFields = $fields->random($this->faker->numberBetween(1, $fields->count()));
 
         $parameters = [
-            FieldParser::$param => [
+            FieldParser::param() => [
                 ThemeResource::$wrap => $includedFields->map(fn (Field $field) => $field->getKey())->join(','),
             ],
         ];
@@ -187,10 +187,10 @@ class ThemeShowTest extends TestCase
         $seasonFilter = AnimeSeason::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_SEASON => $seasonFilter->description,
             ],
-            IncludeParser::$param => AnimeTheme::RELATION_ANIME,
+            IncludeParser::param() => AnimeTheme::RELATION_ANIME,
         ];
 
         AnimeTheme::factory()
@@ -229,10 +229,10 @@ class ThemeShowTest extends TestCase
         $excludedYear = $yearFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_YEAR => $yearFilter,
             ],
-            IncludeParser::$param => AnimeTheme::RELATION_ANIME,
+            IncludeParser::param() => AnimeTheme::RELATION_ANIME,
         ];
 
         AnimeTheme::factory()
@@ -275,10 +275,10 @@ class ThemeShowTest extends TestCase
         $facetFilter = ImageFacet::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Image::ATTRIBUTE_FACET => $facetFilter->description,
             ],
-            IncludeParser::$param => AnimeTheme::RELATION_IMAGES,
+            IncludeParser::param() => AnimeTheme::RELATION_IMAGES,
         ];
 
         AnimeTheme::factory()
@@ -319,10 +319,10 @@ class ThemeShowTest extends TestCase
         $nsfwFilter = $this->faker->boolean();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeThemeEntry::ATTRIBUTE_NSFW => $nsfwFilter,
             ],
-            IncludeParser::$param => AnimeTheme::RELATION_ENTRIES,
+            IncludeParser::param() => AnimeTheme::RELATION_ENTRIES,
         ];
 
         AnimeTheme::factory()
@@ -361,10 +361,10 @@ class ThemeShowTest extends TestCase
         $spoilerFilter = $this->faker->boolean();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeThemeEntry::ATTRIBUTE_SPOILER => $spoilerFilter,
             ],
-            IncludeParser::$param => AnimeTheme::RELATION_ENTRIES,
+            IncludeParser::param() => AnimeTheme::RELATION_ENTRIES,
         ];
 
         AnimeTheme::factory()
@@ -404,10 +404,10 @@ class ThemeShowTest extends TestCase
         $excludedVersion = $versionFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeThemeEntry::ATTRIBUTE_VERSION => $versionFilter,
             ],
-            IncludeParser::$param => AnimeTheme::RELATION_ENTRIES,
+            IncludeParser::param() => AnimeTheme::RELATION_ENTRIES,
         ];
 
         AnimeTheme::factory()
@@ -453,10 +453,10 @@ class ThemeShowTest extends TestCase
         $lyricsFilter = $this->faker->boolean();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Video::ATTRIBUTE_LYRICS => $lyricsFilter,
             ],
-            IncludeParser::$param => AnimeTheme::RELATION_VIDEOS,
+            IncludeParser::param() => AnimeTheme::RELATION_VIDEOS,
         ];
 
         AnimeTheme::factory()
@@ -499,10 +499,10 @@ class ThemeShowTest extends TestCase
         $ncFilter = $this->faker->boolean();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Video::ATTRIBUTE_NC => $ncFilter,
             ],
-            IncludeParser::$param => AnimeTheme::RELATION_VIDEOS,
+            IncludeParser::param() => AnimeTheme::RELATION_VIDEOS,
         ];
 
         AnimeTheme::factory()
@@ -545,10 +545,10 @@ class ThemeShowTest extends TestCase
         $overlapFilter = VideoOverlap::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Video::ATTRIBUTE_OVERLAP => $overlapFilter->description,
             ],
-            IncludeParser::$param => AnimeTheme::RELATION_VIDEOS,
+            IncludeParser::param() => AnimeTheme::RELATION_VIDEOS,
         ];
 
         AnimeTheme::factory()
@@ -592,10 +592,10 @@ class ThemeShowTest extends TestCase
         $excludedResolution = $resolutionFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Video::ATTRIBUTE_RESOLUTION => $resolutionFilter,
             ],
-            IncludeParser::$param => AnimeTheme::RELATION_VIDEOS,
+            IncludeParser::param() => AnimeTheme::RELATION_VIDEOS,
         ];
 
         AnimeTheme::factory()
@@ -645,10 +645,10 @@ class ThemeShowTest extends TestCase
         $sourceFilter = VideoSource::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Video::ATTRIBUTE_SOURCE => $sourceFilter->description,
             ],
-            IncludeParser::$param => AnimeTheme::RELATION_VIDEOS,
+            IncludeParser::param() => AnimeTheme::RELATION_VIDEOS,
         ];
 
         AnimeTheme::factory()
@@ -691,10 +691,10 @@ class ThemeShowTest extends TestCase
         $subbedFilter = $this->faker->boolean();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Video::ATTRIBUTE_SUBBED => $subbedFilter,
             ],
-            IncludeParser::$param => AnimeTheme::RELATION_VIDEOS,
+            IncludeParser::param() => AnimeTheme::RELATION_VIDEOS,
         ];
 
         AnimeTheme::factory()
@@ -737,10 +737,10 @@ class ThemeShowTest extends TestCase
         $uncenFilter = $this->faker->boolean();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Video::ATTRIBUTE_UNCEN => $uncenFilter,
             ],
-            IncludeParser::$param => AnimeTheme::RELATION_VIDEOS,
+            IncludeParser::param() => AnimeTheme::RELATION_VIDEOS,
         ];
 
         AnimeTheme::factory()

--- a/tests/Feature/Http/Api/Wiki/Anime/YearShowTest.php
+++ b/tests/Feature/Http/Api/Wiki/Anime/YearShowTest.php
@@ -104,7 +104,7 @@ class YearShowTest extends TestCase
         $includedPaths = $selectedIncludes->map(fn (AllowedInclude $include) => $include->path());
 
         $parameters = [
-            IncludeParser::$param => $includedPaths->join(','),
+            IncludeParser::param() => $includedPaths->join(','),
         ];
 
         Anime::factory()
@@ -179,7 +179,7 @@ class YearShowTest extends TestCase
         $includedFields = $fields->random($this->faker->numberBetween(1, $fields->count()));
 
         $parameters = [
-            FieldParser::$param => [
+            FieldParser::param() => [
                 AnimeResource::$wrap => $includedFields->map(fn (Field $field) => $field->getKey())->join(','),
             ],
         ];

--- a/tests/Feature/Http/Api/Wiki/Artist/ArtistIndexTest.php
+++ b/tests/Feature/Http/Api/Wiki/Artist/ArtistIndexTest.php
@@ -108,8 +108,8 @@ class ArtistIndexTest extends TestCase
         $includedPaths = $selectedIncludes->map(fn (AllowedInclude $include) => $include->path());
 
         $parameters = [
-            IncludeParser::$param => $includedPaths->join(','),
-            PagingParser::$param => [
+            IncludeParser::param() => $includedPaths->join(','),
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -147,7 +147,7 @@ class ArtistIndexTest extends TestCase
         $includedFields = $fields->random($this->faker->numberBetween(1, $fields->count()));
 
         $parameters = [
-            FieldParser::$param => [
+            FieldParser::param() => [
                 ArtistResource::$wrap => $includedFields->map(fn (Field $field) => $field->getKey())->join(','),
             ],
         ];
@@ -184,7 +184,7 @@ class ArtistIndexTest extends TestCase
             ->random();
 
         $parameters = [
-            SortParser::$param => $field->getSort()->format(Direction::getRandomInstance()),
+            SortParser::param() => $field->getSort()->format(Direction::getRandomInstance()),
         ];
 
         $query = ArtistQuery::make($parameters);
@@ -218,10 +218,10 @@ class ArtistIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_CREATED_AT => $createdFilter,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -263,10 +263,10 @@ class ArtistIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_UPDATED_AT => $updatedFilter,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -305,10 +305,10 @@ class ArtistIndexTest extends TestCase
         $this->withoutEvents();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITHOUT,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -346,10 +346,10 @@ class ArtistIndexTest extends TestCase
         $this->withoutEvents();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITH,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -387,10 +387,10 @@ class ArtistIndexTest extends TestCase
         $this->withoutEvents();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::ONLY,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -431,11 +431,11 @@ class ArtistIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_DELETED_AT => $deletedFilter,
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITH,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -481,10 +481,10 @@ class ArtistIndexTest extends TestCase
         $excludedGroup = $this->faker->word();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeTheme::ATTRIBUTE_GROUP => $groupFilter,
             ],
-            IncludeParser::$param => Artist::RELATION_ANIMETHEMES,
+            IncludeParser::param() => Artist::RELATION_ANIMETHEMES,
         ];
 
         Artist::factory()
@@ -536,10 +536,10 @@ class ArtistIndexTest extends TestCase
         $excludedSequence = $sequenceFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeTheme::ATTRIBUTE_SEQUENCE => $sequenceFilter,
             ],
-            IncludeParser::$param => Artist::RELATION_ANIMETHEMES,
+            IncludeParser::param() => Artist::RELATION_ANIMETHEMES,
         ];
 
         Artist::factory()
@@ -590,10 +590,10 @@ class ArtistIndexTest extends TestCase
         $typeFilter = ThemeType::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeTheme::ATTRIBUTE_TYPE => $typeFilter->description,
             ],
-            IncludeParser::$param => Artist::RELATION_ANIMETHEMES,
+            IncludeParser::param() => Artist::RELATION_ANIMETHEMES,
         ];
 
         Artist::factory()
@@ -640,10 +640,10 @@ class ArtistIndexTest extends TestCase
         $seasonFilter = AnimeSeason::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_SEASON => $seasonFilter->description,
             ],
-            IncludeParser::$param => Artist::RELATION_ANIME,
+            IncludeParser::param() => Artist::RELATION_ANIME,
         ];
 
         Artist::factory()
@@ -691,10 +691,10 @@ class ArtistIndexTest extends TestCase
         $excludedYear = $yearFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_YEAR => $yearFilter,
             ],
-            IncludeParser::$param => Artist::RELATION_ANIME,
+            IncludeParser::param() => Artist::RELATION_ANIME,
         ];
 
         Artist::factory()
@@ -748,10 +748,10 @@ class ArtistIndexTest extends TestCase
         $siteFilter = ResourceSite::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 ExternalResource::ATTRIBUTE_SITE => $siteFilter->description,
             ],
-            IncludeParser::$param => Artist::RELATION_RESOURCES,
+            IncludeParser::param() => Artist::RELATION_RESOURCES,
         ];
 
         Artist::factory()
@@ -792,10 +792,10 @@ class ArtistIndexTest extends TestCase
         $facetFilter = ImageFacet::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Image::ATTRIBUTE_FACET => $facetFilter->description,
             ],
-            IncludeParser::$param => Artist::RELATION_IMAGES,
+            IncludeParser::param() => Artist::RELATION_IMAGES,
         ];
 
         Artist::factory()

--- a/tests/Feature/Http/Api/Wiki/Artist/ArtistShowTest.php
+++ b/tests/Feature/Http/Api/Wiki/Artist/ArtistShowTest.php
@@ -106,7 +106,7 @@ class ArtistShowTest extends TestCase
         $includedPaths = $selectedIncludes->map(fn (AllowedInclude $include) => $include->path());
 
         $parameters = [
-            IncludeParser::$param => $includedPaths->join(','),
+            IncludeParser::param() => $includedPaths->join(','),
         ];
 
         Artist::factory()->jsonApiResource()->create();
@@ -142,7 +142,7 @@ class ArtistShowTest extends TestCase
         $includedFields = $fields->random($this->faker->numberBetween(1, $fields->count()));
 
         $parameters = [
-            FieldParser::$param => [
+            FieldParser::param() => [
                 ArtistResource::$wrap => $includedFields->map(fn (Field $field) => $field->getKey())->join(','),
             ],
         ];
@@ -174,10 +174,10 @@ class ArtistShowTest extends TestCase
         $excludedGroup = $this->faker->word();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeTheme::ATTRIBUTE_GROUP => $groupFilter,
             ],
-            IncludeParser::$param => Artist::RELATION_ANIMETHEMES,
+            IncludeParser::param() => Artist::RELATION_ANIMETHEMES,
         ];
 
         Artist::factory()
@@ -228,10 +228,10 @@ class ArtistShowTest extends TestCase
         $excludedSequence = $sequenceFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeTheme::ATTRIBUTE_SEQUENCE => $sequenceFilter,
             ],
-            IncludeParser::$param => Artist::RELATION_ANIMETHEMES,
+            IncludeParser::param() => Artist::RELATION_ANIMETHEMES,
         ];
 
         Artist::factory()
@@ -281,10 +281,10 @@ class ArtistShowTest extends TestCase
         $typeFilter = ThemeType::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeTheme::ATTRIBUTE_TYPE => $typeFilter->description,
             ],
-            IncludeParser::$param => Artist::RELATION_ANIMETHEMES,
+            IncludeParser::param() => Artist::RELATION_ANIMETHEMES,
         ];
 
         Artist::factory()
@@ -330,10 +330,10 @@ class ArtistShowTest extends TestCase
         $seasonFilter = AnimeSeason::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_SEASON => $seasonFilter->description,
             ],
-            IncludeParser::$param => Artist::RELATION_ANIME,
+            IncludeParser::param() => Artist::RELATION_ANIME,
         ];
 
         Artist::factory()
@@ -380,10 +380,10 @@ class ArtistShowTest extends TestCase
         $excludedYear = $yearFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_YEAR => $yearFilter,
             ],
-            IncludeParser::$param => Artist::RELATION_ANIME,
+            IncludeParser::param() => Artist::RELATION_ANIME,
         ];
 
         Artist::factory()
@@ -436,10 +436,10 @@ class ArtistShowTest extends TestCase
         $siteFilter = ResourceSite::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 ExternalResource::ATTRIBUTE_SITE => $siteFilter->description,
             ],
-            IncludeParser::$param => Artist::RELATION_RESOURCES,
+            IncludeParser::param() => Artist::RELATION_RESOURCES,
         ];
 
         Artist::factory()
@@ -479,10 +479,10 @@ class ArtistShowTest extends TestCase
         $facetFilter = ImageFacet::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Image::ATTRIBUTE_FACET => $facetFilter->description,
             ],
-            IncludeParser::$param => Artist::RELATION_IMAGES,
+            IncludeParser::param() => Artist::RELATION_IMAGES,
         ];
 
         Artist::factory()

--- a/tests/Feature/Http/Api/Wiki/ExternalResource/ExternalResourceIndexTest.php
+++ b/tests/Feature/Http/Api/Wiki/ExternalResource/ExternalResourceIndexTest.php
@@ -100,7 +100,7 @@ class ExternalResourceIndexTest extends TestCase
         $includedPaths = $selectedIncludes->map(fn (AllowedInclude $include) => $include->path());
 
         $parameters = [
-            IncludeParser::$param => $includedPaths->join(','),
+            IncludeParser::param() => $includedPaths->join(','),
         ];
 
         ExternalResource::factory()
@@ -139,7 +139,7 @@ class ExternalResourceIndexTest extends TestCase
         $includedFields = $fields->random($this->faker->numberBetween(1, $fields->count()));
 
         $parameters = [
-            FieldParser::$param => [
+            FieldParser::param() => [
                 ExternalResourceResource::$wrap => $includedFields->map(fn (Field $field) => $field->getKey())->join(','),
             ],
         ];
@@ -176,7 +176,7 @@ class ExternalResourceIndexTest extends TestCase
             ->random();
 
         $parameters = [
-            SortParser::$param => $field->getSort()->format(Direction::getRandomInstance()),
+            SortParser::param() => $field->getSort()->format(Direction::getRandomInstance()),
         ];
 
         $query = ExternalResourceQuery::make($parameters);
@@ -208,10 +208,10 @@ class ExternalResourceIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_CREATED_AT => $createdFilter,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -251,10 +251,10 @@ class ExternalResourceIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_UPDATED_AT => $updatedFilter,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -291,10 +291,10 @@ class ExternalResourceIndexTest extends TestCase
     public function testWithoutTrashedFilter(): void
     {
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITHOUT,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -330,10 +330,10 @@ class ExternalResourceIndexTest extends TestCase
     public function testWithTrashedFilter(): void
     {
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITH,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -369,10 +369,10 @@ class ExternalResourceIndexTest extends TestCase
     public function testOnlyTrashedFilter(): void
     {
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::ONLY,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -411,11 +411,11 @@ class ExternalResourceIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_DELETED_AT => $deletedFilter,
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITH,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -460,7 +460,7 @@ class ExternalResourceIndexTest extends TestCase
         $siteFilter = ResourceSite::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 ExternalResource::ATTRIBUTE_SITE => $siteFilter->description,
             ],
         ];
@@ -495,10 +495,10 @@ class ExternalResourceIndexTest extends TestCase
         $seasonFilter = AnimeSeason::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_SEASON => $seasonFilter->description,
             ],
-            IncludeParser::$param => ExternalResource::RELATION_ANIME,
+            IncludeParser::param() => ExternalResource::RELATION_ANIME,
         ];
 
         ExternalResource::factory()
@@ -538,10 +538,10 @@ class ExternalResourceIndexTest extends TestCase
         $excludedYear = $yearFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_YEAR => $yearFilter,
             ],
-            IncludeParser::$param => ExternalResource::RELATION_ANIME,
+            IncludeParser::param() => ExternalResource::RELATION_ANIME,
         ];
 
         ExternalResource::factory()

--- a/tests/Feature/Http/Api/Wiki/ExternalResource/ExternalResourceShowTest.php
+++ b/tests/Feature/Http/Api/Wiki/ExternalResource/ExternalResourceShowTest.php
@@ -95,7 +95,7 @@ class ExternalResourceShowTest extends TestCase
         $includedPaths = $selectedIncludes->map(fn (AllowedInclude $include) => $include->path());
 
         $parameters = [
-            IncludeParser::$param => $includedPaths->join(','),
+            IncludeParser::param() => $includedPaths->join(','),
         ];
 
         ExternalResource::factory()
@@ -133,7 +133,7 @@ class ExternalResourceShowTest extends TestCase
         $includedFields = $fields->random($this->faker->numberBetween(1, $fields->count()));
 
         $parameters = [
-            FieldParser::$param => [
+            FieldParser::param() => [
                 ExternalResourceResource::$wrap => $includedFields->map(fn (Field $field) => $field->getKey())->join(','),
             ],
         ];
@@ -164,10 +164,10 @@ class ExternalResourceShowTest extends TestCase
         $seasonFilter = AnimeSeason::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_SEASON => $seasonFilter->description,
             ],
-            IncludeParser::$param => ExternalResource::RELATION_ANIME,
+            IncludeParser::param() => ExternalResource::RELATION_ANIME,
         ];
 
         ExternalResource::factory()
@@ -206,10 +206,10 @@ class ExternalResourceShowTest extends TestCase
         $excludedYear = $yearFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_YEAR => $yearFilter,
             ],
-            IncludeParser::$param => ExternalResource::RELATION_ANIME,
+            IncludeParser::param() => ExternalResource::RELATION_ANIME,
         ];
 
         ExternalResource::factory()

--- a/tests/Feature/Http/Api/Wiki/Image/ImageIndexTest.php
+++ b/tests/Feature/Http/Api/Wiki/Image/ImageIndexTest.php
@@ -100,7 +100,7 @@ class ImageIndexTest extends TestCase
         $includedPaths = $selectedIncludes->map(fn (AllowedInclude $include) => $include->path());
 
         $parameters = [
-            IncludeParser::$param => $includedPaths->join(','),
+            IncludeParser::param() => $includedPaths->join(','),
         ];
 
         Image::factory()
@@ -139,7 +139,7 @@ class ImageIndexTest extends TestCase
         $includedFields = $fields->random($this->faker->numberBetween(1, $fields->count()));
 
         $parameters = [
-            FieldParser::$param => [
+            FieldParser::param() => [
                 ImageResource::$wrap => $includedFields->map(fn (Field $field) => $field->getKey())->join(','),
             ],
         ];
@@ -176,7 +176,7 @@ class ImageIndexTest extends TestCase
             ->random();
 
         $parameters = [
-            SortParser::$param => $field->getSort()->format(Direction::getRandomInstance()),
+            SortParser::param() => $field->getSort()->format(Direction::getRandomInstance()),
         ];
 
         $query = ImageQuery::make($parameters);
@@ -208,10 +208,10 @@ class ImageIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_CREATED_AT => $createdFilter,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -251,10 +251,10 @@ class ImageIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_UPDATED_AT => $updatedFilter,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -291,10 +291,10 @@ class ImageIndexTest extends TestCase
     public function testWithoutTrashedFilter(): void
     {
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITHOUT,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -330,10 +330,10 @@ class ImageIndexTest extends TestCase
     public function testWithTrashedFilter(): void
     {
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITH,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -369,10 +369,10 @@ class ImageIndexTest extends TestCase
     public function testOnlyTrashedFilter(): void
     {
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::ONLY,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -411,11 +411,11 @@ class ImageIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_DELETED_AT => $deletedFilter,
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITH,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -460,7 +460,7 @@ class ImageIndexTest extends TestCase
         $facetFilter = ImageFacet::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Image::ATTRIBUTE_FACET => $facetFilter->description,
             ],
         ];
@@ -495,10 +495,10 @@ class ImageIndexTest extends TestCase
         $seasonFilter = AnimeSeason::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_SEASON => $seasonFilter->description,
             ],
-            IncludeParser::$param => Image::RELATION_ANIME,
+            IncludeParser::param() => Image::RELATION_ANIME,
         ];
 
         Image::factory()
@@ -538,10 +538,10 @@ class ImageIndexTest extends TestCase
         $excludedYear = $yearFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_YEAR => $yearFilter,
             ],
-            IncludeParser::$param => Image::RELATION_ANIME,
+            IncludeParser::param() => Image::RELATION_ANIME,
         ];
 
         Image::factory()

--- a/tests/Feature/Http/Api/Wiki/Image/ImageShowTest.php
+++ b/tests/Feature/Http/Api/Wiki/Image/ImageShowTest.php
@@ -95,7 +95,7 @@ class ImageShowTest extends TestCase
         $includedPaths = $selectedIncludes->map(fn (AllowedInclude $include) => $include->path());
 
         $parameters = [
-            IncludeParser::$param => $includedPaths->join(','),
+            IncludeParser::param() => $includedPaths->join(','),
         ];
 
         Image::factory()
@@ -133,7 +133,7 @@ class ImageShowTest extends TestCase
         $includedFields = $fields->random($this->faker->numberBetween(1, $fields->count()));
 
         $parameters = [
-            FieldParser::$param => [
+            FieldParser::param() => [
                 ImageResource::$wrap => $includedFields->map(fn (Field $field) => $field->getKey())->join(','),
             ],
         ];
@@ -164,10 +164,10 @@ class ImageShowTest extends TestCase
         $seasonFilter = AnimeSeason::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_SEASON => $seasonFilter->description,
             ],
-            IncludeParser::$param => Image::RELATION_ANIME,
+            IncludeParser::param() => Image::RELATION_ANIME,
         ];
 
         Image::factory()
@@ -206,10 +206,10 @@ class ImageShowTest extends TestCase
         $excludedYear = $yearFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_YEAR => $yearFilter,
             ],
-            IncludeParser::$param => Image::RELATION_ANIME,
+            IncludeParser::param() => Image::RELATION_ANIME,
         ];
 
         Image::factory()

--- a/tests/Feature/Http/Api/Wiki/SearchTest.php
+++ b/tests/Feature/Http/Api/Wiki/SearchTest.php
@@ -16,6 +16,7 @@ use App\Http\Resources\Wiki\Collection\VideoCollection;
 use App\Http\Resources\Wiki\Resource\SearchResource;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Config;
 use Tests\TestCase;
 
 /**
@@ -34,7 +35,7 @@ class SearchTest extends TestCase
     {
         $response = $this->get(route('api.search.show'));
 
-        $response->assertJson([]);
+        $response->assertJsonValidationErrors(SearchParser::param());
     }
 
     /**
@@ -44,10 +45,15 @@ class SearchTest extends TestCase
      */
     public function testSearchAttributes(): void
     {
+        $driver = Config::get('scout.driver');
+        if (empty($driver)) {
+            static::markTestSkipped('A driver must be configured for this test');
+        }
+
         $q = $this->faker->word();
 
         $parameters = [
-            SearchParser::$param => $q,
+            SearchParser::param() => $q,
         ];
 
         $response = $this->get(route('api.search.show', $parameters));
@@ -72,6 +78,11 @@ class SearchTest extends TestCase
      */
     public function testSearchSparseFieldsets(): void
     {
+        $driver = Config::get('scout.driver');
+        if (empty($driver)) {
+            static::markTestSkipped('A driver must be configured for this test');
+        }
+
         $fields = [
             AnimeCollection::$wrap,
             ThemeCollection::$wrap,
@@ -87,8 +98,8 @@ class SearchTest extends TestCase
         $q = $this->faker->word();
 
         $parameters = [
-            SearchParser::$param => $q,
-            FieldParser::$param => [
+            SearchParser::param() => $q,
+            FieldParser::param() => [
                 SearchResource::$wrap => implode(',', $includedFields),
             ],
         ];

--- a/tests/Feature/Http/Api/Wiki/Series/SeriesIndexTest.php
+++ b/tests/Feature/Http/Api/Wiki/Series/SeriesIndexTest.php
@@ -99,7 +99,7 @@ class SeriesIndexTest extends TestCase
         $includedPaths = $selectedIncludes->map(fn (AllowedInclude $include) => $include->path());
 
         $parameters = [
-            IncludeParser::$param => $includedPaths->join(','),
+            IncludeParser::param() => $includedPaths->join(','),
         ];
 
         Series::factory()
@@ -139,7 +139,7 @@ class SeriesIndexTest extends TestCase
         $includedFields = $fields->random($this->faker->numberBetween(1, $fields->count()));
 
         $parameters = [
-            FieldParser::$param => [
+            FieldParser::param() => [
                 SeriesResource::$wrap => $includedFields->map(fn (Field $field) => $field->getKey())->join(','),
             ],
         ];
@@ -176,7 +176,7 @@ class SeriesIndexTest extends TestCase
             ->random();
 
         $parameters = [
-            SortParser::$param => $field->getSort()->format(Direction::getRandomInstance()),
+            SortParser::param() => $field->getSort()->format(Direction::getRandomInstance()),
         ];
 
         $query = SeriesQuery::make($parameters);
@@ -210,10 +210,10 @@ class SeriesIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_CREATED_AT => $createdFilter,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -255,10 +255,10 @@ class SeriesIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_UPDATED_AT => $updatedFilter,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -297,10 +297,10 @@ class SeriesIndexTest extends TestCase
         $this->withoutEvents();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITHOUT,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -338,10 +338,10 @@ class SeriesIndexTest extends TestCase
         $this->withoutEvents();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITH,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -379,10 +379,10 @@ class SeriesIndexTest extends TestCase
         $this->withoutEvents();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::ONLY,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -423,11 +423,11 @@ class SeriesIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_DELETED_AT => $deletedFilter,
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITH,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -474,10 +474,10 @@ class SeriesIndexTest extends TestCase
         $seasonFilter = AnimeSeason::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_SEASON => $seasonFilter->description,
             ],
-            IncludeParser::$param => Series::RELATION_ANIME,
+            IncludeParser::param() => Series::RELATION_ANIME,
         ];
 
         Series::factory()
@@ -518,10 +518,10 @@ class SeriesIndexTest extends TestCase
         $yearFilter = $this->faker->numberBetween(2000, 2002);
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_YEAR => $yearFilter,
             ],
-            IncludeParser::$param => Series::RELATION_ANIME,
+            IncludeParser::param() => Series::RELATION_ANIME,
         ];
 
         Series::factory()

--- a/tests/Feature/Http/Api/Wiki/Series/SeriesShowTest.php
+++ b/tests/Feature/Http/Api/Wiki/Series/SeriesShowTest.php
@@ -97,7 +97,7 @@ class SeriesShowTest extends TestCase
         $includedPaths = $selectedIncludes->map(fn (AllowedInclude $include) => $include->path());
 
         $parameters = [
-            IncludeParser::$param => $includedPaths->join(','),
+            IncludeParser::param() => $includedPaths->join(','),
         ];
 
         Series::factory()
@@ -136,7 +136,7 @@ class SeriesShowTest extends TestCase
         $includedFields = $fields->random($this->faker->numberBetween(1, $fields->count()));
 
         $parameters = [
-            FieldParser::$param => [
+            FieldParser::param() => [
                 SeriesResource::$wrap => $includedFields->map(fn (Field $field) => $field->getKey())->join(','),
             ],
         ];
@@ -169,10 +169,10 @@ class SeriesShowTest extends TestCase
         $seasonFilter = AnimeSeason::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_SEASON => $seasonFilter->description,
             ],
-            IncludeParser::$param => Series::RELATION_ANIME,
+            IncludeParser::param() => Series::RELATION_ANIME,
         ];
 
         Series::factory()
@@ -212,10 +212,10 @@ class SeriesShowTest extends TestCase
         $yearFilter = $this->faker->numberBetween(2000, 2002);
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_YEAR => $yearFilter,
             ],
-            IncludeParser::$param => Series::RELATION_ANIME,
+            IncludeParser::param() => Series::RELATION_ANIME,
         ];
 
         Series::factory()

--- a/tests/Feature/Http/Api/Wiki/Song/SongIndexTest.php
+++ b/tests/Feature/Http/Api/Wiki/Song/SongIndexTest.php
@@ -103,7 +103,7 @@ class SongIndexTest extends TestCase
         $includedPaths = $selectedIncludes->map(fn (AllowedInclude $include) => $include->path());
 
         $parameters = [
-            IncludeParser::$param => $includedPaths->join(','),
+            IncludeParser::param() => $includedPaths->join(','),
         ];
 
         Song::factory()
@@ -144,7 +144,7 @@ class SongIndexTest extends TestCase
         $includedFields = $fields->random($this->faker->numberBetween(1, $fields->count()));
 
         $parameters = [
-            FieldParser::$param => [
+            FieldParser::param() => [
                 SongResource::$wrap => $includedFields->map(fn (Field $field) => $field->getKey())->join(','),
             ],
         ];
@@ -179,7 +179,7 @@ class SongIndexTest extends TestCase
             ->random();
 
         $parameters = [
-            SortParser::$param => $field->getSort()->format(Direction::getRandomInstance()),
+            SortParser::param() => $field->getSort()->format(Direction::getRandomInstance()),
         ];
 
         $query = SongQuery::make($parameters);
@@ -213,10 +213,10 @@ class SongIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_CREATED_AT => $createdFilter,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -258,10 +258,10 @@ class SongIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_UPDATED_AT => $updatedFilter,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -300,10 +300,10 @@ class SongIndexTest extends TestCase
         $this->withoutEvents();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITHOUT,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -341,10 +341,10 @@ class SongIndexTest extends TestCase
         $this->withoutEvents();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITH,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -382,10 +382,10 @@ class SongIndexTest extends TestCase
         $this->withoutEvents();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::ONLY,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -426,11 +426,11 @@ class SongIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_DELETED_AT => $deletedFilter,
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITH,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -476,10 +476,10 @@ class SongIndexTest extends TestCase
         $excludedGroup = $this->faker->word();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeTheme::ATTRIBUTE_GROUP => $groupFilter,
             ],
-            IncludeParser::$param => Song::RELATION_ANIMETHEMES,
+            IncludeParser::param() => Song::RELATION_ANIMETHEMES,
         ];
 
         Song::factory()
@@ -527,10 +527,10 @@ class SongIndexTest extends TestCase
         $excludedSequence = $sequenceFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeTheme::ATTRIBUTE_SEQUENCE => $sequenceFilter,
             ],
-            IncludeParser::$param => Song::RELATION_ANIMETHEMES,
+            IncludeParser::param() => Song::RELATION_ANIMETHEMES,
         ];
 
         Song::factory()
@@ -577,10 +577,10 @@ class SongIndexTest extends TestCase
         $typeFilter = ThemeType::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeTheme::ATTRIBUTE_TYPE => $typeFilter->description,
             ],
-            IncludeParser::$param => Song::RELATION_ANIMETHEMES,
+            IncludeParser::param() => Song::RELATION_ANIMETHEMES,
         ];
 
         Song::factory()
@@ -619,10 +619,10 @@ class SongIndexTest extends TestCase
         $seasonFilter = AnimeSeason::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_SEASON => $seasonFilter->description,
             ],
-            IncludeParser::$param => Song::RELATION_ANIME,
+            IncludeParser::param() => Song::RELATION_ANIME,
         ];
 
         Song::factory()
@@ -662,10 +662,10 @@ class SongIndexTest extends TestCase
         $excludedYear = $yearFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_YEAR => $yearFilter,
             ],
-            IncludeParser::$param => Song::RELATION_ANIME,
+            IncludeParser::param() => Song::RELATION_ANIME,
         ];
 
         Song::factory()

--- a/tests/Feature/Http/Api/Wiki/Song/SongShowTest.php
+++ b/tests/Feature/Http/Api/Wiki/Song/SongShowTest.php
@@ -101,7 +101,7 @@ class SongShowTest extends TestCase
         $includedPaths = $selectedIncludes->map(fn (AllowedInclude $include) => $include->path());
 
         $parameters = [
-            IncludeParser::$param => $includedPaths->join(','),
+            IncludeParser::param() => $includedPaths->join(','),
         ];
 
         Song::factory()
@@ -141,7 +141,7 @@ class SongShowTest extends TestCase
         $includedFields = $fields->random($this->faker->numberBetween(1, $fields->count()));
 
         $parameters = [
-            FieldParser::$param => [
+            FieldParser::param() => [
                 SongResource::$wrap => $includedFields->map(fn (Field $field) => $field->getKey())->join(','),
             ],
         ];
@@ -173,10 +173,10 @@ class SongShowTest extends TestCase
         $excludedGroup = $this->faker->word();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeTheme::ATTRIBUTE_GROUP => $groupFilter,
             ],
-            IncludeParser::$param => Song::RELATION_ANIMETHEMES,
+            IncludeParser::param() => Song::RELATION_ANIMETHEMES,
         ];
 
         Song::factory()
@@ -223,10 +223,10 @@ class SongShowTest extends TestCase
         $excludedSequence = $sequenceFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeTheme::ATTRIBUTE_SEQUENCE => $sequenceFilter,
             ],
-            IncludeParser::$param => Song::RELATION_ANIMETHEMES,
+            IncludeParser::param() => Song::RELATION_ANIMETHEMES,
         ];
 
         Song::factory()
@@ -272,10 +272,10 @@ class SongShowTest extends TestCase
         $typeFilter = ThemeType::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeTheme::ATTRIBUTE_TYPE => $typeFilter->description,
             ],
-            IncludeParser::$param => Song::RELATION_ANIMETHEMES,
+            IncludeParser::param() => Song::RELATION_ANIMETHEMES,
         ];
 
         Song::factory()
@@ -313,10 +313,10 @@ class SongShowTest extends TestCase
         $seasonFilter = AnimeSeason::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_SEASON => $seasonFilter->description,
             ],
-            IncludeParser::$param => Song::RELATION_ANIME,
+            IncludeParser::param() => Song::RELATION_ANIME,
         ];
 
         Song::factory()
@@ -355,10 +355,10 @@ class SongShowTest extends TestCase
         $excludedYear = $yearFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_YEAR => $yearFilter,
             ],
-            IncludeParser::$param => Song::RELATION_ANIME,
+            IncludeParser::param() => Song::RELATION_ANIME,
         ];
 
         Song::factory()

--- a/tests/Feature/Http/Api/Wiki/Studio/StudioIndexTest.php
+++ b/tests/Feature/Http/Api/Wiki/Studio/StudioIndexTest.php
@@ -99,7 +99,7 @@ class StudioIndexTest extends TestCase
         $includedPaths = $selectedIncludes->map(fn (AllowedInclude $include) => $include->path());
 
         $parameters = [
-            IncludeParser::$param => $includedPaths->join(','),
+            IncludeParser::param() => $includedPaths->join(','),
         ];
 
         Studio::factory()
@@ -139,7 +139,7 @@ class StudioIndexTest extends TestCase
         $includedFields = $fields->random($this->faker->numberBetween(1, $fields->count()));
 
         $parameters = [
-            FieldParser::$param => [
+            FieldParser::param() => [
                 StudioResource::$wrap => $includedFields->map(fn (Field $field) => $field->getKey())->join(','),
             ],
         ];
@@ -176,7 +176,7 @@ class StudioIndexTest extends TestCase
             ->random();
 
         $parameters = [
-            SortParser::$param => $field->getSort()->format(Direction::getRandomInstance()),
+            SortParser::param() => $field->getSort()->format(Direction::getRandomInstance()),
         ];
 
         $query = StudioQuery::make($parameters);
@@ -210,10 +210,10 @@ class StudioIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_CREATED_AT => $createdFilter,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -255,10 +255,10 @@ class StudioIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_UPDATED_AT => $updatedFilter,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -297,10 +297,10 @@ class StudioIndexTest extends TestCase
         $this->withoutEvents();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITHOUT,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -338,10 +338,10 @@ class StudioIndexTest extends TestCase
         $this->withoutEvents();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITH,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -379,10 +379,10 @@ class StudioIndexTest extends TestCase
         $this->withoutEvents();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::ONLY,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -423,11 +423,11 @@ class StudioIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_DELETED_AT => $deletedFilter,
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITH,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -474,10 +474,10 @@ class StudioIndexTest extends TestCase
         $seasonFilter = AnimeSeason::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_SEASON => $seasonFilter->description,
             ],
-            IncludeParser::$param => Studio::RELATION_ANIME,
+            IncludeParser::param() => Studio::RELATION_ANIME,
         ];
 
         Studio::factory()
@@ -518,10 +518,10 @@ class StudioIndexTest extends TestCase
         $yearFilter = $this->faker->numberBetween(2000, 2002);
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_YEAR => $yearFilter,
             ],
-            IncludeParser::$param => Studio::RELATION_ANIME,
+            IncludeParser::param() => Studio::RELATION_ANIME,
         ];
 
         Studio::factory()

--- a/tests/Feature/Http/Api/Wiki/Studio/StudioShowTest.php
+++ b/tests/Feature/Http/Api/Wiki/Studio/StudioShowTest.php
@@ -97,7 +97,7 @@ class StudioShowTest extends TestCase
         $includedPaths = $selectedIncludes->map(fn (AllowedInclude $include) => $include->path());
 
         $parameters = [
-            IncludeParser::$param => $includedPaths->join(','),
+            IncludeParser::param() => $includedPaths->join(','),
         ];
 
         Studio::factory()
@@ -136,7 +136,7 @@ class StudioShowTest extends TestCase
         $includedFields = $fields->random($this->faker->numberBetween(1, $fields->count()));
 
         $parameters = [
-            FieldParser::$param => [
+            FieldParser::param() => [
                 StudioResource::$wrap => $includedFields->map(fn (Field $field) => $field->getKey())->join(','),
             ],
         ];
@@ -169,10 +169,10 @@ class StudioShowTest extends TestCase
         $seasonFilter = AnimeSeason::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_SEASON => $seasonFilter->description,
             ],
-            IncludeParser::$param => Studio::RELATION_ANIME,
+            IncludeParser::param() => Studio::RELATION_ANIME,
         ];
 
         Studio::factory()
@@ -212,10 +212,10 @@ class StudioShowTest extends TestCase
         $yearFilter = $this->faker->numberBetween(2000, 2002);
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_YEAR => $yearFilter,
             ],
-            IncludeParser::$param => Studio::RELATION_ANIME,
+            IncludeParser::param() => Studio::RELATION_ANIME,
         ];
 
         Studio::factory()

--- a/tests/Feature/Http/Api/Wiki/Video/VideoIndexTest.php
+++ b/tests/Feature/Http/Api/Wiki/Video/VideoIndexTest.php
@@ -109,7 +109,7 @@ class VideoIndexTest extends TestCase
         $includedPaths = $selectedIncludes->map(fn (AllowedInclude $include) => $include->path());
 
         $parameters = [
-            IncludeParser::$param => $includedPaths->join(','),
+            IncludeParser::param() => $includedPaths->join(','),
         ];
 
         Video::factory()
@@ -153,7 +153,7 @@ class VideoIndexTest extends TestCase
         $includedFields = $fields->random($this->faker->numberBetween(1, $fields->count()));
 
         $parameters = [
-            FieldParser::$param => [
+            FieldParser::param() => [
                 VideoResource::$wrap => $includedFields->map(fn (Field $field) => $field->getKey())->join(','),
             ],
         ];
@@ -192,7 +192,7 @@ class VideoIndexTest extends TestCase
             ->random();
 
         $parameters = [
-            SortParser::$param => $field->getSort()->format(Direction::getRandomInstance()),
+            SortParser::param() => $field->getSort()->format(Direction::getRandomInstance()),
         ];
 
         $query = VideoQuery::make($parameters);
@@ -228,10 +228,10 @@ class VideoIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_CREATED_AT => $createdFilter,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -273,10 +273,10 @@ class VideoIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_UPDATED_AT => $updatedFilter,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -315,10 +315,10 @@ class VideoIndexTest extends TestCase
         $this->withoutEvents();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITHOUT,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -356,10 +356,10 @@ class VideoIndexTest extends TestCase
         $this->withoutEvents();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITH,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -397,10 +397,10 @@ class VideoIndexTest extends TestCase
         $this->withoutEvents();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::ONLY,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -441,11 +441,11 @@ class VideoIndexTest extends TestCase
         $excludedDate = $this->faker->date();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 BaseModel::ATTRIBUTE_DELETED_AT => $deletedFilter,
                 TrashedCriteria::PARAM_VALUE => TrashedStatus::WITH,
             ],
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
             ],
         ];
@@ -492,7 +492,7 @@ class VideoIndexTest extends TestCase
         $lyricsFilter = $this->faker->boolean();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Video::ATTRIBUTE_LYRICS => $lyricsFilter,
             ],
         ];
@@ -529,7 +529,7 @@ class VideoIndexTest extends TestCase
         $ncFilter = $this->faker->boolean();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Video::ATTRIBUTE_NC => $ncFilter,
             ],
         ];
@@ -566,7 +566,7 @@ class VideoIndexTest extends TestCase
         $overlapFilter = VideoOverlap::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Video::ATTRIBUTE_OVERLAP => $overlapFilter->description,
             ],
         ];
@@ -604,7 +604,7 @@ class VideoIndexTest extends TestCase
         $excludedResolution = $resolutionFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Video::ATTRIBUTE_RESOLUTION => $resolutionFilter,
             ],
         ];
@@ -645,7 +645,7 @@ class VideoIndexTest extends TestCase
         $sourceFilter = VideoSource::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Video::ATTRIBUTE_SOURCE => $sourceFilter->description,
             ],
         ];
@@ -682,7 +682,7 @@ class VideoIndexTest extends TestCase
         $subbedFilter = $this->faker->boolean();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Video::ATTRIBUTE_SUBBED => $subbedFilter,
             ],
         ];
@@ -719,7 +719,7 @@ class VideoIndexTest extends TestCase
         $uncenFilter = $this->faker->boolean();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Video::ATTRIBUTE_UNCEN => $uncenFilter,
             ],
         ];
@@ -754,10 +754,10 @@ class VideoIndexTest extends TestCase
         $nsfwFilter = $this->faker->boolean();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeThemeEntry::ATTRIBUTE_NSFW => $nsfwFilter,
             ],
-            IncludeParser::$param => Video::RELATION_ANIMETHEMEENTRIES,
+            IncludeParser::param() => Video::RELATION_ANIMETHEMEENTRIES,
         ];
 
         Video::factory()
@@ -800,10 +800,10 @@ class VideoIndexTest extends TestCase
         $spoilerFilter = $this->faker->boolean();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeThemeEntry::ATTRIBUTE_SPOILER => $spoilerFilter,
             ],
-            IncludeParser::$param => Video::RELATION_ANIMETHEMEENTRIES,
+            IncludeParser::param() => Video::RELATION_ANIMETHEMEENTRIES,
         ];
 
         Video::factory()
@@ -847,10 +847,10 @@ class VideoIndexTest extends TestCase
         $excludedVersion = $versionFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeThemeEntry::ATTRIBUTE_VERSION => $versionFilter,
             ],
-            IncludeParser::$param => Video::RELATION_ANIMETHEMEENTRIES,
+            IncludeParser::param() => Video::RELATION_ANIMETHEMEENTRIES,
         ];
 
         Video::factory()
@@ -898,10 +898,10 @@ class VideoIndexTest extends TestCase
         $excludedGroup = $this->faker->word();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeTheme::ATTRIBUTE_GROUP => $groupFilter,
             ],
-            IncludeParser::$param => Video::RELATION_ANIMETHEME,
+            IncludeParser::param() => Video::RELATION_ANIMETHEME,
         ];
 
         Video::factory()
@@ -951,10 +951,10 @@ class VideoIndexTest extends TestCase
         $excludedSequence = $sequenceFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeTheme::ATTRIBUTE_SEQUENCE => $sequenceFilter,
             ],
-            IncludeParser::$param => Video::RELATION_ANIMETHEME,
+            IncludeParser::param() => Video::RELATION_ANIMETHEME,
         ];
 
         Video::factory()
@@ -1003,10 +1003,10 @@ class VideoIndexTest extends TestCase
         $typeFilter = ThemeType::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeTheme::ATTRIBUTE_TYPE => $typeFilter->description,
             ],
-            IncludeParser::$param => Video::RELATION_ANIMETHEME,
+            IncludeParser::param() => Video::RELATION_ANIMETHEME,
         ];
 
         Video::factory()
@@ -1049,10 +1049,10 @@ class VideoIndexTest extends TestCase
         $seasonFilter = AnimeSeason::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_SEASON => $seasonFilter->description,
             ],
-            IncludeParser::$param => Video::RELATION_ANIME,
+            IncludeParser::param() => Video::RELATION_ANIME,
         ];
 
         Video::factory()
@@ -1096,10 +1096,10 @@ class VideoIndexTest extends TestCase
         $excludedYear = $yearFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_YEAR => $yearFilter,
             ],
-            IncludeParser::$param => Video::RELATION_ANIME,
+            IncludeParser::param() => Video::RELATION_ANIME,
         ];
 
         Video::factory()

--- a/tests/Feature/Http/Api/Wiki/Video/VideoShowTest.php
+++ b/tests/Feature/Http/Api/Wiki/Video/VideoShowTest.php
@@ -99,7 +99,7 @@ class VideoShowTest extends TestCase
         $includedPaths = $selectedIncludes->map(fn (AllowedInclude $include) => $include->path());
 
         $parameters = [
-            IncludeParser::$param => $includedPaths->join(','),
+            IncludeParser::param() => $includedPaths->join(','),
         ];
 
         Video::factory()
@@ -142,7 +142,7 @@ class VideoShowTest extends TestCase
         $includedFields = $fields->random($this->faker->numberBetween(1, $fields->count()));
 
         $parameters = [
-            FieldParser::$param => [
+            FieldParser::param() => [
                 VideoResource::$wrap => $includedFields->map(fn (Field $field) => $field->getKey())->join(','),
             ],
         ];
@@ -173,10 +173,10 @@ class VideoShowTest extends TestCase
         $nsfwFilter = $this->faker->boolean();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeThemeEntry::ATTRIBUTE_NSFW => $nsfwFilter,
             ],
-            IncludeParser::$param => Video::RELATION_ANIMETHEMEENTRIES,
+            IncludeParser::param() => Video::RELATION_ANIMETHEMEENTRIES,
         ];
 
         Video::factory()
@@ -218,10 +218,10 @@ class VideoShowTest extends TestCase
         $spoilerFilter = $this->faker->boolean();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeThemeEntry::ATTRIBUTE_SPOILER => $spoilerFilter,
             ],
-            IncludeParser::$param => Video::RELATION_ANIMETHEMEENTRIES,
+            IncludeParser::param() => Video::RELATION_ANIMETHEMEENTRIES,
         ];
 
         Video::factory()
@@ -264,10 +264,10 @@ class VideoShowTest extends TestCase
         $excludedVersion = $versionFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeThemeEntry::ATTRIBUTE_VERSION => $versionFilter,
             ],
-            IncludeParser::$param => Video::RELATION_ANIMETHEMEENTRIES,
+            IncludeParser::param() => Video::RELATION_ANIMETHEMEENTRIES,
         ];
 
         Video::factory()
@@ -314,10 +314,10 @@ class VideoShowTest extends TestCase
         $excludedGroup = $this->faker->word();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeTheme::ATTRIBUTE_GROUP => $groupFilter,
             ],
-            IncludeParser::$param => Video::RELATION_ANIMETHEME,
+            IncludeParser::param() => Video::RELATION_ANIMETHEME,
         ];
 
         Video::factory()
@@ -366,10 +366,10 @@ class VideoShowTest extends TestCase
         $excludedSequence = $sequenceFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeTheme::ATTRIBUTE_SEQUENCE => $sequenceFilter,
             ],
-            IncludeParser::$param => Video::RELATION_ANIMETHEME,
+            IncludeParser::param() => Video::RELATION_ANIMETHEME,
         ];
 
         Video::factory()
@@ -417,10 +417,10 @@ class VideoShowTest extends TestCase
         $typeFilter = ThemeType::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 AnimeTheme::ATTRIBUTE_TYPE => $typeFilter->description,
             ],
-            IncludeParser::$param => Video::RELATION_ANIMETHEME,
+            IncludeParser::param() => Video::RELATION_ANIMETHEME,
         ];
 
         Video::factory()
@@ -462,10 +462,10 @@ class VideoShowTest extends TestCase
         $seasonFilter = AnimeSeason::getRandomInstance();
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_SEASON => $seasonFilter->description,
             ],
-            IncludeParser::$param => Video::RELATION_ANIME,
+            IncludeParser::param() => Video::RELATION_ANIME,
         ];
 
         Video::factory()
@@ -508,10 +508,10 @@ class VideoShowTest extends TestCase
         $excludedYear = $yearFilter + 1;
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 Anime::ATTRIBUTE_YEAR => $yearFilter,
             ],
-            IncludeParser::$param => Video::RELATION_ANIME,
+            IncludeParser::param() => Video::RELATION_ANIME,
         ];
 
         Video::factory()

--- a/tests/Feature/Http/Auth/RegistrationTest.php
+++ b/tests/Feature/Http/Auth/RegistrationTest.php
@@ -20,7 +20,7 @@ class RegistrationTest extends TestCase
 
     /**
      * If the show registration form request uses a closed invitation,
-     * the application shall redirect the user to the welcome screen.
+     * the user shall receive a forbidden exception.
      *
      * @return void
      */
@@ -38,12 +38,12 @@ class RegistrationTest extends TestCase
 
         $response = $this->get($url);
 
-        $response->assertRedirect(route('welcome'));
+        $response->assertForbidden();
     }
 
     /**
      * If the show registration form request uses a soft deleted invitation,
-     * the application shall redirect the user to the welcome screen.
+     * the user shall receive a forbidden exception.
      *
      * @return void
      */
@@ -61,7 +61,7 @@ class RegistrationTest extends TestCase
 
         $response = $this->get($url);
 
-        $response->assertRedirect(route('welcome'));
+        $response->assertForbidden();
     }
 
     /**
@@ -87,7 +87,7 @@ class RegistrationTest extends TestCase
 
     /**
      * If the registration request uses a closed invitation,
-     * the application shall redirect the user to the welcome screen.
+     * the user shall receive a forbidden exception.
      *
      * @return void
      */
@@ -105,7 +105,7 @@ class RegistrationTest extends TestCase
 
         $response = $this->post($url);
 
-        $response->assertRedirect(route('welcome'));
+        $response->assertForbidden();
     }
 
     /**

--- a/tests/Feature/Http/Wiki/ImageTest.php
+++ b/tests/Feature/Http/Wiki/ImageTest.php
@@ -19,11 +19,11 @@ class ImageTest extends TestCase
     use WithoutEvents;
 
     /**
-     * If the image is soft-deleted, the user shall be redirected to the Welcome Screen.
+     * If the image is soft-deleted, the user shall receive a forbidden exception.
      *
      * @return void
      */
-    public function testSoftDeleteImageStreamingRedirect(): void
+    public function testSoftDeleteImageStreamingForbidden(): void
     {
         $image = Image::factory()->createOne();
 
@@ -31,7 +31,7 @@ class ImageTest extends TestCase
 
         $response = $this->get(route('image.show', ['image' => $image]));
 
-        $response->assertRedirect(route('welcome'));
+        $response->assertForbidden();
     }
 
     /**

--- a/tests/Feature/Http/Wiki/VideoTest.php
+++ b/tests/Feature/Http/Wiki/VideoTest.php
@@ -23,11 +23,11 @@ class VideoTest extends TestCase
 
     /**
      * If video streaming is disabled through the 'flags.allow_video_streams' property,
-     * the user shall be redirected to the Welcome Screen.
+     * the user shall receive a forbidden exception.
      *
      * @return void
      */
-    public function testVideoStreamingNotAllowedRedirect(): void
+    public function testVideoStreamingNotAllowedForbidden(): void
     {
         Config::set(FlagConstants::ALLOW_VIDEO_STREAMS_FLAG_QUALIFIED, false);
 
@@ -35,15 +35,15 @@ class VideoTest extends TestCase
 
         $response = $this->get(route('video.show', ['video' => $video]));
 
-        $response->assertRedirect(route('welcome'));
+        $response->assertForbidden();
     }
 
     /**
-     * If the video is soft-deleted, the user shall be redirected to the Welcome Screen.
+     * If the video is soft-deleted, the user shall receive a forbidden exception.
      *
      * @return void
      */
-    public function testSoftDeleteVideoStreamingRedirect(): void
+    public function testSoftDeleteVideoStreamingForbidden(): void
     {
         Config::set(FlagConstants::ALLOW_VIDEO_STREAMS_FLAG_QUALIFIED, true);
 
@@ -53,7 +53,7 @@ class VideoTest extends TestCase
 
         $response = $this->get(route('video.show', ['video' => $video]));
 
-        $response->assertRedirect(route('welcome'));
+        $response->assertForbidden();
     }
 
     /**

--- a/tests/Unit/Http/Api/Parser/FieldParserTest.php
+++ b/tests/Unit/Http/Api/Parser/FieldParserTest.php
@@ -38,7 +38,7 @@ class FieldParserTest extends TestCase
         $fields = collect($this->faker()->words($this->faker->randomDigitNotNull()));
 
         $parameters = [
-            FieldParser::$param => [
+            FieldParser::param() => [
                 $this->faker->word() => $fields->join(','),
             ],
         ];
@@ -60,7 +60,7 @@ class FieldParserTest extends TestCase
         $fields = collect($this->faker()->words($this->faker->randomDigitNotNull()));
 
         $parameters = [
-            FieldParser::$param => [
+            FieldParser::param() => [
                 $type => $fields->join(','),
             ],
         ];
@@ -80,7 +80,7 @@ class FieldParserTest extends TestCase
         $fields = $this->faker()->words($this->faker->randomDigitNotNull());
 
         $parameters = [
-            FieldParser::$param => [
+            FieldParser::param() => [
                 $this->faker->word() => collect($fields)->join(','),
             ],
         ];

--- a/tests/Unit/Http/Api/Parser/FilterParserTest.php
+++ b/tests/Unit/Http/Api/Parser/FilterParserTest.php
@@ -39,7 +39,7 @@ class FilterParserTest extends TestCase
     public function testParseTrashedCriteria(): void
     {
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 TrashedCriteria::PARAM_VALUE => $this->faker->word(),
             ],
         ];
@@ -59,7 +59,7 @@ class FilterParserTest extends TestCase
         $fields = collect($this->faker()->words());
 
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 $this->faker->word() => $fields->join(','),
             ],
         ];
@@ -77,7 +77,7 @@ class FilterParserTest extends TestCase
     public function testParseHasCriteria(): void
     {
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 HasCriteria::PARAM_VALUE => $this->faker->word(),
             ],
         ];
@@ -95,7 +95,7 @@ class FilterParserTest extends TestCase
     public function testParseWhereCriteria(): void
     {
         $parameters = [
-            FilterParser::$param => [
+            FilterParser::param() => [
                 $this->faker->word() => $this->faker->word(),
             ],
         ];

--- a/tests/Unit/Http/Api/Parser/IncludeParserTest.php
+++ b/tests/Unit/Http/Api/Parser/IncludeParserTest.php
@@ -39,7 +39,7 @@ class IncludeParserTest extends TestCase
         $fields = collect($this->faker()->words($this->faker->randomDigitNotNull()));
 
         $parameters = [
-            IncludeParser::$param => $fields->join(','),
+            IncludeParser::param() => $fields->join(','),
         ];
 
         $criteria = IncludeParser::parse($parameters)[0];
@@ -57,7 +57,7 @@ class IncludeParserTest extends TestCase
         $fields = $this->faker()->words($this->faker->randomDigitNotNull());
 
         $parameters = [
-            IncludeParser::$param => collect($fields)->join(','),
+            IncludeParser::param() => collect($fields)->join(','),
         ];
 
         $criteria = IncludeParser::parse($parameters)[0];
@@ -75,7 +75,7 @@ class IncludeParserTest extends TestCase
         $fields = collect($this->faker()->words($this->faker->randomDigitNotNull()));
 
         $parameters = [
-            IncludeParser::$param => [
+            IncludeParser::param() => [
                 $this->faker->word() => $fields->join(','),
             ],
         ];
@@ -97,7 +97,7 @@ class IncludeParserTest extends TestCase
         $fields = collect($this->faker()->words($this->faker->randomDigitNotNull()));
 
         $parameters = [
-            IncludeParser::$param => [
+            IncludeParser::param() => [
                 $type => $fields->join(','),
             ],
         ];
@@ -120,7 +120,7 @@ class IncludeParserTest extends TestCase
         $fields = $this->faker()->words($this->faker->randomDigitNotNull());
 
         $parameters = [
-            IncludeParser::$param => [
+            IncludeParser::param() => [
                 $this->faker->word() => collect($fields)->join(','),
             ],
         ];

--- a/tests/Unit/Http/Api/Parser/PagingParserTest.php
+++ b/tests/Unit/Http/Api/Parser/PagingParserTest.php
@@ -45,7 +45,7 @@ class PagingParserTest extends TestCase
         $limit = $this->faker->word();
 
         $parameters = [
-            PagingParser::$param => [
+            PagingParser::param() => [
                 LimitCriteria::PARAM => $limit,
             ],
         ];
@@ -70,7 +70,7 @@ class PagingParserTest extends TestCase
         $limit = $this->faker->numberBetween(1, Criteria::DEFAULT_SIZE);
 
         $parameters = [
-            PagingParser::$param => [
+            PagingParser::param() => [
                 LimitCriteria::PARAM => $limit,
             ],
         ];
@@ -111,7 +111,7 @@ class PagingParserTest extends TestCase
         $size = $this->faker->word();
 
         $parameters = [
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => $size,
             ],
         ];
@@ -136,7 +136,7 @@ class PagingParserTest extends TestCase
         $size = $this->faker->numberBetween(1, Criteria::MAX_RESULTS);
 
         $parameters = [
-            PagingParser::$param => [
+            PagingParser::param() => [
                 OffsetCriteria::SIZE_PARAM => $size,
             ],
         ];

--- a/tests/Unit/Http/Api/Parser/SearchParserTest.php
+++ b/tests/Unit/Http/Api/Parser/SearchParserTest.php
@@ -36,7 +36,7 @@ class SearchParserTest extends TestCase
     public function testParseSearchCriteria(): void
     {
         $parameters = [
-            SearchParser::$param => $this->faker->word(),
+            SearchParser::param() => $this->faker->word(),
         ];
 
         $criteria = SearchParser::parse($parameters)[0];
@@ -54,7 +54,7 @@ class SearchParserTest extends TestCase
         $term = $this->faker->word();
 
         $parameters = [
-            SearchParser::$param => $term,
+            SearchParser::param() => $term,
         ];
 
         $criteria = SearchParser::parse($parameters)[0];

--- a/tests/Unit/Http/Api/Parser/SortParserTest.php
+++ b/tests/Unit/Http/Api/Parser/SortParserTest.php
@@ -40,7 +40,7 @@ class SortParserTest extends TestCase
     public function testParseRandomCriteria(): void
     {
         $parameters = [
-            SortParser::$param => RandomCriteria::PARAM_VALUE,
+            SortParser::param() => RandomCriteria::PARAM_VALUE,
         ];
 
         $criteria = SortParser::parse($parameters)[0];
@@ -56,7 +56,7 @@ class SortParserTest extends TestCase
     public function testParseRelationCriteria(): void
     {
         $parameters = [
-            SortParser::$param => collect($this->faker->words())->join('.'),
+            SortParser::param() => collect($this->faker->words())->join('.'),
         ];
 
         $criteria = SortParser::parse($parameters)[0];
@@ -72,7 +72,7 @@ class SortParserTest extends TestCase
     public function testParseFieldCriteria(): void
     {
         $parameters = [
-            SortParser::$param => $this->faker->word(),
+            SortParser::param() => $this->faker->word(),
         ];
 
         $criteria = SortParser::parse($parameters)[0];
@@ -90,7 +90,7 @@ class SortParserTest extends TestCase
         $field = $this->faker->word();
 
         $parameters = [
-            SortParser::$param => $field,
+            SortParser::param() => $field,
         ];
 
         $criteria = SortParser::parse($parameters)[0];
@@ -106,7 +106,7 @@ class SortParserTest extends TestCase
     public function testParseDefaultDirection(): void
     {
         $parameters = [
-            SortParser::$param => $this->faker->word(),
+            SortParser::param() => $this->faker->word(),
         ];
 
         $criteria = SortParser::parse($parameters)[0];
@@ -127,7 +127,7 @@ class SortParserTest extends TestCase
         $field = Str::of('-')->append($this->faker->word())->__toString();
 
         $parameters = [
-            SortParser::$param => $field,
+            SortParser::param() => $field,
         ];
 
         $criteria = SortParser::parse($parameters)[0];

--- a/tests/Unit/Http/Api/Query/QueryTest.php
+++ b/tests/Unit/Http/Api/Query/QueryTest.php
@@ -38,7 +38,7 @@ class QueryTest extends TestCase
         $type = $this->faker->word();
 
         $parameters = [
-            FieldParser::$param => [
+            FieldParser::param() => [
                 $type => $this->faker->word(),
             ],
         ];
@@ -56,7 +56,7 @@ class QueryTest extends TestCase
     public function testGetIncludeCriteria(): void
     {
         $parameters = [
-            IncludeParser::$param => $this->faker->word(),
+            IncludeParser::param() => $this->faker->word(),
         ];
 
         $query = FakeQuery::make($parameters);
@@ -74,7 +74,7 @@ class QueryTest extends TestCase
         $type = $this->faker->word();
 
         $parameters = [
-            IncludeParser::$param => [
+            IncludeParser::param() => [
                 $type => $this->faker->word(),
             ],
         ];
@@ -94,7 +94,7 @@ class QueryTest extends TestCase
         $fields = collect($this->faker()->words($this->faker->randomDigitNotNull()));
 
         $parameters = [
-            SortParser::$param => $fields->join(','),
+            SortParser::param() => $fields->join(','),
         ];
 
         $query = FakeQuery::make($parameters);
@@ -111,7 +111,7 @@ class QueryTest extends TestCase
     {
         $filterCount = $this->faker->randomDigitNotNull();
 
-        $parameters = Collection::times($filterCount, fn () => FilterParser::$param.'.'.Str::random())
+        $parameters = Collection::times($filterCount, fn () => FilterParser::param().'.'.Str::random())
             ->combine(Collection::times($filterCount, fn () => Str::random()))
             ->undot()
             ->all();
@@ -143,7 +143,7 @@ class QueryTest extends TestCase
     public function testHasSearch(): void
     {
         $parameters = [
-            SearchParser::$param => $this->faker->word(),
+            SearchParser::param() => $this->faker->word(),
         ];
 
         $query = FakeQuery::make($parameters);
@@ -173,7 +173,7 @@ class QueryTest extends TestCase
     public function testGetSearch(): void
     {
         $parameters = [
-            SearchParser::$param => $this->faker->word(),
+            SearchParser::param() => $this->faker->word(),
         ];
 
         $query = FakeQuery::make($parameters);


### PR DESCRIPTION
Reduce conditions where we exit early. IMO this can introduce side effects.

For example, we are returning an empty collection for DO repositories if tokens are not configured or if some exception is thrown. If DO experiences a problem with their API, we may end up deleting objects in our next reconciliation. It would be better to raise the exception in this case to prevent this.

Additionally, raising exceptions provide more information than silent failures. Prior to this change, we simply redirect if we attempt to access a video when the feature flag for video streams is disabled or if we try to display a deleted image. We now raise a 403 with a short message so that the user is informed that video streaming is disabled or that the object they are attempting to stream/download is deleted.

Note: this is incremental. I intend on continuing this tomorrow.

Address duplicate code block.