### PR TITLE
feat(api): add scoping to sorts & cleanup validation for endpoints [incremental]

### DIFF
--- a/app/Http/Api/Criteria/Sort/Criteria.php
+++ b/app/Http/Api/Criteria/Sort/Criteria.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Api\Criteria\Sort;
 
+use App\Http\Api\Scope\Scope;
 use App\Http\Api\Sort\Sort;
 use Illuminate\Database\Eloquent\Builder;
 
@@ -15,10 +16,21 @@ abstract class Criteria
     /**
      * Create a new criteria instance.
      *
+     * @param  Scope  $scope
      * @param  string  $field
      */
-    public function __construct(protected string $field)
+    public function __construct(protected Scope $scope, protected string $field)
     {
+    }
+
+    /**
+     * Get the scope of the criteria.
+     *
+     * @return Scope
+     */
+    public function getScope(): Scope
+    {
+        return $this->scope;
     }
 
     /**
@@ -35,12 +47,22 @@ abstract class Criteria
      * Determine if this sort should be applied.
      *
      * @param  Sort  $sort
+     * @param  Scope  $scope
      * @return bool
      */
-    public function shouldSort(Sort $sort): bool
+    public function shouldSort(Sort $sort, Scope $scope): bool
     {
-        // Apply sort if key matches
-        return $this->getField() === $sort->getKey();
+        // Don't apply sort if key does not match
+        if ($this->getField() !== $sort->getKey()) {
+            return false;
+        }
+
+        // Don't apply sort if scope does not match
+        if (! $this->getScope()->isWithinScope($scope)) {
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/app/Http/Api/Criteria/Sort/FieldCriteria.php
+++ b/app/Http/Api/Criteria/Sort/FieldCriteria.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Api\Criteria\Sort;
 
 use App\Enums\Http\Api\Sort\Direction;
+use App\Http\Api\Scope\Scope;
 use App\Http\Api\Sort\Sort;
 use Illuminate\Database\Eloquent\Builder;
 
@@ -16,12 +17,13 @@ class FieldCriteria extends Criteria
     /**
      * Create a new criteria instance.
      *
+     * @param  Scope  $scope
      * @param  string  $field
      * @param  Direction  $direction
      */
-    public function __construct(string $field, protected Direction $direction)
+    public function __construct(Scope $scope, string $field, protected Direction $direction)
     {
-        parent::__construct($field);
+        parent::__construct($scope, $field);
     }
 
     /**

--- a/app/Http/Api/Criteria/Sort/RandomCriteria.php
+++ b/app/Http/Api/Criteria/Sort/RandomCriteria.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Api\Criteria\Sort;
 
+use App\Http\Api\Scope\Scope;
 use App\Http\Api\Sort\Sort;
 use Illuminate\Database\Eloquent\Builder;
 
@@ -16,10 +17,12 @@ class RandomCriteria extends Criteria
 
     /**
      * Create a new criteria instance.
+     *
+     * @param  Scope  $scope
      */
-    public function __construct()
+    public function __construct(Scope $scope)
     {
-        parent::__construct(self::PARAM_VALUE);
+        parent::__construct($scope, self::PARAM_VALUE);
     }
 
     /**

--- a/app/Http/Requests/Api/Admin/AnnouncementIndexRequest.php
+++ b/app/Http/Requests/Api/Admin/AnnouncementIndexRequest.php
@@ -20,7 +20,7 @@ class AnnouncementIndexRequest extends EloquentIndexRequest
      *
      * @return EloquentSchema
      */
-    protected function getSchema(): EloquentSchema
+    protected function schema(): EloquentSchema
     {
         return new AnnouncementSchema();
     }

--- a/app/Http/Requests/Api/Admin/AnnouncementShowRequest.php
+++ b/app/Http/Requests/Api/Admin/AnnouncementShowRequest.php
@@ -20,7 +20,7 @@ class AnnouncementShowRequest extends EloquentShowRequest
      *
      * @return EloquentSchema
      */
-    protected function getSchema(): EloquentSchema
+    protected function schema(): EloquentSchema
     {
         return new AnnouncementSchema();
     }

--- a/app/Http/Requests/Api/BaseRequest.php
+++ b/app/Http/Requests/Api/BaseRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Requests\Api;
 
+use App\Enums\Http\Api\Sort\Direction;
 use App\Http\Api\Field\Field;
 use App\Http\Api\Include\AllowedInclude;
 use App\Http\Api\Parser\FieldParser;
@@ -11,7 +12,10 @@ use App\Http\Api\Parser\FilterParser;
 use App\Http\Api\Parser\IncludeParser;
 use App\Http\Api\Query\Query;
 use App\Http\Api\Schema\Schema;
+use App\Rules\Api\DistinctIgnoringDirectionRule;
+use App\Rules\Api\RandomSoleRule;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 use Spatie\ValidationRules\Rules\Delimited;
@@ -49,55 +53,125 @@ abstract class BaseRequest extends FormRequest
     }
 
     /**
+     * Restrict the allowed types for the parameter.
+     *
+     * @param  string  $param
+     * @param  Collection  $types
+     * @return array
+     */
+    protected function restrictAllowedTypes(string $param, Collection $types): array
+    {
+        return [
+            $param => [
+                'nullable',
+                Str::of('array:')->append($types->join(','))->__toString(),
+            ],
+        ];
+    }
+
+    /**
+     * Restrict the allowed values for the parameter.
+     *
+     * @param  string  $param
+     * @param  Collection  $values
+     * @param  array  $customRules
+     * @return array
+     */
+    protected function restrictAllowedValues(string $param, Collection $values, array $customRules = []): array
+    {
+        return [
+            $param => array_merge(
+                ['sometimes', 'required', new Delimited(Rule::in($values))],
+                $customRules,
+            ),
+        ];
+    }
+
+    /**
+     * Prohibit the parameter.
+     *
+     * @param  string  $param
+     * @return array
+     */
+    protected function prohibit(string $param): array
+    {
+        return [
+            $param => [
+                'prohibited',
+            ],
+        ];
+    }
+
+    /**
+     * Optional parameter.
+     *
+     * @param  string  $param
+     * @param  array  $customRules
+     * @return array
+     */
+    protected function optional(string $param, array $customRules = []): array
+    {
+        return [
+            $param => array_merge(
+                ['sometimes', 'required'],
+                $customRules,
+            ),
+        ];
+    }
+
+    /**
+     * Require the parameter.
+     *
+     * @param  string  $param
+     * @param  array  $customRules
+     * @return array
+     */
+    protected function require(string $param, array $customRules = []): array
+    {
+        return [
+            $param => array_merge(
+                ['required'],
+                $customRules,
+            ),
+        ];
+    }
+
+    /**
      * Get the field validation rules.
      *
      * @return array
      */
     protected function getFieldRules(): array
     {
-        $schema = $this->getSchema();
+        $schema = $this->schema();
 
         $types = collect($schema->type());
 
-        $rules = $this->getSchemaFieldRules($schema);
+        $rules = $this->restrictAllowedFieldValues($schema);
 
         foreach ($schema->allowedIncludes() as $allowedIncludePath) {
             $relationSchema = $allowedIncludePath->schema();
 
             $types->push($relationSchema->type());
 
-            $rules = array_merge($rules, $this->getSchemaFieldRules($relationSchema));
+            $rules = $rules + $this->restrictAllowedFieldValues($relationSchema);
         }
 
-        return array_merge(
-            $rules,
-            [
-                FieldParser::param() => [
-                    'nullable',
-                    Str::of('array:')->append($types->join(','))->__toString(),
-                ],
-            ],
-        );
+        return $rules + $this->restrictAllowedTypes(FieldParser::param(), $types);
     }
 
     /**
-     * Get the validation rules for the schema.
+     * Restrict the allowed values for the schema fields.
      *
      * @param  Schema  $schema
-     * @return array
+     * @return array[]
      */
-    protected function getSchemaFieldRules(Schema $schema): array
+    protected function restrictAllowedFieldValues(Schema $schema): array
     {
-        return [
-            Str::of(FieldParser::param())
-                ->append('.')
-                ->append($schema->type())
-                ->__toString() => [
-                    'sometimes',
-                    'required',
-                    new Delimited(Rule::in(collect($schema->fields())->map(fn (Field $field) => $field->getKey()))),
-                ],
-        ];
+        return $this->restrictAllowedValues(
+            Str::of(FieldParser::param())->append('.')->append($schema->type())->__toString(),
+            collect($schema->fields())->map(fn (Field $field) => $field->getKey())
+        );
     }
 
     /**
@@ -122,25 +196,66 @@ abstract class BaseRequest extends FormRequest
      */
     protected function getIncludeRules(): array
     {
-        $schema = $this->getSchema();
+        $schema = $this->schema();
 
-        $allowedIncludes = collect($schema->allowedIncludes());
-
-        if ($allowedIncludes->isEmpty()) {
-            return [
-                IncludeParser::param() => [
-                    'prohibited',
-                ],
-            ];
+        if (collect($schema->allowedIncludes())->isEmpty()) {
+            return $this->prohibit(IncludeParser::param());
         }
 
-        return [
-            IncludeParser::param() => [
-                'sometimes',
-                'required',
-                new Delimited(Rule::in($allowedIncludes->map(fn (AllowedInclude $include) => $include->path()))),
-            ],
-        ];
+        return $this->restrictAllowedIncludeValues(IncludeParser::param(), $schema);
+    }
+
+    /**
+     * Restrict the allowed values for the schema includes.
+     *
+     * @param  string  $param
+     * @param  Schema  $schema
+     * @return array[]
+     */
+    protected function restrictAllowedIncludeValues(string $param, Schema $schema): array
+    {
+        return $this->restrictAllowedValues(
+            $param,
+            collect($schema->allowedIncludes())->map(fn (AllowedInclude $include) => $include->path())
+        );
+    }
+
+    /**
+     * Get allowed sorts for schema.
+     *
+     * @param  Schema  $schema
+     * @return Collection
+     */
+    protected function formatAllowedSortValues(Schema $schema): Collection
+    {
+        $allowedSorts = collect();
+
+        foreach ($schema->sorts() as $sort) {
+            foreach (Direction::getInstances() as $direction) {
+                $formattedSort = $sort->format($direction);
+                if (! $allowedSorts->contains($formattedSort)) {
+                    $allowedSorts->push($formattedSort);
+                }
+            }
+        }
+
+        return $allowedSorts;
+    }
+
+    /**
+     * Restrict allowed sorts for schema.
+     *
+     * @param  string  $param
+     * @param  Schema  $schema
+     * @return array[]
+     */
+    protected function restrictAllowedSortValues(string $param, Schema $schema): array
+    {
+        return $this->restrictAllowedValues(
+            $param,
+            $this->formatAllowedSortValues($schema),
+            [new DistinctIgnoringDirectionRule(), new RandomSoleRule()]
+        );
     }
 
     /**
@@ -169,7 +284,7 @@ abstract class BaseRequest extends FormRequest
      *
      * @return Schema
      */
-    abstract protected function getSchema(): Schema;
+    abstract protected function schema(): Schema;
 
     /**
      * Get the validation API Query.

--- a/app/Http/Requests/Api/Billing/Balance/BalanceIndexRequest.php
+++ b/app/Http/Requests/Api/Billing/Balance/BalanceIndexRequest.php
@@ -20,7 +20,7 @@ class BalanceIndexRequest extends EloquentIndexRequest
      *
      * @return EloquentSchema
      */
-    protected function getSchema(): EloquentSchema
+    protected function schema(): EloquentSchema
     {
         return new BalanceSchema();
     }

--- a/app/Http/Requests/Api/Billing/Balance/BalanceShowRequest.php
+++ b/app/Http/Requests/Api/Billing/Balance/BalanceShowRequest.php
@@ -20,7 +20,7 @@ class BalanceShowRequest extends EloquentShowRequest
      *
      * @return EloquentSchema
      */
-    protected function getSchema(): EloquentSchema
+    protected function schema(): EloquentSchema
     {
         return new BalanceSchema();
     }

--- a/app/Http/Requests/Api/Billing/Transaction/TransactionIndexRequest.php
+++ b/app/Http/Requests/Api/Billing/Transaction/TransactionIndexRequest.php
@@ -20,7 +20,7 @@ class TransactionIndexRequest extends EloquentIndexRequest
      *
      * @return EloquentSchema
      */
-    protected function getSchema(): EloquentSchema
+    protected function schema(): EloquentSchema
     {
         return new TransactionSchema();
     }

--- a/app/Http/Requests/Api/Billing/Transaction/TransactionShowRequest.php
+++ b/app/Http/Requests/Api/Billing/Transaction/TransactionShowRequest.php
@@ -20,7 +20,7 @@ class TransactionShowRequest extends EloquentShowRequest
      *
      * @return EloquentSchema
      */
-    protected function getSchema(): EloquentSchema
+    protected function schema(): EloquentSchema
     {
         return new TransactionSchema();
     }

--- a/app/Http/Requests/Api/Config/FlagsRequest.php
+++ b/app/Http/Requests/Api/Config/FlagsRequest.php
@@ -20,7 +20,7 @@ class FlagsRequest extends ShowRequest
      *
      * @return Schema
      */
-    protected function getSchema(): Schema
+    protected function schema(): Schema
     {
         return new FlagsSchema();
     }

--- a/app/Http/Requests/Api/Config/WikiRequest.php
+++ b/app/Http/Requests/Api/Config/WikiRequest.php
@@ -20,7 +20,7 @@ class WikiRequest extends ShowRequest
      *
      * @return Schema
      */
-    protected function getSchema(): Schema
+    protected function schema(): Schema
     {
         return new WikiSchema();
     }

--- a/app/Http/Requests/Api/Document/Page/PageIndexRequest.php
+++ b/app/Http/Requests/Api/Document/Page/PageIndexRequest.php
@@ -20,7 +20,7 @@ class PageIndexRequest extends EloquentIndexRequest
      *
      * @return EloquentSchema
      */
-    protected function getSchema(): EloquentSchema
+    protected function schema(): EloquentSchema
     {
         return new PageSchema();
     }

--- a/app/Http/Requests/Api/Document/Page/PageShowRequest.php
+++ b/app/Http/Requests/Api/Document/Page/PageShowRequest.php
@@ -20,7 +20,7 @@ class PageShowRequest extends EloquentShowRequest
      *
      * @return EloquentSchema
      */
-    protected function getSchema(): EloquentSchema
+    protected function schema(): EloquentSchema
     {
         return new PageSchema();
     }

--- a/app/Http/Requests/Api/EloquentIndexRequest.php
+++ b/app/Http/Requests/Api/EloquentIndexRequest.php
@@ -17,7 +17,7 @@ abstract class EloquentIndexRequest extends IndexRequest
      *
      * @return EloquentSchema
      */
-    abstract protected function getSchema(): EloquentSchema;
+    abstract protected function schema(): EloquentSchema;
 
     /**
      * Get the validation API Query.

--- a/app/Http/Requests/Api/EloquentShowRequest.php
+++ b/app/Http/Requests/Api/EloquentShowRequest.php
@@ -17,7 +17,7 @@ abstract class EloquentShowRequest extends ShowRequest
      *
      * @return EloquentSchema
      */
-    abstract protected function getSchema(): EloquentSchema;
+    abstract protected function schema(): EloquentSchema;
 
     /**
      * Get the validation API Query.

--- a/app/Http/Requests/Api/Wiki/Anime/AnimeIndexRequest.php
+++ b/app/Http/Requests/Api/Wiki/Anime/AnimeIndexRequest.php
@@ -21,7 +21,7 @@ class AnimeIndexRequest extends EloquentIndexRequest implements SearchableReques
      *
      * @return EloquentSchema
      */
-    protected function getSchema(): EloquentSchema
+    protected function schema(): EloquentSchema
     {
         return new AnimeSchema();
     }

--- a/app/Http/Requests/Api/Wiki/Anime/AnimeShowRequest.php
+++ b/app/Http/Requests/Api/Wiki/Anime/AnimeShowRequest.php
@@ -20,7 +20,7 @@ class AnimeShowRequest extends EloquentShowRequest
      *
      * @return EloquentSchema
      */
-    protected function getSchema(): EloquentSchema
+    protected function schema(): EloquentSchema
     {
         return new AnimeSchema();
     }

--- a/app/Http/Requests/Api/Wiki/Anime/Synonym/SynonymIndexRequest.php
+++ b/app/Http/Requests/Api/Wiki/Anime/Synonym/SynonymIndexRequest.php
@@ -21,7 +21,7 @@ class SynonymIndexRequest extends EloquentIndexRequest implements SearchableRequ
      *
      * @return EloquentSchema
      */
-    protected function getSchema(): EloquentSchema
+    protected function schema(): EloquentSchema
     {
         return new SynonymSchema();
     }

--- a/app/Http/Requests/Api/Wiki/Anime/Synonym/SynonymShowRequest.php
+++ b/app/Http/Requests/Api/Wiki/Anime/Synonym/SynonymShowRequest.php
@@ -20,7 +20,7 @@ class SynonymShowRequest extends EloquentShowRequest
      *
      * @return EloquentSchema
      */
-    protected function getSchema(): EloquentSchema
+    protected function schema(): EloquentSchema
     {
         return new SynonymSchema();
     }

--- a/app/Http/Requests/Api/Wiki/Anime/Theme/Entry/EntryIndexRequest.php
+++ b/app/Http/Requests/Api/Wiki/Anime/Theme/Entry/EntryIndexRequest.php
@@ -21,7 +21,7 @@ class EntryIndexRequest extends EloquentIndexRequest implements SearchableReques
      *
      * @return EloquentSchema
      */
-    protected function getSchema(): EloquentSchema
+    protected function schema(): EloquentSchema
     {
         return new EntrySchema();
     }

--- a/app/Http/Requests/Api/Wiki/Anime/Theme/Entry/EntryShowRequest.php
+++ b/app/Http/Requests/Api/Wiki/Anime/Theme/Entry/EntryShowRequest.php
@@ -20,7 +20,7 @@ class EntryShowRequest extends EloquentShowRequest
      *
      * @return EloquentSchema
      */
-    protected function getSchema(): EloquentSchema
+    protected function schema(): EloquentSchema
     {
         return new EntrySchema();
     }

--- a/app/Http/Requests/Api/Wiki/Anime/Theme/ThemeIndexRequest.php
+++ b/app/Http/Requests/Api/Wiki/Anime/Theme/ThemeIndexRequest.php
@@ -21,7 +21,7 @@ class ThemeIndexRequest extends EloquentIndexRequest implements SearchableReques
      *
      * @return EloquentSchema
      */
-    protected function getSchema(): EloquentSchema
+    protected function schema(): EloquentSchema
     {
         return new ThemeSchema();
     }

--- a/app/Http/Requests/Api/Wiki/Anime/Theme/ThemeShowRequest.php
+++ b/app/Http/Requests/Api/Wiki/Anime/Theme/ThemeShowRequest.php
@@ -20,7 +20,7 @@ class ThemeShowRequest extends EloquentShowRequest
      *
      * @return EloquentSchema
      */
-    protected function getSchema(): EloquentSchema
+    protected function schema(): EloquentSchema
     {
         return new ThemeSchema();
     }

--- a/app/Http/Requests/Api/Wiki/Anime/YearIndexRequest.php
+++ b/app/Http/Requests/Api/Wiki/Anime/YearIndexRequest.php
@@ -82,7 +82,7 @@ class YearIndexRequest extends BaseRequest
      *
      * @return EloquentSchema
      */
-    protected function getSchema(): EloquentSchema
+    protected function schema(): EloquentSchema
     {
         return new AnimeSchema();
     }

--- a/app/Http/Requests/Api/Wiki/Anime/YearShowRequest.php
+++ b/app/Http/Requests/Api/Wiki/Anime/YearShowRequest.php
@@ -20,7 +20,7 @@ class YearShowRequest extends ShowRequest
      *
      * @return EloquentSchema
      */
-    protected function getSchema(): EloquentSchema
+    protected function schema(): EloquentSchema
     {
         return new AnimeSchema();
     }

--- a/app/Http/Requests/Api/Wiki/Artist/ArtistIndexRequest.php
+++ b/app/Http/Requests/Api/Wiki/Artist/ArtistIndexRequest.php
@@ -21,7 +21,7 @@ class ArtistIndexRequest extends EloquentIndexRequest implements SearchableReque
      *
      * @return EloquentSchema
      */
-    protected function getSchema(): EloquentSchema
+    protected function schema(): EloquentSchema
     {
         return new ArtistSchema();
     }

--- a/app/Http/Requests/Api/Wiki/Artist/ArtistShowRequest.php
+++ b/app/Http/Requests/Api/Wiki/Artist/ArtistShowRequest.php
@@ -20,7 +20,7 @@ class ArtistShowRequest extends EloquentShowRequest
      *
      * @return EloquentSchema
      */
-    protected function getSchema(): EloquentSchema
+    protected function schema(): EloquentSchema
     {
         return new ArtistSchema();
     }

--- a/app/Http/Requests/Api/Wiki/ExternalResource/ExternalResourceIndexRequest.php
+++ b/app/Http/Requests/Api/Wiki/ExternalResource/ExternalResourceIndexRequest.php
@@ -20,7 +20,7 @@ class ExternalResourceIndexRequest extends EloquentIndexRequest
      *
      * @return EloquentSchema
      */
-    protected function getSchema(): EloquentSchema
+    protected function schema(): EloquentSchema
     {
         return new ExternalResourceSchema();
     }

--- a/app/Http/Requests/Api/Wiki/ExternalResource/ExternalResourceShowRequest.php
+++ b/app/Http/Requests/Api/Wiki/ExternalResource/ExternalResourceShowRequest.php
@@ -20,7 +20,7 @@ class ExternalResourceShowRequest extends EloquentShowRequest
      *
      * @return EloquentSchema
      */
-    protected function getSchema(): EloquentSchema
+    protected function schema(): EloquentSchema
     {
         return new ExternalResourceSchema();
     }

--- a/app/Http/Requests/Api/Wiki/Image/ImageIndexRequest.php
+++ b/app/Http/Requests/Api/Wiki/Image/ImageIndexRequest.php
@@ -20,7 +20,7 @@ class ImageIndexRequest extends EloquentIndexRequest
      *
      * @return EloquentSchema
      */
-    protected function getSchema(): EloquentSchema
+    protected function schema(): EloquentSchema
     {
         return new ImageSchema();
     }

--- a/app/Http/Requests/Api/Wiki/Image/ImageShowRequest.php
+++ b/app/Http/Requests/Api/Wiki/Image/ImageShowRequest.php
@@ -20,7 +20,7 @@ class ImageShowRequest extends EloquentShowRequest
      *
      * @return EloquentSchema
      */
-    protected function getSchema(): EloquentSchema
+    protected function schema(): EloquentSchema
     {
         return new ImageSchema();
     }

--- a/app/Http/Requests/Api/Wiki/Series/SeriesIndexRequest.php
+++ b/app/Http/Requests/Api/Wiki/Series/SeriesIndexRequest.php
@@ -21,7 +21,7 @@ class SeriesIndexRequest extends EloquentIndexRequest implements SearchableReque
      *
      * @return EloquentSchema
      */
-    protected function getSchema(): EloquentSchema
+    protected function schema(): EloquentSchema
     {
         return new SeriesSchema();
     }

--- a/app/Http/Requests/Api/Wiki/Series/SeriesShowRequest.php
+++ b/app/Http/Requests/Api/Wiki/Series/SeriesShowRequest.php
@@ -20,7 +20,7 @@ class SeriesShowRequest extends EloquentShowRequest
      *
      * @return EloquentSchema
      */
-    protected function getSchema(): EloquentSchema
+    protected function schema(): EloquentSchema
     {
         return new SeriesSchema();
     }

--- a/app/Http/Requests/Api/Wiki/Song/SongIndexRequest.php
+++ b/app/Http/Requests/Api/Wiki/Song/SongIndexRequest.php
@@ -21,7 +21,7 @@ class SongIndexRequest extends EloquentIndexRequest implements SearchableRequest
      *
      * @return EloquentSchema
      */
-    protected function getSchema(): EloquentSchema
+    protected function schema(): EloquentSchema
     {
         return new SongSchema();
     }

--- a/app/Http/Requests/Api/Wiki/Song/SongShowRequest.php
+++ b/app/Http/Requests/Api/Wiki/Song/SongShowRequest.php
@@ -20,7 +20,7 @@ class SongShowRequest extends EloquentShowRequest
      *
      * @return EloquentSchema
      */
-    protected function getSchema(): EloquentSchema
+    protected function schema(): EloquentSchema
     {
         return new SongSchema();
     }

--- a/app/Http/Requests/Api/Wiki/Studio/StudioIndexRequest.php
+++ b/app/Http/Requests/Api/Wiki/Studio/StudioIndexRequest.php
@@ -21,7 +21,7 @@ class StudioIndexRequest extends EloquentIndexRequest implements SearchableReque
      *
      * @return EloquentSchema
      */
-    protected function getSchema(): EloquentSchema
+    protected function schema(): EloquentSchema
     {
         return new StudioSchema();
     }

--- a/app/Http/Requests/Api/Wiki/Studio/StudioShowRequest.php
+++ b/app/Http/Requests/Api/Wiki/Studio/StudioShowRequest.php
@@ -20,7 +20,7 @@ class StudioShowRequest extends EloquentShowRequest
      *
      * @return EloquentSchema
      */
-    protected function getSchema(): EloquentSchema
+    protected function schema(): EloquentSchema
     {
         return new StudioSchema();
     }

--- a/app/Http/Requests/Api/Wiki/Video/VideoIndexRequest.php
+++ b/app/Http/Requests/Api/Wiki/Video/VideoIndexRequest.php
@@ -21,7 +21,7 @@ class VideoIndexRequest extends EloquentIndexRequest implements SearchableReques
      *
      * @return EloquentSchema
      */
-    protected function getSchema(): EloquentSchema
+    protected function schema(): EloquentSchema
     {
         return new VideoSchema();
     }

--- a/app/Http/Requests/Api/Wiki/Video/VideoShowRequest.php
+++ b/app/Http/Requests/Api/Wiki/Video/VideoShowRequest.php
@@ -20,7 +20,7 @@ class VideoShowRequest extends EloquentShowRequest
      *
      * @return EloquentSchema
      */
-    protected function getSchema(): EloquentSchema
+    protected function schema(): EloquentSchema
     {
         return new VideoSchema();
     }

--- a/app/Services/Elasticsearch/Elasticsearch.php
+++ b/app/Services/Elasticsearch/Elasticsearch.php
@@ -18,7 +18,6 @@ use ElasticScoutDriverPlus\Exceptions\QueryBuilderException;
 use Elasticsearch\Client;
 use Exception;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Str;
 use RuntimeException;
 
 /**
@@ -92,9 +91,7 @@ class Elasticsearch extends Search
         $builder = $elasticQueryPayload->buildQuery();
 
         // eager load relations with constraints
-        $constrainedEagerLoads = $query->constrainEagerLoads(
-            $query->getIncludeCriteria(Str::singular($schema->type()))
-        );
+        $constrainedEagerLoads = $query->constrainEagerLoads();
         $builder = $builder->load($constrainedEagerLoads);
 
         // apply filters
@@ -121,7 +118,7 @@ class Elasticsearch extends Search
             $elasticSortCriteria = SortParser::parse($sortCriterion);
             if ($elasticSortCriteria !== null) {
                 foreach ($schema->sorts() as $sort) {
-                    if ($sortCriterion->shouldSort($sort)) {
+                    if ($sortCriterion->shouldSort($sort, $scope)) {
                         $elasticSortCriteria->sort($builder, $sort);
                     }
                 }

--- a/tests/Unit/Services/Elasticsearch/Api/Parser/SortParserTest.php
+++ b/tests/Unit/Services/Elasticsearch/Api/Parser/SortParserTest.php
@@ -8,6 +8,7 @@ use App\Enums\Http\Api\Sort\Direction;
 use App\Http\Api\Criteria\Sort\FieldCriteria as BaseFieldCriteria;
 use App\Http\Api\Criteria\Sort\RandomCriteria;
 use App\Http\Api\Criteria\Sort\RelationCriteria as BaseRelationCriteria;
+use App\Http\Api\Scope\GlobalScope;
 use App\Services\Elasticsearch\Api\Criteria\Sort\FieldCriteria;
 use App\Services\Elasticsearch\Api\Criteria\Sort\RelationCriteria;
 use App\Services\Elasticsearch\Api\Parser\SortParser;
@@ -28,7 +29,7 @@ class SortParserTest extends TestCase
      */
     public function testRelationCriteria(): void
     {
-        $criteria = new BaseRelationCriteria($this->faker->word(), Direction::getRandomInstance());
+        $criteria = new BaseRelationCriteria(new GlobalScope(), $this->faker->word(), Direction::getRandomInstance());
 
         static::assertInstanceOf(RelationCriteria::class, SortParser::parse($criteria));
     }
@@ -40,7 +41,7 @@ class SortParserTest extends TestCase
      */
     public function testFieldCriteria(): void
     {
-        $criteria = new BaseFieldCriteria($this->faker->word(), Direction::getRandomInstance());
+        $criteria = new BaseFieldCriteria(new GlobalScope(), $this->faker->word(), Direction::getRandomInstance());
 
         static::assertInstanceOf(FieldCriteria::class, SortParser::parse($criteria));
     }
@@ -52,7 +53,7 @@ class SortParserTest extends TestCase
      */
     public function testRandomCriteria(): void
     {
-        $criteria = new RandomCriteria();
+        $criteria = new RandomCriteria(new GlobalScope());
 
         static::assertNull(SortParser::parse($criteria));
     }


### PR DESCRIPTION
* Sorts now support scoping similarly to filters. This applies to constrained eager loads as well as top-level api resources. For example, `/api/series?include=anime&sort[anime]=-year` will sort included anime by year in descending order.
* Validation has been cleaned up. Sort validation should now be applied to all endpoints. The only remaining work for validation is for filtering.