### PR TITLE
feat(api): support extended write endpoints [incremental: artists]

### DIFF
--- a/app/Http/Api/Field/Wiki/Artist/ArtistNameField.php
+++ b/app/Http/Api/Field/Wiki/Artist/ArtistNameField.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace App\Http\Api\Field\Wiki\Artist;
 
+use App\Contracts\Http\Api\Field\CreatableField;
+use App\Contracts\Http\Api\Field\UpdatableField;
 use App\Http\Api\Field\StringField;
 use App\Models\Wiki\Artist;
+use Illuminate\Http\Request;
 
 /**
  * Class ArtistNameField.
  */
-class ArtistNameField extends StringField
+class ArtistNameField extends StringField implements CreatableField, UpdatableField
 {
     /**
      * Create a new field instance.
@@ -18,5 +21,36 @@ class ArtistNameField extends StringField
     public function __construct()
     {
         parent::__construct(Artist::ATTRIBUTE_NAME);
+    }
+
+    /**
+     * Set the creation validation rules for the field.
+     *
+     * @param  Request  $request
+     * @return array
+     */
+    public function getCreationRules(Request $request): array
+    {
+        return [
+            'required',
+            'string',
+            'max:192',
+        ];
+    }
+
+    /**
+     * Set the update validation rules for the field.
+     *
+     * @param  Request  $request
+     * @return array
+     */
+    public function getUpdateRules(Request $request): array
+    {
+        return [
+            'sometimes',
+            'required',
+            'string',
+            'max:192',
+        ];
     }
 }

--- a/app/Http/Api/Field/Wiki/Artist/ArtistSlugField.php
+++ b/app/Http/Api/Field/Wiki/Artist/ArtistSlugField.php
@@ -4,13 +4,17 @@ declare(strict_types=1);
 
 namespace App\Http\Api\Field\Wiki\Artist;
 
+use App\Contracts\Http\Api\Field\CreatableField;
+use App\Contracts\Http\Api\Field\UpdatableField;
 use App\Http\Api\Field\StringField;
 use App\Models\Wiki\Artist;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 
 /**
  * Class ArtistSlugField.
  */
-class ArtistSlugField extends StringField
+class ArtistSlugField extends StringField implements CreatableField, UpdatableField
 {
     /**
      * Create a new field instance.
@@ -18,5 +22,38 @@ class ArtistSlugField extends StringField
     public function __construct()
     {
         parent::__construct(Artist::ATTRIBUTE_SLUG);
+    }
+
+    /**
+     * Set the creation validation rules for the field.
+     *
+     * @param  Request  $request
+     * @return array
+     */
+    public function getCreationRules(Request $request): array
+    {
+        return [
+            'required',
+            'max:192',
+            'alpha_dash',
+            Rule::unique(Artist::TABLE),
+        ];
+    }
+
+    /**
+     * Set the update validation rules for the field.
+     *
+     * @param  Request  $request
+     * @return array
+     */
+    public function getUpdateRules(Request $request): array
+    {
+        return [
+            'sometimes',
+            'required',
+            'max:192',
+            'alpha_dash',
+            Rule::unique(Artist::TABLE)->ignore($request->route('artist'), Artist::ATTRIBUTE_ID),
+        ];
     }
 }

--- a/app/Http/Controllers/Api/Wiki/ArtistController.php
+++ b/app/Http/Controllers/Api/Wiki/ArtistController.php
@@ -6,8 +6,13 @@ namespace App\Http\Controllers\Api\Wiki;
 
 use App\Enums\Http\Api\Paging\PaginationStrategy;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\Wiki\Artist\ArtistDestroyRequest;
+use App\Http\Requests\Api\Wiki\Artist\ArtistForceDeleteRequest;
 use App\Http\Requests\Api\Wiki\Artist\ArtistIndexRequest;
+use App\Http\Requests\Api\Wiki\Artist\ArtistRestoreRequest;
 use App\Http\Requests\Api\Wiki\Artist\ArtistShowRequest;
+use App\Http\Requests\Api\Wiki\Artist\ArtistStoreRequest;
+use App\Http\Requests\Api\Wiki\Artist\ArtistUpdateRequest;
 use App\Models\Wiki\Artist;
 use Illuminate\Http\JsonResponse;
 
