### PR TITLE
feat(api): validate allowed filter types [incremental]

### DIFF
--- a/app/Concerns/Http/Requests/Api/ValidatesConditionally.php
+++ b/app/Concerns/Http/Requests/Api/ValidatesConditionally.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Concerns\Http\Requests\Api;
+
+use Illuminate\Validation\Validator;
+
+/**
+ * Trait ValidatesConditionally.
+ */
+trait ValidatesConditionally
+{
+    /**
+     * Configure the validator instance.
+     * Note: This function is invoked by name if it exists.
+     * We define a decorator that provides better clarity for what conditional validation needs to be applied.
+     *
+     * @param  Validator  $validator
+     * @return void
+     *
+     * @noinspection PhpUnused
+     */
+    public function withValidator(Validator $validator): void
+    {
+        $this->handleConditionalValidation($validator);
+    }
+
+    /**
+     * Configure conditional validation.
+     *
+     * @param  Validator  $validator
+     * @return void
+     */
+    protected function handleConditionalValidation(Validator $validator): void
+    {
+        $this->conditionallyRestrictAllowedFilterValues($validator);
+    }
+
+    /**
+     * Filters shall be validated based on values.
+     * If the value contains a separator, we assume this is a multi-value filter that builds a where in clause.
+     * Otherwise, we assume this is a single-value filter that builds a where clause.
+     * Logical operators apply to specific clauses, so we must check formatted filter parameters against filter values.
+     *
+     * @param  Validator  $validator
+     * @return void
+     */
+    protected function conditionallyRestrictAllowedFilterValues(Validator $validator): void
+    {
+        //
+    }
+}

--- a/app/Concerns/Http/Requests/Api/ValidatesFields.php
+++ b/app/Concerns/Http/Requests/Api/ValidatesFields.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Concerns\Http\Requests\Api;
+
+use App\Http\Api\Field\Field;
+use App\Http\Api\Parser\FieldParser;
+use App\Http\Api\Schema\Schema;
+use Illuminate\Support\Str;
+
+/**
+ * Trait ValidatesFields.
+ */
+trait ValidatesFields
+{
+    use ValidatesParameters;
+
+    /**
+     * Restrict the allowed values for the schema fields.
+     *
+     * @param  Schema  $schema
+     * @return array[]
+     */
+    protected function restrictAllowedFieldValues(Schema $schema): array
+    {
+        return $this->restrictAllowedValues(
+            Str::of(FieldParser::param())->append('.')->append($schema->type())->__toString(),
+            collect($schema->fields())->map(fn (Field $field) => $field->getKey())
+        );
+    }
+}

--- a/app/Concerns/Http/Requests/Api/ValidatesFilters.php
+++ b/app/Concerns/Http/Requests/Api/ValidatesFilters.php
@@ -28,7 +28,7 @@ trait ValidatesFilters
     /**
      * Get the list of formatted filters for the schema.
      *
-     * @param Schema $schema
+     * @param  Schema  $schema
      * @return Collection
      */
     protected function getSchemaFormattedFilters(Schema $schema): Collection

