### PR TITLE
fix(admin): explicitly declare searchable columns as columns

### DIFF
--- a/app/Nova/Resources/Admin/Announcement.php
+++ b/app/Nova/Resources/Admin/Announcement.php
@@ -8,8 +8,10 @@ use App\Models\Admin\Announcement as AnnouncementModel;
 use App\Nova\Resources\Resource;
 use Laravel\Nova\Fields\Code;
 use Laravel\Nova\Fields\ID;
+use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
+use Laravel\Nova\Query\Search\Column;
 
 /**
  * Class Announcement.
@@ -67,13 +69,18 @@ class Announcement extends Resource
     }
 
     /**
-     * The columns that should be searched.
+     * Get the searchable columns for the resource.
      *
-     * @var array
+     * @return array
+     *
+     * @noinspection PhpMissingParentCallCommonInspection
      */
-    public static $search = [
-        AnnouncementModel::ATTRIBUTE_ID,
-    ];
+    public static function searchableColumns(): array
+    {
+        return [
+            new Column(AnnouncementModel::ATTRIBUTE_ID),
+        ];
+    }
 
     /**
      * Indicates if the resource should be globally searchable.
@@ -114,6 +121,29 @@ class Announcement extends Resource
                 ->sortable()
                 ->rules(['required', 'max:65535'])
                 ->language('htmlmixed')
+                ->showOnPreview(),
+
+            Panel::make(__('nova.timestamps'), $this->timestamps()),
+        ];
+    }
+
+    /**
+     * Get the fields displayed by the resource on index page.
+     *
+     * @param  NovaRequest  $request
+     * @return array
+     *
+     * @noinspection PhpUnusedParameterInspection
+     */
+    public function fieldsForIndex(NovaRequest $request): array
+    {
+        return [
+            ID::make(__('nova.id'), AnnouncementModel::ATTRIBUTE_ID)
+                ->sortable()
+                ->showOnPreview(),
+
+            Text::make(__('nova.content'), AnnouncementModel::ATTRIBUTE_CONTENT)
+                ->sortable()
                 ->showOnPreview(),
 
             Panel::make(__('nova.timestamps'), $this->timestamps()),

--- a/app/Nova/Resources/Auth/Invitation.php
+++ b/app/Nova/Resources/Auth/Invitation.php
@@ -16,6 +16,7 @@ use Laravel\Nova\Fields\Select;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
+use Laravel\Nova\Query\Search\Column;
 
 /**
  * Class Invitation.
@@ -34,7 +35,7 @@ class Invitation extends Resource
      *
      * @var string
      */
-    public static $title = InvitationModel::ATTRIBUTE_EMAIL;
+    public static $title = InvitationModel::ATTRIBUTE_NAME;
 
     /**
      * The logical group associated with the resource.
@@ -73,13 +74,18 @@ class Invitation extends Resource
     }
 
     /**
-     * The columns that should be searched.
+     * Get the searchable columns for the resource.
      *
-     * @var array
+     * @return array
+     *
+     * @noinspection PhpMissingParentCallCommonInspection
      */
-    public static $search = [
-        InvitationModel::ATTRIBUTE_EMAIL,
-    ];
+    public static function searchableColumns(): array
+    {
+        return [
+            new Column(InvitationModel::ATTRIBUTE_NAME),
+        ];
+    }
 
     /**
      * Determine if this resource uses Laravel Scout.

--- a/app/Nova/Resources/Auth/User.php
+++ b/app/Nova/Resources/Auth/User.php
@@ -13,6 +13,7 @@ use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
+use Laravel\Nova\Query\Search\Column;
 
 /**
  * Class User.
@@ -85,13 +86,30 @@ class User extends Resource
     }
 
     /**
-     * The columns that should be searched.
+     * Get the searchable columns for the resource.
      *
-     * @var array
+     * @return array
+     *
+     * @noinspection PhpMissingParentCallCommonInspection
      */
-    public static $search = [
-        UserModel::ATTRIBUTE_NAME,
-    ];
+    public static function searchableColumns(): array
+    {
+        return [
+            new Column(UserModel::ATTRIBUTE_NAME),
+        ];
+    }
+
+    /**
+     * Determine if this resource uses Laravel Scout.
+     *
+     * @return bool
+     *
+     * @noinspection PhpMissingParentCallCommonInspection
+     */
+    public static function usesScout(): bool
+    {
+        return false;
+    }
 
     /**
      * Get the fields displayed by the resource.

--- a/app/Nova/Resources/Billing/Balance.php
+++ b/app/Nova/Resources/Billing/Balance.php
@@ -16,6 +16,7 @@ use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\Select;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
+use Laravel\Nova\Query\Search\Column;
 
 /**
  * Class Balance.
@@ -73,13 +74,18 @@ class Balance extends Resource
     }
 
     /**
-     * The columns that should be searched.
+     * Get the searchable columns for the resource.
      *
-     * @var array
+     * @return array
+     *
+     * @noinspection PhpMissingParentCallCommonInspection
      */
-    public static $search = [
-        BalanceModel::ATTRIBUTE_ID,
-    ];
+    public static function searchableColumns(): array
+    {
+        return [
+            new Column(BalanceModel::ATTRIBUTE_ID),
+        ];
+    }
 
     /**
      * Indicates if the resource should be globally searchable.

--- a/app/Nova/Resources/Billing/Transaction.php
+++ b/app/Nova/Resources/Billing/Transaction.php
@@ -16,6 +16,7 @@ use Laravel\Nova\Fields\Select;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
+use Laravel\Nova\Query\Search\Column;
 
 /**
  * Class Transaction.
@@ -73,13 +74,37 @@ class Transaction extends Resource
     }
 
     /**
-     * The columns that should be searched.
+     * Get the searchable columns for the resource.
      *
-     * @var array
+     * @return array
+     *
+     * @noinspection PhpMissingParentCallCommonInspection
      */
-    public static $search = [
-        TransactionModel::ATTRIBUTE_ID,
-    ];
+    public static function searchableColumns(): array
+    {
+        return [
+            new Column(TransactionModel::ATTRIBUTE_DESCRIPTION),
+        ];
+    }
+
+    /**
+     * Indicates if the resource should be globally searchable.
+     *
+     * @var bool
+     */
+    public static $globallySearchable = false;
+
+    /**
+     * Determine if this resource uses Laravel Scout.
+     *
+     * @return bool
+     *
+     * @noinspection PhpMissingParentCallCommonInspection
+     */
+    public static function usesScout(): bool
+    {
+        return false;
+    }
 
     /**
      * Get the fields displayed by the resource.

--- a/app/Nova/Resources/Document/Page.php
+++ b/app/Nova/Resources/Document/Page.php
@@ -13,6 +13,7 @@ use Laravel\Nova\Fields\Slug;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
+use Laravel\Nova\Query\Search\Column;
 
 /**
  * Class Page.
@@ -70,13 +71,18 @@ class Page extends Resource
     }
 
     /**
-     * The columns that should be searched.
+     * Get the searchable columns for the resource.
      *
-     * @var array
+     * @return array
+     *
+     * @noinspection PhpMissingParentCallCommonInspection
      */
-    public static $search = [
-        PageModel::ATTRIBUTE_NAME,
-    ];
+    public static function searchableColumns(): array
+    {
+        return [
+            new Column(PageModel::ATTRIBUTE_NAME),
+        ];
+    }
 
     /**
      * Determine if this resource uses Laravel Scout.

--- a/app/Nova/Resources/Wiki/Anime.php
+++ b/app/Nova/Resources/Wiki/Anime.php
@@ -37,6 +37,7 @@ use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Fields\Textarea;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
+use Laravel\Nova\Query\Search\Column;
 
 /**
  * Class Anime.
@@ -106,13 +107,18 @@ class Anime extends Resource
     }
 
     /**
-     * The columns that should be searched.
+     * Get the searchable columns for the resource.
      *
-     * @var array
+     * @return array
+     *
+     * @noinspection PhpMissingParentCallCommonInspection
      */
-    public static $search = [
-        AnimeModel::ATTRIBUTE_NAME,
-    ];
+    public static function searchableColumns(): array
+    {
+        return [
+            new Column(AnimeModel::ATTRIBUTE_NAME),
+        ];
+    }
 
     /**
      * Get the fields displayed by the resource.

--- a/app/Nova/Resources/Wiki/Anime/Synonym.php
+++ b/app/Nova/Resources/Wiki/Anime/Synonym.php
@@ -91,15 +91,6 @@ class Synonym extends Resource
     }
 
     /**
-     * The columns that should be searched.
-     *
-     * @var array
-     */
-    public static $search = [
-        AnimeSynonym::ATTRIBUTE_TEXT,
-    ];
-
-    /**
      * Indicates if the resource should be globally searchable.
      *
      * @var bool

--- a/app/Nova/Resources/Wiki/Anime/Synonym.php
+++ b/app/Nova/Resources/Wiki/Anime/Synonym.php
@@ -12,6 +12,7 @@ use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
+use Laravel\Nova\Query\Search\Column;
 
 /**
  * Class Synonym.
@@ -73,6 +74,20 @@ class Synonym extends Resource
     public static function uriKey(): string
     {
         return 'anime-synonyms';
+    }
+
+    /**
+     * Get the searchable columns for the resource.
+     *
+     * @return array
+     *
+     * @noinspection PhpMissingParentCallCommonInspection
+     */
+    public static function searchableColumns(): array
+    {
+        return [
+            new Column(AnimeSynonym::ATTRIBUTE_TEXT),
+        ];
     }
 
     /**

--- a/app/Nova/Resources/Wiki/Anime/Theme.php
+++ b/app/Nova/Resources/Wiki/Anime/Theme.php
@@ -20,6 +20,7 @@ use Laravel\Nova\Fields\Select;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
+use Laravel\Nova\Query\Search\Column;
 
 /**
  * Class Theme.
@@ -77,13 +78,18 @@ class Theme extends Resource
     }
 
     /**
-     * The columns that should be searched.
+     * Get the searchable columns for the resource.
      *
-     * @var array
+     * @return array
+     *
+     * @noinspection PhpMissingParentCallCommonInspection
      */
-    public static $search = [
-        AnimeTheme::ATTRIBUTE_SLUG,
-    ];
+    public static function searchableColumns(): array
+    {
+        return [
+            new Column(AnimeTheme::ATTRIBUTE_SLUG),
+        ];
+    }
 
     /**
      * Indicates if the resource should be globally searchable.

--- a/app/Nova/Resources/Wiki/Anime/Theme/Entry.php
+++ b/app/Nova/Resources/Wiki/Anime/Theme/Entry.php
@@ -19,6 +19,7 @@ use Laravel\Nova\Fields\Number;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
+use Laravel\Nova\Query\Search\Column;
 
 /**
  * Class Entry.
@@ -83,13 +84,18 @@ class Entry extends Resource
     }
 
     /**
-     * The columns that should be searched.
+     * Get the searchable columns for the resource.
      *
-     * @var array
+     * @return array
+     *
+     * @noinspection PhpMissingParentCallCommonInspection
      */
-    public static $search = [
-        AnimeThemeEntry::ATTRIBUTE_ID,
-    ];
+    public static function searchableColumns(): array
+    {
+        return [
+            new Column(AnimeThemeEntry::ATTRIBUTE_ID),
+        ];
+    }
 
     /**
      * Indicates if the resource should be globally searchable.

--- a/app/Nova/Resources/Wiki/Artist.php
+++ b/app/Nova/Resources/Wiki/Artist.php
@@ -28,6 +28,7 @@ use Laravel\Nova\Fields\Slug;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
+use Laravel\Nova\Query\Search\Column;
 
 /**
  * Class Artist.
@@ -85,13 +86,18 @@ class Artist extends Resource
     }
 
     /**
-     * The columns that should be searched.
+     * Get the searchable columns for the resource.
      *
-     * @var array
+     * @return array
+     *
+     * @noinspection PhpMissingParentCallCommonInspection
      */
-    public static $search = [
-        ArtistModel::ATTRIBUTE_NAME,
-    ];
+    public static function searchableColumns(): array
+    {
+        return [
+            new Column(ArtistModel::ATTRIBUTE_NAME),
+        ];
+    }
 
     /**
      * Get the fields displayed by the resource.
@@ -144,7 +150,8 @@ class Artist extends Resource
                             ->readonly()
                             ->hideWhenCreating(),
                     ];
-                }),
+                })
+                ->showCreateRelationButton(),
 
             BelongsToMany::make(__('nova.external_resources'), 'Resources', ExternalResource::class)
                 ->searchable()
@@ -162,7 +169,8 @@ class Artist extends Resource
                             ->readonly()
                             ->hideWhenCreating(),
                     ];
-                }),
+                })
+                ->showCreateRelationButton(),
 
             BelongsToMany::make(__('nova.members'), 'Members', Artist::class)
                 ->searchable()
@@ -180,7 +188,8 @@ class Artist extends Resource
                             ->readonly()
                             ->hideWhenCreating(),
                     ];
-                }),
+                })
+                ->showCreateRelationButton(),
 
             BelongsToMany::make(__('nova.groups'), 'Groups', Artist::class)
                 ->searchable()
@@ -196,7 +205,8 @@ class Artist extends Resource
                         DateTime::make(__('nova.updated_at'), BasePivot::ATTRIBUTE_UPDATED_AT)
                             ->readonly(),
                     ];
-                }),
+                })
+                ->showCreateRelationButton(),
 
             BelongsToMany::make(__('nova.images'), 'Images', Image::class)
                 ->searchable()
@@ -208,7 +218,8 @@ class Artist extends Resource
                         DateTime::make(__('nova.updated_at'), BasePivot::ATTRIBUTE_UPDATED_AT)
                             ->readonly(),
                     ];
-                }),
+                })
+                ->showCreateRelationButton(),
 
             Panel::make(__('nova.timestamps'), $this->timestamps()),
         ];

--- a/app/Nova/Resources/Wiki/ExternalResource.php
+++ b/app/Nova/Resources/Wiki/ExternalResource.php
@@ -25,6 +25,7 @@ use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Fields\URL;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
+use Laravel\Nova\Query\Search\Column;
 
 /**
  * Class ExternalResource.
@@ -58,13 +59,18 @@ class ExternalResource extends Resource
     }
 
     /**
-     * The columns that should be searched.
+     * Get the searchable columns for the resource.
      *
-     * @var array
+     * @return array
+     *
+     * @noinspection PhpMissingParentCallCommonInspection
      */
-    public static $search = [
-        ExternalResourceModel::ATTRIBUTE_LINK,
-    ];
+    public static function searchableColumns(): array
+    {
+        return [
+            new Column(ExternalResourceModel::ATTRIBUTE_LINK),
+        ];
+    }
 
     /**
      * Determine if this resource uses Laravel Scout.
@@ -164,7 +170,8 @@ class ExternalResource extends Resource
                             ->readonly()
                             ->hideWhenCreating(),
                     ];
-                }),
+                })
+                ->showCreateRelationButton(),
 
             BelongsToMany::make(__('nova.anime'), 'Anime', Anime::class)
                 ->searchable()
@@ -182,7 +189,8 @@ class ExternalResource extends Resource
                             ->readonly()
                             ->hideWhenCreating(),
                     ];
-                }),
+                })
+                ->showCreateRelationButton(),
 
             BelongsToMany::make(__('nova.studios'), 'Studios', Studio::class)
                 ->searchable()
@@ -200,7 +208,8 @@ class ExternalResource extends Resource
                             ->readonly()
                             ->hideWhenCreating(),
                     ];
-                }),
+                })
+                ->showCreateRelationButton(),
 
             Panel::make(__('nova.timestamps'), $this->timestamps()),
         ];

--- a/app/Nova/Resources/Wiki/Image.php
+++ b/app/Nova/Resources/Wiki/Image.php
@@ -19,6 +19,7 @@ use Laravel\Nova\Fields\Select;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
+use Laravel\Nova\Query\Search\Column;
 
 /**
  * Class Image.
@@ -52,13 +53,18 @@ class Image extends Resource
     }
 
     /**
-     * The columns that should be searched.
+     * Get the searchable columns for the resource.
      *
-     * @var array
+     * @return array
+     *
+     * @noinspection PhpMissingParentCallCommonInspection
      */
-    public static $search = [
-        ImageModel::ATTRIBUTE_ID,
-    ];
+    public static function searchableColumns(): array
+    {
+        return [
+            new Column(ImageModel::ATTRIBUTE_ID),
+        ];
+    }
 
     /**
      * Determine if this resource uses Laravel Scout.
@@ -136,7 +142,8 @@ class Image extends Resource
                             ->readonly()
                             ->hideWhenCreating(),
                     ];
-                }),
+                })
+                ->showCreateRelationButton(),
 
             BelongsToMany::make(__('nova.artists'), 'Artists', Artist::class)
                 ->searchable()
@@ -150,7 +157,8 @@ class Image extends Resource
                             ->readonly()
                             ->hideWhenCreating(),
                     ];
-                }),
+                })
+                ->showCreateRelationButton(),
 
             Panel::make(__('nova.file_properties'), $this->fileProperties()),
 

--- a/app/Nova/Resources/Wiki/Series.php
+++ b/app/Nova/Resources/Wiki/Series.php
@@ -18,6 +18,7 @@ use Laravel\Nova\Fields\Slug;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
+use Laravel\Nova\Query\Search\Column;
 
 /**
  * Class Series.
@@ -75,13 +76,18 @@ class Series extends Resource
     }
 
     /**
-     * The columns that should be searched.
+     * Get the searchable columns for the resource.
      *
-     * @var array
+     * @return array
+     *
+     * @noinspection PhpMissingParentCallCommonInspection
      */
-    public static $search = [
-        SeriesModel::ATTRIBUTE_NAME,
-    ];
+    public static function searchableColumns(): array
+    {
+        return [
+            new Column(SeriesModel::ATTRIBUTE_NAME),
+        ];
+    }
 
     /**
      * Get the fields displayed by the resource.
@@ -130,7 +136,8 @@ class Series extends Resource
                             ->readonly()
                             ->hideWhenCreating(),
                     ];
-                }),
+                })
+                ->showCreateRelationButton(),
 
             Panel::make(__('nova.timestamps'), $this->timestamps()),
         ];

--- a/app/Nova/Resources/Wiki/Song.php
+++ b/app/Nova/Resources/Wiki/Song.php
@@ -17,6 +17,7 @@ use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
+use Laravel\Nova\Query\Search\Column;
 
 /**
  * Class Song.
@@ -83,13 +84,18 @@ class Song extends Resource
     }
 
     /**
-     * The columns that should be searched.
+     * Get the searchable columns for the resource.
      *
-     * @var array
+     * @return array
+     *
+     * @noinspection PhpMissingParentCallCommonInspection
      */
-    public static $search = [
-        SongModel::ATTRIBUTE_TITLE,
-    ];
+    public static function searchableColumns(): array
+    {
+        return [
+            new Column(SongModel::ATTRIBUTE_TITLE),
+        ];
+    }
 
     /**
      * Get the fields displayed by the resource.
@@ -130,7 +136,8 @@ class Song extends Resource
                             ->readonly()
                             ->hideWhenCreating(),
                     ];
-                }),
+                })
+                ->showCreateRelationButton(),
 
             HasMany::make(__('nova.themes'), 'AnimeThemes', Theme::class),
 

--- a/app/Nova/Resources/Wiki/Studio.php
+++ b/app/Nova/Resources/Wiki/Studio.php
@@ -22,6 +22,7 @@ use Laravel\Nova\Fields\Slug;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
+use Laravel\Nova\Query\Search\Column;
 
 /**
  * Class Studio.
@@ -79,13 +80,18 @@ class Studio extends Resource
     }
 
     /**
-     * The columns that should be searched.
+     * Get the searchable columns for the resource.
      *
-     * @var array
+     * @return array
+     *
+     * @noinspection PhpMissingParentCallCommonInspection
      */
-    public static $search = [
-        StudioModel::ATTRIBUTE_NAME,
-    ];
+    public static function searchableColumns(): array
+    {
+        return [
+            new Column(StudioModel::ATTRIBUTE_NAME),
+        ];
+    }
 
     /**
      * Get the fields displayed by the resource.
@@ -134,7 +140,8 @@ class Studio extends Resource
                             ->readonly()
                             ->hideWhenCreating(),
                     ];
-                }),
+                })
+                ->showCreateRelationButton(),
 
             BelongsToMany::make(__('nova.external_resources'), 'Resources', ExternalResource::class)
                 ->searchable()
@@ -150,7 +157,8 @@ class Studio extends Resource
                             ->readonly()
                             ->hideWhenCreating(),
                     ];
-                }),
+                })
+                ->showCreateRelationButton(),
 
             Panel::make(__('nova.timestamps'), $this->timestamps()),
         ];

--- a/app/Nova/Resources/Wiki/Video.php
+++ b/app/Nova/Resources/Wiki/Video.php
@@ -26,6 +26,7 @@ use Laravel\Nova\Fields\Select;
 use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
+use Laravel\Nova\Query\Search\Column;
 
 /**
  * Class Video.
@@ -83,13 +84,18 @@ class Video extends Resource
     }
 
     /**
-     * The columns that should be searched.
+     * Get the searchable columns for the resource.
      *
-     * @var array
+     * @return array
+     *
+     * @noinspection PhpMissingParentCallCommonInspection
      */
-    public static $search = [
-        VideoModel::ATTRIBUTE_FILENAME,
-    ];
+    public static function searchableColumns(): array
+    {
+        return [
+            new Column(VideoModel::ATTRIBUTE_FILENAME),
+        ];
+    }
 
     /**
      * Get the fields displayed by the resource.


### PR DESCRIPTION
* Explicitly declare searchable columns as columns to avoid column string being invoked as callable.
* Add missing Create Relation Buttons for BelongsToMany relations.
* Some QoL fixes to admin resources.

Note: v4.0.6 should be available tomorrow. This patch will fix the select issue.