@@ -34,6 +39,21 @@ class ArtistController extends Controller
     }
 
     /**
+     * Store a newly created resource.
+     *
+     * @param  ArtistStoreRequest  $request
+     * @return JsonResponse
+     */
+    public function store(ArtistStoreRequest $request): JsonResponse
+    {
+        $artist = Artist::query()->create($request->validated());
+
+        $resource = $request->getQuery()->resource($artist);
+
+        return $resource->toResponse($request);
+    }
+
+    /**
      * Display the specified resource.
      *
      * @param  ArtistShowRequest  $request
@@ -43,6 +63,70 @@ class ArtistController extends Controller
     public function show(ArtistShowRequest $request, Artist $artist): JsonResponse
     {
         $resource = $request->getQuery()->show($artist);
+
+        return $resource->toResponse($request);
+    }
+
+    /**
+     * Update the specified resource.
+     *
+     * @param  ArtistUpdateRequest  $request
+     * @param  Artist  $artist
+     * @return JsonResponse
+     */
+    public function update(ArtistUpdateRequest $request, Artist $artist): JsonResponse
+    {
+        $artist->update($request->validated());
+
+        $resource = $request->getQuery()->resource($artist);
+
+        return $resource->toResponse($request);
+    }
+
+    /**
+     * Remove the specified resource.
+     *
+     * @param  ArtistDestroyRequest  $request
+     * @param  Artist  $artist
+     * @return JsonResponse
+     */
+    public function destroy(ArtistDestroyRequest $request, Artist $artist): JsonResponse
+    {
+        $artist->delete();
+
+        $resource = $request->getQuery()->resource($artist);
+
+        return $resource->toResponse($request);
+    }
+
+    /**
+     * Restore the specified resource.
+     *
+     * @param  ArtistRestoreRequest  $request
+     * @param  Artist  $artist
+     * @return JsonResponse
+     */
+    public function restore(ArtistRestoreRequest $request, Artist $artist): JsonResponse
+    {
+        $artist->restore();
+
+        $resource = $request->getQuery()->resource($artist);
+
+        return $resource->toResponse($request);
+    }
+
+    /**
+     * Hard-delete the specified resource.
+     *
+     * @param  ArtistForceDeleteRequest  $request
+     * @param  Artist  $artist
+     * @return JsonResponse
+     */
+    public function forceDelete(ArtistForceDeleteRequest $request, Artist $artist): JsonResponse
+    {
+        $artist->forceDelete();
+
+        $resource = $request->getQuery()->resource(new Artist());
 
         return $resource->toResponse($request);
     }

--- a/app/Http/Requests/Api/Wiki/Artist/ArtistDestroyRequest.php
+++ b/app/Http/Requests/Api/Wiki/Artist/ArtistDestroyRequest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\Wiki\Artist;
+
+use App\Http\Api\Query\EloquentQuery;
+use App\Http\Api\Query\Wiki\ArtistQuery;
+use App\Http\Api\Schema\EloquentSchema;
+use App\Http\Api\Schema\Wiki\ArtistSchema;
+use App\Http\Requests\Api\Base\EloquentDestroyRequest;
+
+/**
+ * Class ArtistDestroyRequest.
+ */
+class ArtistDestroyRequest extends EloquentDestroyRequest
+{
+    /**
+     * Get the schema.
+     *
+     * @return EloquentSchema
+     */
+    protected function schema(): EloquentSchema
+    {
+        return new ArtistSchema();
+    }
+
+    /**
+     * Get the validation API Query.
+     *
+     * @return EloquentQuery
+     */
+    public function getQuery(): EloquentQuery
+    {
+        return new ArtistQuery();
+    }
+
+    /**
+     * The token ability to authorize.
+     *
+     * @return string
+     */
+    protected function tokenAbility(): string
+    {
+        return 'artist:delete';
+    }
+}