--- a/app/Concerns/Http/Requests/Api/ValidatesFilters.php
+++ b/app/Concerns/Http/Requests/Api/ValidatesFilters.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Concerns\Http\Requests\Api;
+
+use App\Enums\Http\Api\Filter\BinaryLogicalOperator;
+use App\Enums\Http\Api\Filter\LogicalOperator;
+use App\Enums\Http\Api\Filter\UnaryLogicalOperator;
+use App\Http\Api\Criteria\Filter\Criteria;
+use App\Http\Api\Filter\Filter;
+use App\Http\Api\Parser\FilterParser;
+use App\Http\Api\Schema\Schema;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Fluent;
+use Illuminate\Support\Str;
+use Illuminate\Validation\Validator;
+use Spatie\ValidationRules\Rules\Delimited;
+
+/**
+ * Trait ValidatesFilters.
+ */
+trait ValidatesFilters
+{
+    use ValidatesParameters;
+
+    /**
+     * Get the list of formatted filters for the schema.
+     *
+     * @param Schema $schema
+     * @return Collection
+     */
+    protected function getSchemaFormattedFilters(Schema $schema): Collection
+    {
+        $schemaFilters = collect();
+
+        foreach ($schema->filters() as $filter) {
+            $schemaFilters = $schemaFilters->concat($this->getFilterFormats($filter, BinaryLogicalOperator::getInstances()));
+            $schemaFilters = $schemaFilters->concat($this->getFilterFormats($filter, UnaryLogicalOperator::getInstances()));
+        }
+
+        return $schemaFilters->filter()->unique();
+    }
+
+    /**
+     * Get the allowed list of filter keys with possible conditions.
+     *
+     * @param  Filter  $filter
+     * @param  LogicalOperator[]  $logicalOperators
+     * @return array
+     */
+    protected function getFilterFormats(Filter $filter, array $logicalOperators): array
+    {
+        $formattedFilters = [];
+
+        foreach ($logicalOperators as $binaryLogicalOperator) {
+            foreach ($filter->getAllowedComparisonOperators() as $allowedComparisonOperator) {
+                $formattedFilters[] = $filter->format($binaryLogicalOperator, $allowedComparisonOperator);
+            }
+            $formattedFilters[] = $filter->format($binaryLogicalOperator);
+        }
+
+        foreach ($filter->getAllowedComparisonOperators() as $allowedComparisonOperator) {
+            $formattedFilters[] = $filter->format(null, $allowedComparisonOperator);
+        }
+
+        $formattedFilters[] = $filter->format();
+
+        return array_unique(array_filter($formattedFilters));
+    }
+
+    /**
+     * Get possible qualified parameter values for formatted filter.
+     *
+     * @param  Schema  $schema
+     * @param  string  $formattedFilter
+     * @return array
+     */
+    protected function getFormattedParameters(Schema $schema, string $formattedFilter): array
+    {
+        return [
+            Str::of(FilterParser::param())
+                ->append('.')
+                ->append($formattedFilter)
+                ->__toString(),
+
+            Str::of(FilterParser::param())
+                ->append('.')
+                ->append($schema->type())
+                ->append('.')
+                ->append($formattedFilter)
+                ->__toString(),
+        ];
+    }
+
+    /**
+     * Restrict filter based on allowed formats and provided values.
+     *
+     * @param  Validator  $validator
+     * @param  Schema  $schema
+     * @param  Filter  $filter
+     * @return void
+     */
+    protected function conditionallyRestrictFilter(Validator $validator, Schema $schema, Filter $filter): void
+    {
+        $singleValueFilterFormats = $this->getFilterFormats($filter, BinaryLogicalOperator::getInstances());
+        foreach ($singleValueFilterFormats as $singleValueFilterFormat) {
+            foreach ($this->getFormattedParameters($schema, $singleValueFilterFormat) as $formattedParameter) {
+                if (collect($validator->getRules())->keys()->doesntContain($formattedParameter)) {
+                    $validator->sometimes(
+                        $formattedParameter,
+                        $filter->getRules(),
+                        fn (Fluent $fluent) => is_string(Arr::get($fluent->toArray(), $formattedParameter)) && ! Str::of(Arr::get($fluent->toArray(), $formattedParameter))->contains(Criteria::VALUE_SEPARATOR)
+                    );
+                }
+            }
+        }
+
+        $multiValueRules = [];
+        foreach ($filter->getRules() as $rule) {
+            $multiValueRules[] = new Delimited($rule);
+        }
+
+        $multiValueFilterFormats = $this->getFilterFormats($filter, UnaryLogicalOperator::getInstances());
+        foreach ($multiValueFilterFormats as $multiValueFilterFormat) {
+            foreach ($this->getFormattedParameters($schema, $multiValueFilterFormat) as $formattedParameter) {
+                if (collect($validator->getRules())->keys()->doesntContain($formattedParameter)) {
+                    $validator->sometimes(
+                        $formattedParameter,
+                        $multiValueRules,
+                        fn (Fluent $fluent) => is_string(Arr::get($fluent->toArray(), $formattedParameter)) && Str::of(Arr::get($fluent->toArray(), $formattedParameter))->contains(Criteria::VALUE_SEPARATOR)
+                    );
+                }
+            }
+        }
+    }
+}

