### PR TITLE
feat(admin): allow backfilling multiple anime & fixing resource reconciliation

### DIFF
--- a/app/Nova/Resources/Admin/Announcement.php
+++ b/app/Nova/Resources/Admin/Announcement.php
@@ -142,7 +142,8 @@ class Announcement extends Resource
                 ->sortable()
                 ->showOnPreview(),
 
-            Panel::make(__('nova.timestamps'), $this->timestamps()),
+            Panel::make(__('nova.timestamps'), $this->timestamps())
+                ->collapsable(),
         ];
     }
 }

--- a/app/Nova/Resources/Auth/Invitation.php
+++ b/app/Nova/Resources/Auth/Invitation.php
@@ -152,7 +152,8 @@ class Invitation extends Resource
                 ->showOnPreview()
                 ->filterable(),
 
-            Panel::make(__('nova.timestamps'), $this->timestamps()),
+            Panel::make(__('nova.timestamps'), $this->timestamps())
+                ->collapsable(),
         ];
     }
 

--- a/app/Nova/Resources/Auth/User.php
+++ b/app/Nova/Resources/Auth/User.php
@@ -158,7 +158,8 @@ class User extends Resource
                 ->showOnPreview()
                 ->filterable(),
 
-            Panel::make(__('nova.timestamps'), $this->timestamps()),
+            Panel::make(__('nova.timestamps'), $this->timestamps())
+                ->collapsable(),
         ];
     }
 }

--- a/app/Nova/Resources/Billing/Balance.php
+++ b/app/Nova/Resources/Billing/Balance.php
@@ -158,7 +158,8 @@ class Balance extends Resource
                 ->showOnPreview()
                 ->filterable(),
 
-            Panel::make(__('nova.timestamps'), $this->timestamps()),
+            Panel::make(__('nova.timestamps'), $this->timestamps())
+                ->collapsable(),
         ];
     }
 }

--- a/app/Nova/Resources/Billing/Transaction.php
+++ b/app/Nova/Resources/Billing/Transaction.php
@@ -157,7 +157,8 @@ class Transaction extends Resource
                 ->showOnPreview()
                 ->filterable(),
 
-            Panel::make(__('nova.timestamps'), $this->timestamps()),
+            Panel::make(__('nova.timestamps'), $this->timestamps())
+                ->collapsable(),
         ];
     }
 }

--- a/app/Nova/Resources/Document/Page.php
+++ b/app/Nova/Resources/Document/Page.php
@@ -146,7 +146,8 @@ class Page extends Resource
                 ->rules(['required', 'max:16777215'])
                 ->help(__('nova.page_body_help')),
 
-            Panel::make(__('nova.timestamps'), $this->timestamps()),
+            Panel::make(__('nova.timestamps'), $this->timestamps())
+                ->collapsable(),
         ];
     }
 }

--- a/app/Nova/Resources/Wiki/Anime.php
+++ b/app/Nova/Resources/Wiki/Anime.php
@@ -255,7 +255,8 @@ class Anime extends Resource
                         ->hideWhenCreating(),
                 ]),
 
-            Panel::make(__('nova.timestamps'), $this->timestamps()),
+            Panel::make(__('nova.timestamps'), $this->timestamps())
+                ->collapsable(),
         ];
     }
 
@@ -273,7 +274,9 @@ class Anime extends Resource
                 (new BackfillAnimeAction($request->user()))
                     ->confirmButtonText(__('nova.backfill'))
                     ->cancelButtonText(__('nova.cancel'))
-                    ->exceptOnIndex()
+                    ->showOnIndex()
+                    ->showOnDetail()
+                    ->showInline()
                     ->canSee(function (Request $request) {
                         $user = $request->user();
 

--- a/app/Nova/Resources/Wiki/Anime/Synonym.php
+++ b/app/Nova/Resources/Wiki/Anime/Synonym.php
@@ -142,7 +142,8 @@ class Synonym extends Resource
                 ->showOnPreview()
                 ->filterable(),
 
-            Panel::make(__('nova.timestamps'), $this->timestamps()),
+            Panel::make(__('nova.timestamps'), $this->timestamps())
+                ->collapsable(),
         ];
     }
 }

--- a/app/Nova/Resources/Wiki/Anime/Theme.php
+++ b/app/Nova/Resources/Wiki/Anime/Theme.php
@@ -220,7 +220,8 @@ class Theme extends Resource
 
             HasMany::make(__('nova.anime_theme_entries'), AnimeTheme::RELATION_ENTRIES, Entry::class),
 
-            Panel::make(__('nova.timestamps'), $this->timestamps()),
+            Panel::make(__('nova.timestamps'), $this->timestamps())
+                ->collapsable(),
         ];
     }
 }

--- a/app/Nova/Resources/Wiki/Anime/Theme/Entry.php
+++ b/app/Nova/Resources/Wiki/Anime/Theme/Entry.php
@@ -246,7 +246,8 @@ class Entry extends Resource
                         ->hideWhenCreating(),
                 ]),
 
-            Panel::make(__('nova.timestamps'), $this->timestamps()),
+            Panel::make(__('nova.timestamps'), $this->timestamps())
+                ->collapsable(),
         ];
     }
 }

--- a/app/Nova/Resources/Wiki/Artist.php
+++ b/app/Nova/Resources/Wiki/Artist.php
@@ -236,7 +236,8 @@ class Artist extends Resource
                         ->hideWhenCreating(),
                 ]),
 