--- a/app/Http/Requests/Api/Wiki/Artist/ArtistForceDeleteRequest.php
+++ b/app/Http/Requests/Api/Wiki/Artist/ArtistForceDeleteRequest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\Wiki\Artist;
+
+use App\Http\Api\Query\EloquentQuery;
+use App\Http\Api\Query\Wiki\ArtistQuery;
+use App\Http\Api\Schema\EloquentSchema;
+use App\Http\Api\Schema\Wiki\ArtistSchema;
+use App\Http\Requests\Api\Base\EloquentForceDeleteRequest;
+
+/**
+ * Class ArtistForceDeleteRequest.
+ */
+class ArtistForceDeleteRequest extends EloquentForceDeleteRequest
+{
+    /**
+     * Get the schema.
+     *
+     * @return EloquentSchema
+     */
+    protected function schema(): EloquentSchema
+    {
+        return new ArtistSchema();
+    }
+
+    /**
+     * Get the validation API Query.
+     *
+     * @return EloquentQuery
+     */
+    public function getQuery(): EloquentQuery
+    {
+        return new ArtistQuery();
+    }
+
+    /**
+     * The token ability to authorize.
+     *
+     * @return string
+     */
+    protected function tokenAbility(): string
+    {
+        return 'artist:delete';
+    }
+}

--- a/app/Http/Requests/Api/Wiki/Artist/ArtistRestoreRequest.php
+++ b/app/Http/Requests/Api/Wiki/Artist/ArtistRestoreRequest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\Wiki\Artist;
+
+use App\Http\Api\Query\EloquentQuery;
+use App\Http\Api\Query\Wiki\ArtistQuery;
+use App\Http\Api\Schema\EloquentSchema;
+use App\Http\Api\Schema\Wiki\ArtistSchema;
+use App\Http\Requests\Api\Base\EloquentRestoreRequest;
+
+/**
+ * Class ArtistRestoreRequest.
+ */
+class ArtistRestoreRequest extends EloquentRestoreRequest
+{
+    /**
+     * Get the schema.
+     *
+     * @return EloquentSchema
+     */
+    protected function schema(): EloquentSchema
+    {
+        return new ArtistSchema();
+    }
+
+    /**
+     * Get the validation API Query.
+     *
+     * @return EloquentQuery
+     */
+    public function getQuery(): EloquentQuery
+    {
+        return new ArtistQuery();
+    }
+
+    /**
+     * The token ability to authorize.
+     *
+     * @return string
+     */
+    protected function tokenAbility(): string
+    {
+        return 'artist:restore';
+    }
+}

--- a/app/Http/Requests/Api/Wiki/Artist/ArtistStoreRequest.php
+++ b/app/Http/Requests/Api/Wiki/Artist/ArtistStoreRequest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\Wiki\Artist;
+
+use App\Http\Api\Query\EloquentQuery;
+use App\Http\Api\Query\Wiki\ArtistQuery;
+use App\Http\Api\Schema\EloquentSchema;
+use App\Http\Api\Schema\Wiki\ArtistSchema;
+use App\Http\Requests\Api\Base\EloquentStoreRequest;
+
+/**
+ * Class ArtistStoreRequest.
+ */
+class ArtistStoreRequest extends EloquentStoreRequest
+{
+    /**
+     * Get the schema.
+     *
+     * @return EloquentSchema
+     */
+    protected function schema(): EloquentSchema
+    {
+        return new ArtistSchema();
+    }
+
+    /**
+     * Get the validation API Query.
+     *
+     * @return EloquentQuery
+     */
+    public function getQuery(): EloquentQuery
+    {
+        return new ArtistQuery();
+    }
+
+    /**
+     * The token ability to authorize.
+     *
+     * @return string
+     */
+    protected function tokenAbility(): string
+    {
+        return 'artist:create';
+    }
+}