--- a/app/Concerns/Http/Requests/Api/ValidatesIncludes.php
+++ b/app/Concerns/Http/Requests/Api/ValidatesIncludes.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Concerns\Http\Requests\Api;
+
+use App\Http\Api\Include\AllowedInclude;
+use App\Http\Api\Schema\Schema;
+
+/**
+ * Trait ValidatesIncludes.
+ */
+trait ValidatesIncludes
+{
+    use ValidatesParameters;
+
+    /**
+     * Restrict the allowed values for the schema includes.
+     *
+     * @param  string  $param
+     * @param  Schema  $schema
+     * @return array[]
+     */
+    protected function restrictAllowedIncludeValues(string $param, Schema $schema): array
+    {
+        return $this->restrictAllowedValues(
+            $param,
+            collect($schema->allowedIncludes())->map(fn (AllowedInclude $include) => $include->path())
+        );
+    }
+}

--- a/app/Concerns/Http/Requests/Api/ValidatesPaging.php
+++ b/app/Concerns/Http/Requests/Api/ValidatesPaging.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Concerns\Http\Requests\Api;
+
+use App\Http\Api\Criteria\Paging\Criteria;
+use App\Http\Api\Criteria\Paging\LimitCriteria;
+use App\Http\Api\Criteria\Paging\OffsetCriteria;
+use App\Http\Api\Parser\PagingParser;
+use Illuminate\Support\Str;
+
+/**
+ * Trait ValidatesPaging.
+ */
+trait ValidatesPaging
+{
+    use ValidatesParameters;
+
+    /**
+     * Validate offset pagination.
+     *
+     * @return array
+     */
+    protected function offset(): array
+    {
+        return array_merge(
+            $this->restrictAllowedTypes(PagingParser::param(), collect([OffsetCriteria::NUMBER_PARAM, OffsetCriteria::SIZE_PARAM])),
+            $this->min(Str::of(PagingParser::param())->append('.')->append(OffsetCriteria::NUMBER_PARAM)->__toString()),
+            $this->range(Str::of(PagingParser::param())->append('.')->append(OffsetCriteria::SIZE_PARAM)->__toString()),
+        );
+    }
+
+    /**
+     * Validate limit pagination.
+     *
+     * @return array
+     */
+    protected function limit(): array
+    {
+        return array_merge(
+            $this->restrictAllowedTypes(PagingParser::param(), collect([LimitCriteria::PARAM])),
+            $this->range(Str::of(PagingParser::param())->append('.')->append(LimitCriteria::PARAM)->__toString()),
+        );
+    }
+
+    /**
+     * Validate minimum value for optional field.
+     *
+     * @param string $param
+     * @param int $min
+     * @return array
+     */
+    protected function min(string $param, int $min = 1): array
+    {
+        $minRule = Str::of('min:')->append($min)->__toString();
+
+        return $this->optional($param, ['integer', $minRule]);
+    }
+
+    /**
+     * Validate minimum and maximum value for optional field.
+     *
+     * @param string $param
+     * @param int $min
+     * @param int $max
+     * @return array
+     */
+    protected function range(string $param, int $min = 1, int $max = Criteria::MAX_RESULTS): array
+    {
+        $minRule = Str::of('min:')->append($min)->__toString();
+        $maxRule = Str::of('max:')->append($max)->__toString();
+
+        return $this->optional($param, ['integer', $minRule, $maxRule]);
+    }
+}

--- a/app/Concerns/Http/Requests/Api/ValidatesPaging.php
+++ b/app/Concerns/Http/Requests/Api/ValidatesPaging.php
@@ -47,8 +47,8 @@ trait ValidatesPaging
     /**
      * Validate minimum value for optional field.
      *
-     * @param string $param
-     * @param int $min
+     * @param  string  $param
+     * @param  int  $min
      * @return array
      */
     protected function min(string $param, int $min = 1): array
@@ -61,9 +61,9 @@ trait ValidatesPaging
     /**
      * Validate minimum and maximum value for optional field.
      *
-     * @param string $param
-     * @param int $min
-     * @param int $max
+     * @param  string  $param
+     * @param  int  $min
+     * @param  int  $max
      * @return array
      */
     protected function range(string $param, int $min = 1, int $max = Criteria::MAX_RESULTS): array