-            Panel::make(__('nova.timestamps'), $this->timestamps()),
+            Panel::make(__('nova.timestamps'), $this->timestamps())
+                ->collapsable(),
         ];
     }
 

--- a/app/Nova/Resources/Wiki/ExternalResource.php
+++ b/app/Nova/Resources/Wiki/ExternalResource.php
@@ -227,7 +227,8 @@ class ExternalResource extends Resource
                     ];
                 }),
 
-            Panel::make(__('nova.timestamps'), $this->timestamps()),
+            Panel::make(__('nova.timestamps'), $this->timestamps())
+                ->collapsable(),
         ];
     }
 

--- a/app/Nova/Resources/Wiki/Image.php
+++ b/app/Nova/Resources/Wiki/Image.php
@@ -167,9 +167,11 @@ class Image extends Resource
                         ->hideWhenCreating(),
                 ]),
 
-            Panel::make(__('nova.file_properties'), $this->fileProperties()),
+            Panel::make(__('nova.file_properties'), $this->fileProperties())
+                ->collapsable(),
 
-            Panel::make(__('nova.timestamps'), $this->timestamps()),
+            Panel::make(__('nova.timestamps'), $this->timestamps())
+                ->collapsable(),
         ];
     }
 

--- a/app/Nova/Resources/Wiki/Series.php
+++ b/app/Nova/Resources/Wiki/Series.php
@@ -148,7 +148,8 @@ class Series extends Resource
                         ->hideWhenCreating(),
                 ]),
 
-            Panel::make(__('nova.timestamps'), $this->timestamps()),
+            Panel::make(__('nova.timestamps'), $this->timestamps())
+                ->collapsable(),
         ];
     }
 

--- a/app/Nova/Resources/Wiki/Song.php
+++ b/app/Nova/Resources/Wiki/Song.php
@@ -183,7 +183,8 @@ class Song extends Resource
 
             HasMany::make(__('nova.anime_themes'), SongModel::RELATION_ANIMETHEMES, Theme::class),
 
-            Panel::make(__('nova.timestamps'), $this->timestamps()),
+            Panel::make(__('nova.timestamps'), $this->timestamps())
+                ->collapsable(),
         ];
     }
 

--- a/app/Nova/Resources/Wiki/Studio.php
+++ b/app/Nova/Resources/Wiki/Studio.php
@@ -171,7 +171,8 @@ class Studio extends Resource
                         ->hideWhenUpdating(),
                 ]),
 
-            Panel::make(__('nova.timestamps'), $this->timestamps()),
+            Panel::make(__('nova.timestamps'), $this->timestamps())
+                ->collapsable(),
         ];
     }
 

--- a/app/Nova/Resources/Wiki/Video.php
+++ b/app/Nova/Resources/Wiki/Video.php
@@ -185,9 +185,11 @@ class Video extends Resource
                         ->hideWhenCreating(),
                 ]),
 
-            Panel::make(__('nova.file_properties'), $this->fileProperties()),
+            Panel::make(__('nova.file_properties'), $this->fileProperties())
+                ->collapsable(),
 
-            Panel::make(__('nova.timestamps'), $this->timestamps()),
+            Panel::make(__('nova.timestamps'), $this->timestamps())
+                ->collapsable(),
         ];
     }
 

--- a/app/Pipes/Wiki/Anime/BackfillAnimeImage.php
+++ b/app/Pipes/Wiki/Anime/BackfillAnimeImage.php
@@ -31,6 +31,12 @@ abstract class BackfillAnimeImage extends BackfillAnimePipe
      */
     public function handle(User $user, Closure $next): mixed
     {
+        if ($this->anime->images()->where(Image::ATTRIBUTE_FACET, $this->getFacet()->value)->exists()) {
+            Log::info("Anime '{$this->anime->getName()}' already has Image of Facet '{$this->getFacet()->value}'.");
+
+            return $next($user);
+        }
+
         $image = $this->getImage();
 
         if ($image !== null) {

--- a/app/Pipes/Wiki/Anime/BackfillAnimeResource.php
+++ b/app/Pipes/Wiki/Anime/BackfillAnimeResource.php
@@ -28,6 +28,12 @@ abstract class BackfillAnimeResource extends BackfillAnimePipe
      */
     public function handle(User $user, Closure $next): mixed
     {
+        if ($this->anime->resources()->where(ExternalResource::ATTRIBUTE_SITE, $this->getSite()->value)->exists()) {
+            Log::info("Anime '{$this->anime->getName()}' already has Resource of Site '{$this->getSite()->value}'.");
+
+            return $next($user);
+        }
+
         $resource = $this->getResource();
 
         if ($resource !== null) {
@@ -55,7 +61,7 @@ abstract class BackfillAnimeResource extends BackfillAnimePipe
     {
         $resource = ExternalResource::query()
             ->select([ExternalResource::ATTRIBUTE_ID, ExternalResource::ATTRIBUTE_LINK])
-            ->where(ExternalResource::ATTRIBUTE_SITE, ResourceSite::ANILIST)
+            ->where(ExternalResource::ATTRIBUTE_SITE, $this->getSite()->value)
             ->where(ExternalResource::ATTRIBUTE_EXTERNAL_ID, $id)
             ->first();
 


### PR DESCRIPTION
* Support backfilling multiple anime from index screen
* Fix Resource reconciliation to prevent duplicates from being created
* Allow all panels to be collapsible (introduced in v4.2.6)