--- a/app/Http/Requests/Api/Wiki/Artist/ArtistUpdateRequest.php
+++ b/app/Http/Requests/Api/Wiki/Artist/ArtistUpdateRequest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\Wiki\Artist;
+
+use App\Http\Api\Query\EloquentQuery;
+use App\Http\Api\Query\Wiki\ArtistQuery;
+use App\Http\Api\Schema\EloquentSchema;
+use App\Http\Api\Schema\Wiki\ArtistSchema;
+use App\Http\Requests\Api\Base\EloquentUpdateRequest;
+
+/**
+ * Class ArtistUpdateRequest.
+ */
+class ArtistUpdateRequest extends EloquentUpdateRequest
+{
+    /**
+     * Get the schema.
+     *
+     * @return EloquentSchema
+     */
+    protected function schema(): EloquentSchema
+    {
+        return new ArtistSchema();
+    }
+
+    /**
+     * Get the validation API Query.
+     *
+     * @return EloquentQuery
+     */
+    public function getQuery(): EloquentQuery
+    {
+        return new ArtistQuery();
+    }
+
+    /**
+     * The token ability to authorize.
+     *
+     * @return string
+     */
+    protected function tokenAbility(): string
+    {
+        return 'artist:update';
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1040,16 +1040,16 @@
         },
         {
             "name": "composer/composer",
-            "version": "dev-main",
+            "version": "2.3.0-RC1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "aad2f86edfe759d3da35cb5992d81be572d0136b"
+                "reference": "3b150d0ef6454694d074cac2807237894dfd6217"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/aad2f86edfe759d3da35cb5992d81be572d0136b",
-                "reference": "aad2f86edfe759d3da35cb5992d81be572d0136b",
+                "url": "https://api.github.com/repos/composer/composer/zipball/3b150d0ef6454694d074cac2807237894dfd6217",
+                "reference": "3b150d0ef6454694d074cac2807237894dfd6217",
                 "shasum": ""
             },
             "require": {
@@ -1085,7 +1085,6 @@
                 "ext-zip": "Enabling the zip extension allows you to unzip archives",
                 "ext-zlib": "Allow gzip compression of HTTP requests"
             },
-            "default-branch": true,
             "bin": [
                 "bin/composer"
             ],
@@ -1126,7 +1125,7 @@
             "support": {
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/composer/issues",
-                "source": "https://github.com/composer/composer/tree/main"
+                "source": "https://github.com/composer/composer/tree/2.3.0-RC1"
             },
             "funding": [
                 {
@@ -1142,7 +1141,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-15T21:20:21+00:00"
+            "time": "2022-03-16T08:25:31+00:00"
         },
         {
             "name": "composer/metadata-minifier",
@@ -1286,16 +1285,16 @@
         },
         {
             "name": "composer/semver",
-            "version": "3.3.0",
+            "version": "3.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "f79c90ad4e9b41ac4dfc5d77bf398cf61fbd718b"
+                "reference": "5d8e574bb0e69188786b8ef77d43341222a41a71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/f79c90ad4e9b41ac4dfc5d77bf398cf61fbd718b",
-                "reference": "f79c90ad4e9b41ac4dfc5d77bf398cf61fbd718b",
+                "url": "https://api.github.com/repos/composer/semver/zipball/5d8e574bb0e69188786b8ef77d43341222a41a71",
+                "reference": "5d8e574bb0e69188786b8ef77d43341222a41a71",
                 "shasum": ""
             },
             "require": {
@@ -1347,7 +1346,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.3.0"
+                "source": "https://github.com/composer/semver/tree/3.3.1"
             },
             "funding": [
                 {
@@ -1363,7 +1362,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-15T08:35:57+00:00"
+            "time": "2022-03-16T11:22:07+00:00"
         },
         {
             "name": "composer/spdx-licenses",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2028,9 +2028,9 @@
             }
         },
         "node_modules/@types/json-schema": {
-            "version": "7.0.9",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-            "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+            "version": "7.0.10",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.10.tgz",
+            "integrity": "sha512-BLO9bBq59vW3fxCpD4o0N4U+DXsvwvIcl+jofw0frQo/GrBFC+/jRZj1E7kgp6dvTyNmA4y6JCV5Id/r3mNP5A==",
             "dev": true
         },
         "node_modules/@types/mime": {
@@ -2581,14 +2581,14 @@
             }
         },
         "node_modules/autoprefixer": {
-            "version": "10.4.3",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.3.tgz",
-            "integrity": "sha512-3EIK6tHl2SyJWCoPsQzL3NEqKOdjCWbPzoOInjVAQYo/y/OCEFG9KwB5162dehG5GadiGfgxu7nrWCpExCfRFQ==",
+            "version": "10.4.4",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.4.tgz",
+            "integrity": "sha512-Tm8JxsB286VweiZ5F0anmbyGiNI3v3wGv3mz9W+cxEDYB/6jbnj6GM9H9mK3wIL8ftgl+C07Lcwb8PG5PCCPzA==",
             "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
-                    "url": "https://opencollective.com/postcss"
+                    "url": "https://opencollective.com/postcss/"
                 },
                 {
                     "type": "tidelift",
@@ -6887,14 +6887,14 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.4.11",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.11.tgz",
-            "integrity": "sha512-D+jFLnT0ilGfy4CVBGbC+XE68HkVpT8+CUkDrcSpgxmo4RKco2uaZ4kIoyVGEm+m8KN/+Vwgs8MtpNbQ3/ma9w==",
+            "version": "8.4.12",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.12.tgz",
+            "integrity": "sha512-lg6eITwYe9v6Hr5CncVbK70SoioNQIq81nsaG86ev5hAidQvmOeETBqs7jm43K2F5/Ley3ytDtriImV6TpNiSg==",
             "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
-                    "url": "https://opencollective.com/postcss"
+                    "url": "https://opencollective.com/postcss/"
                 },
                 {
                     "type": "tidelift",
@@ -11059,9 +11059,9 @@
             }
         },
         "@types/json-schema": {
-            "version": "7.0.9",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-            "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+            "version": "7.0.10",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.10.tgz",
+            "integrity": "sha512-BLO9bBq59vW3fxCpD4o0N4U+DXsvwvIcl+jofw0frQo/GrBFC+/jRZj1E7kgp6dvTyNmA4y6JCV5Id/r3mNP5A==",
             "dev": true
         },
         "@types/mime": {
@@ -11551,9 +11551,9 @@
             }
         },
         "autoprefixer": {
-            "version": "10.4.3",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.3.tgz",
-            "integrity": "sha512-3EIK6tHl2SyJWCoPsQzL3NEqKOdjCWbPzoOInjVAQYo/y/OCEFG9KwB5162dehG5GadiGfgxu7nrWCpExCfRFQ==",
+            "version": "10.4.4",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.4.tgz",
+            "integrity": "sha512-Tm8JxsB286VweiZ5F0anmbyGiNI3v3wGv3mz9W+cxEDYB/6jbnj6GM9H9mK3wIL8ftgl+C07Lcwb8PG5PCCPzA==",
             "dev": true,
             "requires": {
                 "browserslist": "^4.20.2",
@@ -14846,9 +14846,9 @@
             }
         },
         "postcss": {
-            "version": "8.4.11",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.11.tgz",
-            "integrity": "sha512-D+jFLnT0ilGfy4CVBGbC+XE68HkVpT8+CUkDrcSpgxmo4RKco2uaZ4kIoyVGEm+m8KN/+Vwgs8MtpNbQ3/ma9w==",
+            "version": "8.4.12",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.12.tgz",
+            "integrity": "sha512-lg6eITwYe9v6Hr5CncVbK70SoioNQIq81nsaG86ev5hAidQvmOeETBqs7jm43K2F5/Ley3ytDtriImV6TpNiSg==",
             "dev": true,
             "requires": {
                 "nanoid": "^3.3.1",

--- a/routes/api.php
+++ b/routes/api.php
@@ -52,7 +52,6 @@ Route::apiResource('transaction', TransactionController::class)->only(['index', 
 Route::apiResource('page', PageController::class)->only(['index', 'show'])->where(['page' => '[\pL\pM\pN\/_-]+']);
 
 // Wiki Resources
-Route::apiResource('artist', ArtistController::class)->only(['index', 'show']);
 Route::apiResource('image', ImageController::class)->only(['index', 'show']);
 Route::apiResource('resource', ExternalResourceController::class)->only(['index', 'show']);
 Route::apiResource('series', SeriesController::class)->only(['index', 'show']);
@@ -74,10 +73,14 @@ Route::apiResource('animethemeentry', EntryController::class)->only(['index', 's
 Route::group([['middleware' => ['auth:sanctum' => ['except' => ['index', 'show']]]]], function () {
     Route::apiResources([
         'anime' => AnimeController::class,
+        'artist' => ArtistController::class,
     ]);
 
     Route::patch('anime/{anime}/restore', [AnimeController::class, 'restore'])->name('anime.restore');
+    Route::patch('artist/{artist}/restore', [ArtistController::class, 'restore'])->name('artist.restore');
+
     Route::delete('anime/{anime}/forceDelete', [AnimeController::class, 'forceDelete'])->name('anime.forceDelete');
+    Route::delete('artist/{artist}/forceDelete', [ArtistController::class, 'forceDelete'])->name('artist.forceDelete');
 });
 
 Route::fallback(function () {

--- a/tests/Feature/Http/Api/Wiki/Artist/ArtistDestroyTest.php
+++ b/tests/Feature/Http/Api/Wiki/Artist/ArtistDestroyTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Http\Api\Wiki\Artist;
+
+use App\Models\Auth\User;
+use App\Models\Wiki\Artist;
+use Illuminate\Foundation\Testing\WithoutEvents;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+/**
+ * Class ArtistDestroyTest.
+ */
+class ArtistDestroyTest extends TestCase
+{
+    use WithoutEvents;
+
+    /**
+     * The Artist Destroy Endpoint shall be protected by sanctum.
+     *
+     * @return void
+     */
+    public function testProtected(): void
+    {
+        $artist = Artist::factory()->createOne();
+
+        $response = $this->delete(route('api.artist.destroy', ['artist' => $artist]));
+
+        $response->assertForbidden();
+    }
+
+    /**
+     * The Artist Destroy Endpoint shall delete the artist.
+     *
+     * @return void
+     */
+    public function testDeleted(): void
+    {
+        $artist = Artist::factory()->createOne();
+
+        Sanctum::actingAs(
+            User::factory()->withCurrentTeam('editor')->createOne(),
+            ['artist:delete']
+        );
+
+        $response = $this->delete(route('api.artist.destroy', ['artist' => $artist]));
+
+        $response->assertOk();
+        static::assertSoftDeleted($artist);
+    }
+}

--- a/tests/Feature/Http/Api/Wiki/Artist/ArtistForceDeleteTest.php
+++ b/tests/Feature/Http/Api/Wiki/Artist/ArtistForceDeleteTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Http\Api\Wiki\Artist;
+
+use App\Models\Auth\User;
+use App\Models\Wiki\Artist;
+use Illuminate\Foundation\Testing\WithoutEvents;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+/**
+ * Class ArtistForceDeleteTest.
+ */
+class ArtistForceDeleteTest extends TestCase
+{
+    use WithoutEvents;
+
+    /**
+     * The Artist Force Destroy Endpoint shall be protected by sanctum.
+     *
+     * @return void
+     */
+    public function testProtected(): void
+    {
+        $artist = Artist::factory()->createOne();
+
+        $response = $this->delete(route('api.artist.forceDelete', ['artist' => $artist]));
+
+        $response->assertForbidden();
+    }
+
+    /**
+     * The Artist Force Destroy Endpoint shall force delete the artist.
+     *
+     * @return void
+     */
+    public function testDeleted(): void
+    {
+        $artist = Artist::factory()->createOne();
+
+        Sanctum::actingAs(
+            User::factory()->withCurrentTeam('admin')->createOne(),
+            ['*']
+        );
+
+        $response = $this->delete(route('api.artist.forceDelete', ['artist' => $artist]));
+
+        $response->assertOk();
+        static::assertModelMissing($artist);
+    }
+}

--- a/tests/Feature/Http/Api/Wiki/Artist/ArtistRestoreTest.php
+++ b/tests/Feature/Http/Api/Wiki/Artist/ArtistRestoreTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Http\Api\Wiki\Artist;
+
+use App\Models\Auth\User;
+use App\Models\Wiki\Artist;
+use Illuminate\Foundation\Testing\WithoutEvents;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+/**
+ * Class ArtistRestoreTest.
+ */
+class ArtistRestoreTest extends TestCase
+{
+    use WithoutEvents;
+
+    /**
+     * The Artist Restore Endpoint shall be protected by sanctum.
+     *
+     * @return void
+     */
+    public function testProtected(): void
+    {
+        $artist = Artist::factory()->createOne();
+
+        $artist->delete();
+
+        $response = $this->patch(route('api.artist.restore', ['artist' => $artist]));
+
+        $response->assertForbidden();
+    }
+
+    /**
+     * The Artist Restore Endpoint shall restore the artist.
+     *
+     * @return void
+     */
+    public function testRestored(): void
+    {
+        $artist = Artist::factory()->createOne();
+
+        $artist->delete();
+
+        Sanctum::actingAs(
+            User::factory()->withCurrentTeam('editor')->createOne(),
+            ['artist:restore']
+        );
+
+        $response = $this->patch(route('api.artist.restore', ['artist' => $artist]));
+
+        $response->assertOk();
+        static::assertNotSoftDeleted($artist);
+    }
+}

--- a/tests/Feature/Http/Api/Wiki/Artist/ArtistStoreTest.php
+++ b/tests/Feature/Http/Api/Wiki/Artist/ArtistStoreTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Http\Api\Wiki\Artist;
+
+use App\Models\Auth\User;
+use App\Models\Wiki\Artist;
+use Illuminate\Foundation\Testing\WithoutEvents;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+/**
+ * Class ArtistStoreTest.
+ */
+class ArtistStoreTest extends TestCase
+{
+    use WithoutEvents;
+
+    /**
+     * The Artist Store Endpoint shall be protected by sanctum.
+     *
+     * @return void
+     */
+    public function testProtected(): void
+    {
+        $artist = Artist::factory()->makeOne();
+
+        $response = $this->post(route('api.artist.store', $artist->toArray()));
+
+        $response->assertForbidden();
+    }
+
+    /**
+     * The Artist Store Endpoint shall require name, season, slug & year fields.
+     *
+     * @return void
+     */
+    public function testRequiredFields(): void
+    {
+        Sanctum::actingAs(
+            User::factory()->withCurrentTeam('editor')->createOne(),
+            ['artist:create']
+        );
+
+        $response = $this->post(route('api.artist.store'));
+
+        $response->assertJsonValidationErrors([
+            Artist::ATTRIBUTE_NAME,
+            Artist::ATTRIBUTE_SLUG,
+        ]);
+    }
+
+    /**
+     * The Artist Store Endpoint shall create an artist.
+     *
+     * @return void
+     */
+    public function testCreate(): void
+    {
+        $parameters = Artist::factory()->raw();
+
+        Sanctum::actingAs(
+            User::factory()->withCurrentTeam('editor')->createOne(),
+            ['artist:create']
+        );
+
+        $response = $this->post(route('api.artist.store', $parameters));
+
+        $response->assertCreated();
+        static::assertDatabaseCount(Artist::TABLE, 1);
+    }
+}

--- a/tests/Feature/Http/Api/Wiki/Artist/ArtistUpdateTest.php
+++ b/tests/Feature/Http/Api/Wiki/Artist/ArtistUpdateTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Http\Api\Wiki\Artist;
+
+use App\Models\Auth\User;
+use App\Models\Wiki\Artist;
+use Illuminate\Foundation\Testing\WithoutEvents;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+/**
+ * Class ArtistUpdateTest.
+ */
+class ArtistUpdateTest extends TestCase
+{
+    use WithoutEvents;
+
+    /**
+     * The Artist Update Endpoint shall be protected by sanctum.
+     *
+     * @return void
+     */
+    public function testProtected(): void
+    {
+        $artist = Artist::factory()->createOne();
+
+        $parameters = Artist::factory()->raw();
+
+        $response = $this->put(route('api.artist.update', ['artist' => $artist] + $parameters));
+
+        $response->assertForbidden();
+    }
+
+    /**
+     * The Artist Update Endpoint shall create an artist.
+     *
+     * @return void
+     */
+    public function testUpdate(): void
+    {
+        $artist = Artist::factory()->createOne();
+
+        $parameters = Artist::factory()->raw();
+
+        Sanctum::actingAs(
+            User::factory()->withCurrentTeam('editor')->createOne(),
+            ['artist:update']
+        );
+
+        $response = $this->put(route('api.artist.update', ['artist' => $artist] + $parameters));
+
+        $response->assertOk();
+    }
+}


### PR DESCRIPTION
Added extended CRUD API endpoints for artist resources.

Bumped dependencies.

Note: Github Actions are experiencing an outage at the time of writing. IMO this change is low risk.