--- a/app/Concerns/Http/Requests/Api/ValidatesParameters.php
+++ b/app/Concerns/Http/Requests/Api/ValidatesParameters.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Concerns\Http\Requests\Api;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
+use Spatie\ValidationRules\Rules\Delimited;
+
+/**
+ * Trait ValidatesParameters.
+ */
+trait ValidatesParameters
+{
+    /**
+     * Restrict the allowed types for the parameter.
+     *
+     * @param  string  $param
+     * @param  Collection  $types
+     * @return array
+     */
+    protected function restrictAllowedTypes(string $param, Collection $types): array
+    {
+        return [
+            $param => [
+                'nullable',
+                Str::of('array:')->append($types->join(','))->__toString(),
+            ],
+        ];
+    }
+
+    /**
+     * Restrict the allowed values for the parameter.
+     *
+     * @param  string  $param
+     * @param  Collection  $values
+     * @param  array  $customRules
+     * @return array
+     */
+    protected function restrictAllowedValues(string $param, Collection $values, array $customRules = []): array
+    {
+        return [
+            $param => array_merge(
+                ['bail', 'sometimes', 'required', 'string', new Delimited(Rule::in($values))],
+                $customRules,
+            ),
+        ];
+    }
+
+    /**
+     * Prohibit the parameter.
+     *
+     * @param  string  $param
+     * @return array
+     */
+    protected function prohibit(string $param): array
+    {
+        return [
+            $param => [
+                'prohibited',
+            ],
+        ];
+    }
+
+    /**
+     * Optional parameter.
+     *
+     * @param  string  $param
+     * @param  array  $customRules
+     * @return array
+     */
+    protected function optional(string $param, array $customRules = []): array
+    {
+        return [
+            $param => array_merge(
+                ['sometimes', 'required'],
+                $customRules,
+            ),
+        ];
+    }
+
+    /**
+     * Require the parameter.
+     *
+     * @param  string  $param
+     * @param  array  $customRules
+     * @return array
+     */
+    protected function require(string $param, array $customRules = []): array
+    {
+        return [
+            $param => array_merge(
+                ['required'],
+                $customRules,
+            ),
+        ];
+    }
+}

--- a/app/Concerns/Http/Requests/Api/ValidatesSorts.php
+++ b/app/Concerns/Http/Requests/Api/ValidatesSorts.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Concerns\Http\Requests\Api;
+
+use App\Enums\Http\Api\Sort\Direction;
+use App\Http\Api\Schema\Schema;
+use App\Rules\Api\DistinctIgnoringDirectionRule;
+use App\Rules\Api\RandomSoleRule;
+use Illuminate\Support\Collection;
+
+/**
+ * Trait ValidatesSorts.
+ */
+trait ValidatesSorts
+{
+    use ValidatesParameters;
+
+    /**
+     * Get allowed sorts for schema.
+     *
+     * @param  Schema  $schema
+     * @return Collection
+     */
+    protected function formatAllowedSortValues(Schema $schema): Collection
+    {
+        $allowedSorts = collect();
+
+        foreach ($schema->sorts() as $sort) {
+            foreach (Direction::getInstances() as $direction) {
+                $formattedSort = $sort->format($direction);
+                if (! $allowedSorts->contains($formattedSort)) {
+                    $allowedSorts->push($formattedSort);
+                }
+            }
+        }
+
+        return $allowedSorts;
+    }
+
+    /**
+     * Restrict allowed sorts for schema.
+     *
+     * @param  string  $param
+     * @param  Schema  $schema
+     * @return array[]
+     */
+    protected function restrictAllowedSortValues(string $param, Schema $schema): array
+    {
+        return $this->restrictAllowedValues(
+            $param,
+            $this->formatAllowedSortValues($schema),
+            [new DistinctIgnoringDirectionRule(), new RandomSoleRule()]
+        );
+    }
+}

--- a/app/Http/Api/Criteria/Sort/FieldCriteria.php
+++ b/app/Http/Api/Criteria/Sort/FieldCriteria.php
@@ -45,6 +45,6 @@ class FieldCriteria extends Criteria
      */
     public function sort(Builder $builder, Sort $sort): Builder
     {
-        return $builder->orderBy($sort->getColumn(), $this->direction->value);
+        return $builder->orderBy($builder->qualifyColumn($sort->getColumn()), $this->direction->value);
     }
 }

--- a/app/Http/Api/Filter/TrashedFilter.php
+++ b/app/Http/Api/Filter/TrashedFilter.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Api\Filter;
+
+use App\Enums\Http\Api\Filter\ComparisonOperator;
+use App\Enums\Http\Api\Filter\LogicalOperator;
+use App\Enums\Http\Api\Filter\TrashedStatus;
+use App\Http\Api\Criteria\Filter\TrashedCriteria;
+
+/**
+ * Class TrashedFilter.
+ */
+class TrashedFilter extends EnumFilter
+{
+    /**
+     * Create a new filter instance.
+     */
+    public function __construct()
+    {
+        parent::__construct(TrashedCriteria::PARAM_VALUE, TrashedStatus::class);
+    }
+
+    /**
+     * Format filter string with conditions.
+     *
+     * @param  LogicalOperator|null  $logicalOperator
+     * @param  ComparisonOperator|null  $comparisonOperator
+     * @return string
+     *
+     * @noinspection PhpMissingParentCallCommonInspection
+     */
+    public function format(
+        ?LogicalOperator $logicalOperator = null,
+        ?ComparisonOperator $comparisonOperator = null
+    ): string {
+        return $this->getKey();
+    }
+}

--- a/app/Http/Api/Schema/Schema.php
+++ b/app/Http/Api/Schema/Schema.php
@@ -6,14 +6,12 @@ namespace App\Http\Api\Schema;
 
 use App\Contracts\Http\Api\Field\FilterableField;
 use App\Contracts\Http\Api\Field\SortableField;
-use App\Enums\Http\Api\Filter\TrashedStatus;
-use App\Http\Api\Criteria\Filter\TrashedCriteria;
 use App\Http\Api\Field\Base\CreatedAtField;
 use App\Http\Api\Field\Base\DeletedAtField;
 use App\Http\Api\Field\Base\UpdatedAtField;
 use App\Http\Api\Field\Field;
-use App\Http\Api\Filter\EnumFilter;
 use App\Http\Api\Filter\Filter;
+use App\Http\Api\Filter\TrashedFilter;
 use App\Http\Api\Include\AllowedInclude;
 use App\Http\Api\Sort\RandomSort;
 use App\Http\Api\Sort\Sort;
@@ -66,7 +64,7 @@ abstract class Schema
             }
         }
 
-        $filters[] = new EnumFilter(TrashedCriteria::PARAM_VALUE, TrashedStatus::class);
+        $filters[] = new TrashedFilter();
 
         return $filters;
     }

--- a/app/Http/Requests/Api/BaseRequest.php
+++ b/app/Http/Requests/Api/BaseRequest.php
@@ -4,35 +4,31 @@ declare(strict_types=1);
 
 namespace App\Http\Requests\Api;
 
-use App\Enums\Http\Api\Filter\BinaryLogicalOperator;
-use App\Enums\Http\Api\Filter\LogicalOperator;
-use App\Enums\Http\Api\Filter\UnaryLogicalOperator;
-use App\Enums\Http\Api\Sort\Direction;
-use App\Http\Api\Criteria\Filter\Criteria;
-use App\Http\Api\Field\Field;
-use App\Http\Api\Filter\Filter;
-use App\Http\Api\Include\AllowedInclude;
+use App\Concerns\Http\Requests\Api\ValidatesConditionally;
+use App\Concerns\Http\Requests\Api\ValidatesFields;
+use App\Concerns\Http\Requests\Api\ValidatesFilters;
+use App\Concerns\Http\Requests\Api\ValidatesIncludes;
+use App\Concerns\Http\Requests\Api\ValidatesPaging;
+use App\Concerns\Http\Requests\Api\ValidatesSorts;
 use App\Http\Api\Parser\FieldParser;
-use App\Http\Api\Parser\FilterParser;
 use App\Http\Api\Parser\IncludeParser;
 use App\Http\Api\Query\Query;
 use App\Http\Api\Schema\Schema;
-use App\Rules\Api\DistinctIgnoringDirectionRule;
-use App\Rules\Api\RandomSoleRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Collection;
-use Illuminate\Support\Fluent;
-use Illuminate\Support\Str;
-use Illuminate\Validation\Rule;
-use Illuminate\Validation\Validator;
-use Spatie\ValidationRules\Rules\Delimited;
 
 /**
  * Class BaseRequest.
  */
 abstract class BaseRequest extends FormRequest
 {
+    use ValidatesConditionally;
+    use ValidatesFields;
+    use ValidatesFilters;
+    use ValidatesIncludes;
+    use ValidatesPaging;
+    use ValidatesSorts;
+
     /**
      * Determine if the user is authorized to make this request.
      *
@@ -61,90 +57,6 @@ abstract class BaseRequest extends FormRequest
     }
 
     /**
-     * Restrict the allowed types for the parameter.
-     *
-     * @param  string  $param
-     * @param  Collection  $types
-     * @return array
-     */
-    protected function restrictAllowedTypes(string $param, Collection $types): array
-    {
-        return [
-            $param => [
-                'nullable',
-                Str::of('array:')->append($types->join(','))->__toString(),
-            ],
-        ];
-    }
-
-    /**
-     * Restrict the allowed values for the parameter.
-     *
-     * @param  string  $param
-     * @param  Collection  $values
-     * @param  array  $customRules
-     * @return array
-     */
-    protected function restrictAllowedValues(string $param, Collection $values, array $customRules = []): array
-    {
-        return [
-            $param => array_merge(
-                ['sometimes', 'required', new Delimited(Rule::in($values))],
-                $customRules,
-            ),
-        ];
-    }
-
-    /**
-     * Prohibit the parameter.
-     *
-     * @param  string  $param
-     * @return array
-     */
-    protected function prohibit(string $param): array
-    {
-        return [
-            $param => [
-                'prohibited',
-            ],
-        ];
-    }
-
-    /**
-     * Optional parameter.
-     *
-     * @param  string  $param
-     * @param  array  $customRules
-     * @return array
-     */
-    protected function optional(string $param, array $customRules = []): array
-    {
-        return [
-            $param => array_merge(
-                ['sometimes', 'required'],
-                $customRules,
-            ),
-        ];
-    }
-
-    /**
-     * Require the parameter.
-     *
-     * @param  string  $param
-     * @param  array  $customRules
-     * @return array
-     */
-    protected function require(string $param, array $customRules = []): array
-    {
-        return [
-            $param => array_merge(
-                ['required'],
-                $customRules,
-            ),
-        ];
-    }
-
-    /**
      * Get the field validation rules.
      *
      * @return array
@@ -152,16 +64,12 @@ abstract class BaseRequest extends FormRequest
     protected function getFieldRules(): array
     {
         $schema = $this->schema();
-
         $types = Arr::wrap($schema->type());
-
         $rules = $this->restrictAllowedFieldValues($schema);
 
         foreach ($schema->allowedIncludes() as $allowedInclude) {
             $relationSchema = $allowedInclude->schema();
-
             $types[] = $relationSchema->type();
-
             $rules = $rules + $this->restrictAllowedFieldValues($relationSchema);
         }
 
@@ -169,33 +77,11 @@ abstract class BaseRequest extends FormRequest
     }
 
     /**
-     * Restrict the allowed values for the schema fields.
-     *
-     * @param  Schema  $schema
-     * @return array[]
-     */
-    protected function restrictAllowedFieldValues(Schema $schema): array
-    {
-        return $this->restrictAllowedValues(
-            Str::of(FieldParser::param())->append('.')->append($schema->type())->__toString(),
-            collect($schema->fields())->map(fn (Field $field) => $field->getKey())
-        );
-    }
-
-    /**
      * Get the filter validation rules.
      *
      * @return array
      */
-    protected function getFilterRules(): array
-    {
-        // TODO: placeholder so that filter is passed by form request as validated to DTO
-        return [
-            FilterParser::param() => [
-                'nullable',
-            ],
-        ];
-    }
+    abstract protected function getFilterRules(): array;
 
     /**
      * Get include validation rules.
@@ -206,64 +92,11 @@ abstract class BaseRequest extends FormRequest
     {
         $schema = $this->schema();
 
-        if (collect($schema->allowedIncludes())->isEmpty()) {
+        if (empty($schema->allowedIncludes())) {
             return $this->prohibit(IncludeParser::param());
         }
 
         return $this->restrictAllowedIncludeValues(IncludeParser::param(), $schema);
-    }
-
-    /**
-     * Restrict the allowed values for the schema includes.
-     *
-     * @param  string  $param
-     * @param  Schema  $schema
-     * @return array[]
-     */
-    protected function restrictAllowedIncludeValues(string $param, Schema $schema): array
-    {
-        return $this->restrictAllowedValues(
-            $param,
-            collect($schema->allowedIncludes())->map(fn (AllowedInclude $include) => $include->path())
-        );
-    }
-
-    /**
-     * Get allowed sorts for schema.
-     *
-     * @param  Schema  $schema
-     * @return Collection
-     */
-    protected function formatAllowedSortValues(Schema $schema): Collection
-    {
-        $allowedSorts = collect();
-
-        foreach ($schema->sorts() as $sort) {
-            foreach (Direction::getInstances() as $direction) {
-                $formattedSort = $sort->format($direction);
-                if (! $allowedSorts->contains($formattedSort)) {
-                    $allowedSorts->push($formattedSort);
-                }
-            }
-        }
-
-        return $allowedSorts;
-    }
-
-    /**
-     * Restrict allowed sorts for schema.
-     *
-     * @param  string  $param
-     * @param  Schema  $schema
-     * @return array[]
-     */
-    protected function restrictAllowedSortValues(string $param, Schema $schema): array
-    {
-        return $this->restrictAllowedValues(
-            $param,
-            $this->formatAllowedSortValues($schema),
-            [new DistinctIgnoringDirectionRule(), new RandomSoleRule()]
-        );
     }
 
     /**
@@ -300,138 +133,4 @@ abstract class BaseRequest extends FormRequest
      * @return Query
      */
     abstract public function getQuery(): Query;
-
-    /**
-     * Configure the validator instance.
-     * Note: This function is invoked by name if it exists.
-     * We define a decorator that provides better clarity for what conditional validation needs to be applied.
-     *
-     * @param  Validator  $validator
-     * @return void
-     *
-     * @noinspection PhpUnused
-     */
-    public function withValidator(Validator $validator): void
-    {
-        $this->handleConditionalValidation($validator);
-    }
-
-    /**
-     * Configure conditional validation.
-     *
-     * @param  Validator  $validator
-     * @return void
-     */
-    protected function handleConditionalValidation(Validator $validator): void
-    {
-        $this->conditionallyRestrictAllowedFilterValues($validator);
-    }
-
-    /**
-     * Filters shall be validated based on values.
-     * If the value contains a separator, we assume this is a multi-value filter that builds a where in clause.
-     * Otherwise, we assume this is a single-value filter that builds a where clause.
-     * Logical operators apply to specific clauses, so we must check formatted filter parameters against filter values.
-     *
-     * @param  Validator  $validator
-     * @return void
-     */
-    abstract protected function conditionallyRestrictAllowedFilterValues(Validator $validator): void;
-
-    /**
-     * Restrict filter based on allowed formats and provided values.
-     *
-     * @param  Validator  $validator
-     * @param  Schema  $schema
-     * @param  Filter  $filter
-     * @return void
-     */
-    protected function conditionallyRestrictFilter(Validator $validator, Schema $schema, Filter $filter): void
-    {
-        $singleValueFilterFormats = $this->getFilterFormats($filter, BinaryLogicalOperator::getInstances());
-
-        foreach ($singleValueFilterFormats as $singleValueFilterFormat) {
-            foreach ($this->getFormattedParameters($schema, $singleValueFilterFormat) as $formattedParameter) {
-                if (collect($validator->getRules())->keys()->doesntContain($formattedParameter)) {
-                    $validator->sometimes(
-                        $formattedParameter,
-                        $filter->getRules(),
-                        fn (Fluent $fluent) => is_string(Arr::get($fluent->toArray(), $formattedParameter)) && ! Str::of(Arr::get($fluent->toArray(), $formattedParameter))->contains(Criteria::VALUE_SEPARATOR)
-                    );
-                }
-            }
-        }
-
-        $multiValueFilterFormats = $this->getFilterFormats($filter, UnaryLogicalOperator::getInstances());
-
-        $multiValueRules = [];
-
-        foreach ($filter->getRules() as $rule) {
-            $multiValueRules[] = new Delimited($rule);
-        }
-
-        foreach ($multiValueFilterFormats as $multiValueFilterFormat) {
-            foreach ($this->getFormattedParameters($schema, $multiValueFilterFormat) as $formattedParameter) {
-                if (collect($validator->getRules())->keys()->doesntContain($formattedParameter)) {
-                    $validator->sometimes(
-                        $formattedParameter,
-                        $multiValueRules,
-                        fn (Fluent $fluent) => is_string(Arr::get($fluent->toArray(), $formattedParameter)) && Str::of(Arr::get($fluent->toArray(), $formattedParameter))->contains(Criteria::VALUE_SEPARATOR)
-                    );
-                }
-            }
-        }
-    }
-
-    /**
-     * Get the allowed list of filter keys with possible conditions.
-     *
-     * @param  Filter  $filter
-     * @param  LogicalOperator[]  $logicalOperators
-     * @return array
-     */
-    protected function getFilterFormats(Filter $filter, array $logicalOperators): array
-    {
-        $formattedFilters = [];
-
-        foreach ($logicalOperators as $binaryLogicalOperator) {
-            foreach ($filter->getAllowedComparisonOperators() as $allowedComparisonOperator) {
-                $formattedFilters[] = $filter->format($binaryLogicalOperator, $allowedComparisonOperator);
-            }
-
-            $formattedFilters[] = $filter->format($binaryLogicalOperator);
-        }
-
-        foreach ($filter->getAllowedComparisonOperators() as $allowedComparisonOperator) {
-            $formattedFilters[] = $filter->format(null, $allowedComparisonOperator);
-        }
-
-        $formattedFilters[] = $filter->format();
-
-        return $formattedFilters;
-    }
-
-    /**
-     * Get possible qualified parameter values for formatted filter.
-     *
-     * @param  Schema  $schema
-     * @param  string  $formattedFilter
-     * @return array
-     */
-    protected function getFormattedParameters(Schema $schema, string $formattedFilter): array
-    {
-        return [
-            Str::of(FilterParser::param())
-                ->append('.')
-                ->append($formattedFilter)
-                ->__toString(),
-
-            Str::of(FilterParser::param())
-                ->append('.')
-                ->append($schema->type())
-                ->append('.')
-                ->append($formattedFilter)
-                ->__toString(),
-        ];
-    }
 }

--- a/app/Http/Requests/Api/Wiki/Anime/YearIndexRequest.php
+++ b/app/Http/Requests/Api/Wiki/Anime/YearIndexRequest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Http\Requests\Api\Wiki\Anime;
 
+use App\Http\Api\Parser\FieldParser;
+use App\Http\Api\Parser\FilterParser;
 use App\Http\Api\Parser\IncludeParser;
 use App\Http\Api\Parser\PagingParser;
 use App\Http\Api\Parser\SearchParser;
@@ -13,13 +15,34 @@ use App\Http\Api\Query\Wiki\AnimeQuery;
 use App\Http\Api\Schema\EloquentSchema;
 use App\Http\Api\Schema\Wiki\AnimeSchema;
 use App\Http\Requests\Api\BaseRequest;
-use Illuminate\Validation\Validator;
 
 /**
  * Class YearIndexRequest.
  */
 class YearIndexRequest extends BaseRequest
 {
+    /**
+     * Get the field validation rules.
+     *
+     * @return array
+     *
+     * @noinspection PhpMissingParentCallCommonInspection
+     */
+    protected function getFieldRules(): array
+    {
+        return $this->prohibit(FieldParser::param());
+    }
+
+    /**
+     * Get the filter validation rules.
+     *
+     * @return array
+     */
+    protected function getFilterRules(): array
+    {
+        return $this->prohibit(FilterParser::param());
+    }
+
     /**
      * Get include validation rules.
      *
@@ -80,19 +103,5 @@ class YearIndexRequest extends BaseRequest
     public function getQuery(): Query
     {
         return new AnimeQuery($this->validated());
-    }
-
-    /**
-     * Filters shall be validated based on values.
-     * If the value contains a separator, this is a multi-value filter that builds a where in clause.
-     * Otherwise, this is a single-value filter that builds a where clause.
-     * Logical operators apply to specific clauses, so we must check formatted filter parameters against filter values.
-     *
-     * @param  Validator  $validator
-     * @return void
-     */
-    protected function conditionallyRestrictAllowedFilterValues(Validator $validator): void
-    {
-        //
     }
 }


### PR DESCRIPTION
* Validates allowed types for every API endpoint.
* Refactor form requests to use a collection of traits to declutter.
* Fix issue where array was passed to delimited rule. Allowed values now bails on first failure and validates the type before we evaluate with Delimited.
* Fix ambiguous field sort by qualifying column.

Note: Has Filter is not fully supported, but from the logs it looks like no one is using the count feature, so this is getting pushed for now and support will be added next week.