### PR TITLE
feat(console): allow video reconciliation against a specific path

### DIFF
--- a/app/Concerns/Reconcile/ReconcilesRepositories.php
+++ b/app/Concerns/Reconcile/ReconcilesRepositories.php
@@ -185,15 +185,15 @@ trait ReconcilesRepositories
     public function reconcileRepositories(Repository $source, Repository $destination): void
     {
         try {
-            $sourceModels = $source->all();
+            $sourceModels = $source->get();
 
-            $destinationModels = $destination->all($this->columnsForCreateDelete());
+            $destinationModels = $destination->get($this->columnsForCreateDelete());
 
             $this->createModelsFromSource($destination, $sourceModels, $destinationModels);
 
             $this->deleteModelsFromDestination($destination, $sourceModels, $destinationModels);
 
-            $destinationModels = $destination->all($this->columnsForUpdate());
+            $destinationModels = $destination->get($this->columnsForUpdate());
 
             $this->updateDestinationModels($destination, $sourceModels, $destinationModels);
         } catch (Exception $exception) {

--- a/app/Console/Commands/Wiki/VideoReconcileCommand.php
+++ b/app/Console/Commands/Wiki/VideoReconcileCommand.php
@@ -25,7 +25,8 @@ class VideoReconcileCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'reconcile:video';
+    protected $signature = 'reconcile:video
+                                {--path= : The directory of videos to reconcile. Ex: 2022/Spring/. If unspecified, all directories will be listed.}';
 
     /**
      * The console command description.
@@ -44,6 +45,18 @@ class VideoReconcileCommand extends Command
         $sourceRepository = App::make(VideoSourceRepository::class);
 
         $destinationRepository = App::make(VideoDestinationRepository::class);
+
+        $path = $this->option('path');
+        if ($path !== null) {
+            if (! $sourceRepository->validateFilter('path', $path) || ! $destinationRepository->validateFilter('path', $path)) {
+                $this->error("Invalid path '$path'");
+
+                return 1;
+            }
+
+            $sourceRepository->handleFilter('path', $path);
+            $destinationRepository->handleFilter('path', $path);
+        }
 
         $this->reconcileRepositories($sourceRepository, $destinationRepository);
 

--- a/app/Contracts/Repositories/Repository.php
+++ b/app/Contracts/Repositories/Repository.php
@@ -13,12 +13,12 @@ use Illuminate\Support\Collection;
 interface Repository
 {
     /**
-     * Get all models from the repository.
+     * Get models from the repository.
      *
      * @param  array  $columns
      * @return Collection
      */
-    public function all(array $columns = ['*']): Collection;
+    public function get(array $columns = ['*']): Collection;
 
     /**
      * Save model to the repository.
@@ -44,4 +44,22 @@ interface Repository
      * @return bool
      */
     public function update(Model $model, array $attributes): bool;
+
+    /**
+     * Validate repository filter.
+     *
+     * @param  string  $filter
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function validateFilter(string $filter, mixed $value = null): bool;
+
+    /**
+     * Filter repository models.
+     *
+     * @param  string  $filter
+     * @param  mixed  $value
+     * @return void
+     */
+    public function handleFilter(string $filter, mixed $value = null): void;
 }

--- a/app/Nova/Resources/Resource.php
+++ b/app/Nova/Resources/Resource.php
@@ -18,14 +18,14 @@ abstract class Resource extends NovaResource
      *
      * @var int|null
      */
-    public static $relatableSearchResults = 5;
+    public static $relatableSearchResults = 10;
 
     /**
      * The number of results to display when searching the resource using Scout.
      *
      * @var int
      */
-    public static $scoutSearchResults = 5;
+    public static $scoutSearchResults = 10;
 
     /**
      * Indicates whether the resource should automatically poll for new resources.

--- a/app/Pipes/Wiki/Anime/Studio/BackfillAnimeStudios.php
+++ b/app/Pipes/Wiki/Anime/Studio/BackfillAnimeStudios.php
@@ -38,6 +38,12 @@ class BackfillAnimeStudios extends BackfillAnimePipe
      */
     public function handle(User $user, Closure $next): mixed
     {
+        if ($this->anime->studios()->exists()) {
+            Log::info("Anime '{$this->anime->getName()}' already has Studios.");
+
+            return $next($user);
+        }
+
         $studios = $this->getStudios();
 
         if ($studios->isNotEmpty()) {

--- a/app/Repositories/Eloquent/Billing/DigitalOceanBalanceRepository.php
+++ b/app/Repositories/Eloquent/Billing/DigitalOceanBalanceRepository.php
@@ -8,7 +8,7 @@ use App\Enums\Http\Api\Filter\ComparisonOperator;
 use App\Enums\Models\Billing\Service;
 use App\Models\Billing\Balance;
 use App\Repositories\Eloquent\EloquentRepository;
-use Illuminate\Support\Collection;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Date;
 
 /**
@@ -17,20 +17,42 @@ use Illuminate\Support\Facades\Date;
 class DigitalOceanBalanceRepository extends EloquentRepository
 {
     /**
-     * Get all models from the repository.
+     * Get the underlying query builder.
      *
-     * @param  array  $columns
-     * @return Collection
+     * @return Builder
      */
-    public function all(array $columns = ['*']): Collection
+    protected function builder(): Builder
     {
         $now = Date::now();
 
         return Balance::query()
-            ->select($columns)
             ->where(Balance::ATTRIBUTE_SERVICE, Service::DIGITALOCEAN)
             ->whereMonth(Balance::ATTRIBUTE_DATE, ComparisonOperator::EQ, $now)
-            ->whereYear(Balance::ATTRIBUTE_DATE, ComparisonOperator::EQ, $now)
-            ->get();
+            ->whereYear(Balance::ATTRIBUTE_DATE, ComparisonOperator::EQ, $now);
+    }
+
+    /**
+     * Validate repository filter.
+     *
+     * @param  string  $filter
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function validateFilter(string $filter, mixed $value = null): bool
+    {
+        // not supported
+        return false;
+    }
+
+    /**
+     * Filter repository models.
+     *
+     * @param  string  $filter
+     * @param  mixed  $value
+     * @return void
+     */
+    public function handleFilter(string $filter, mixed $value = null): void
+    {
+        // not supported
     }
 }

--- a/app/Repositories/Eloquent/Billing/DigitalOceanTransactionRepository.php
+++ b/app/Repositories/Eloquent/Billing/DigitalOceanTransactionRepository.php
@@ -7,7 +7,7 @@ namespace App\Repositories\Eloquent\Billing;
 use App\Enums\Models\Billing\Service;
 use App\Models\Billing\Transaction;
 use App\Repositories\Eloquent\EloquentRepository;
-use Illuminate\Support\Collection;
+use Illuminate\Database\Eloquent\Builder;
 
 /**
  * Class DigitalOceanTransactionRepository.
@@ -15,16 +15,37 @@ use Illuminate\Support\Collection;
 class DigitalOceanTransactionRepository extends EloquentRepository
 {
     /**
-     * Get all models from the repository.
+     * Get the underlying query builder.
      *
-     * @param  array  $columns
-     * @return Collection
+     * @return Builder
      */
-    public function all(array $columns = ['*']): Collection
+    protected function builder(): Builder
     {
-        return Transaction::query()
-            ->select($columns)
-            ->where(Transaction::ATTRIBUTE_SERVICE, Service::DIGITALOCEAN)
-            ->get();
+        return Transaction::query()->where(Transaction::ATTRIBUTE_SERVICE, Service::DIGITALOCEAN);
+    }
+
+    /**
+     * Validate repository filter.
+     *
+     * @param  string  $filter
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function validateFilter(string $filter, mixed $value = null): bool
+    {
+        // not supported
+        return false;
+    }
+
+    /**
+     * Filter repository models.
+     *
+     * @param  string  $filter
+     * @param  mixed  $value
+     * @return void
+     */
+    public function handleFilter(string $filter, mixed $value = null): void
+    {
+        // not supported
     }
 }

--- a/app/Repositories/Eloquent/EloquentRepository.php
+++ b/app/Repositories/Eloquent/EloquentRepository.php
@@ -5,13 +5,41 @@ declare(strict_types=1);
 namespace App\Repositories\Eloquent;
 
 use App\Contracts\Repositories\Repository;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
 
 /**
  * Class EloquentRepository.
  */
 abstract class EloquentRepository implements Repository
 {
+    /**
+     * The underlying query builder.
+     *
+     * @var Builder
+     */
+    protected Builder $query;
+
+    /**
+     * Create new repository instance.
+     */
+    public function __construct()
+    {
+        $this->query = $this->builder();
+    }
+
+    /**
+     * Get models from the repository.
+     *
+     * @param  array  $columns
+     * @return Collection
+     */
+    public function get(array $columns = ['*']): Collection
+    {
+        return $this->query->get($columns);
+    }
+
     /**
      * Save model to the repository.
      *
@@ -45,4 +73,11 @@ abstract class EloquentRepository implements Repository
     {
         return $model->update($attributes);
     }
+
+    /**
+     * Get the underlying query builder.
+     *
+     * @return Builder
+     */
+    abstract protected function builder(): Builder;
 }

--- a/app/Repositories/Eloquent/Wiki/VideoRepository.php
+++ b/app/Repositories/Eloquent/Wiki/VideoRepository.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace App\Repositories\Eloquent\Wiki;
 
+use App\Enums\Http\Api\Filter\ComparisonOperator;
 use App\Models\Wiki\Video;
 use App\Repositories\Eloquent\EloquentRepository;
-use Illuminate\Support\Collection;
+use Illuminate\Database\Eloquent\Builder;
 
 /**
  * Class VideoRepository.
@@ -14,13 +15,43 @@ use Illuminate\Support\Collection;
 class VideoRepository extends EloquentRepository
 {
     /**
-     * Get all models from the repository.
+     * Get the underlying query builder.
      *
-     * @param  array  $columns
-     * @return Collection
+     * @return Builder
      */
-    public function all(array $columns = ['*']): Collection
+    protected function builder(): Builder
     {
-        return Video::all($columns);
+        return Video::query();
+    }
+
+    /**
+     * Validate repository filter.
+     *
+     * @param  string  $filter
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function validateFilter(string $filter, mixed $value = null): bool
+    {
+        if ($filter === 'path') {
+            // Defer to source repository for validation
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Filter repository models.
+     *
+     * @param  string  $filter
+     * @param  mixed  $value
+     * @return void
+     */
+    public function handleFilter(string $filter, mixed $value = null): void
+    {
+        if ($filter === 'path') {
+            $this->query->where(Video::ATTRIBUTE_PATH, ComparisonOperator::LIKE, "$value%");
+        }
     }
 }

--- a/app/Repositories/Service/DigitalOcean/Billing/DigitalOceanBalanceRepository.php
+++ b/app/Repositories/Service/DigitalOcean/Billing/DigitalOceanBalanceRepository.php
@@ -24,14 +24,14 @@ use RuntimeException;
 class DigitalOceanBalanceRepository implements Repository
 {
     /**
-     * Get all models from the repository.
+     * Get models from the repository.
      *
      * @param  array  $columns
      * @return Collection
      *
      * @throws RequestException
      */
-    public function all(array $columns = ['*']): Collection
+    public function get(array $columns = ['*']): Collection
     {
         // Do not proceed if we do not have authorization to the DO API
         $doBearerToken = Config::get('services.do.token');
@@ -91,5 +91,30 @@ class DigitalOceanBalanceRepository implements Repository
     {
         // Billing API is not writable
         return false;
+    }
+
+    /**
+     * Validate repository filter.
+     *
+     * @param  string  $filter
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function validateFilter(string $filter, mixed $value = null): bool
+    {
+        // not supported
+        return false;
+    }
+
+    /**
+     * Filter repository models.
+     *
+     * @param  string  $filter
+     * @param  mixed  $value
+     * @return void
+     */
+    public function handleFilter(string $filter, mixed $value = null): void
+    {
+        // not supported
     }
 }

--- a/app/Repositories/Service/DigitalOcean/Billing/DigitalOceanTransactionRepository.php
+++ b/app/Repositories/Service/DigitalOcean/Billing/DigitalOceanTransactionRepository.php
@@ -24,14 +24,14 @@ use RuntimeException;
 class DigitalOceanTransactionRepository implements Repository
 {
     /**
-     * Get all models from the repository.
+     * Get models from the repository.
      *
      * @param  array  $columns
      * @return Collection
      *
      * @throws RequestException
      */
-    public function all(array $columns = ['*']): Collection
+    public function get(array $columns = ['*']): Collection
     {
         // Do not proceed if we do not have authorization to the DO API
         $doBearerToken = Config::get('services.do.token');
@@ -107,5 +107,30 @@ class DigitalOceanTransactionRepository implements Repository
     {
         // Billing API is not writable
         return false;
+    }
+
+    /**
+     * Validate repository filter.
+     *
+     * @param  string  $filter
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function validateFilter(string $filter, mixed $value = null): bool
+    {
+        // not supported
+        return false;
+    }
+
+    /**
+     * Filter repository models.
+     *
+     * @param  string  $filter
+     * @param  mixed  $value
+     * @return void
+     */
+    public function handleFilter(string $filter, mixed $value = null): void
+    {
+        // not supported
     }
 }

--- a/tests/Feature/Console/Commands/Billing/BalanceReconcileTest.php
+++ b/tests/Feature/Console/Commands/Billing/BalanceReconcileTest.php
@@ -58,7 +58,7 @@ class BalanceReconcileTest extends TestCase
     public function testNoResults(): void
     {
         $this->mock(DigitalOceanBalanceRepository::class, function (MockInterface $mock) {
-            $mock->shouldReceive('all')->once()->andReturn(Collection::make());
+            $mock->shouldReceive('get')->once()->andReturn(Collection::make());
         });
 
         $this->artisan(BalanceReconcileCommand::class, ['service' => Service::DIGITALOCEAN()->key])->expectsOutput('No Balances created or deleted or updated');
@@ -83,7 +83,7 @@ class BalanceReconcileTest extends TestCase
             ]);
 
         $this->mock(DigitalOceanBalanceRepository::class, function (MockInterface $mock) use ($balances) {
-            $mock->shouldReceive('all')->once()->andReturn($balances);
+            $mock->shouldReceive('get')->once()->andReturn($balances);
         });
 
         $this->artisan(BalanceReconcileCommand::class, ['service' => Service::DIGITALOCEAN()->key])->expectsOutput("$createdBalanceCount Balances created, 0 Balances deleted, 0 Balances updated");
@@ -106,7 +106,7 @@ class BalanceReconcileTest extends TestCase
             ]);
 
         $this->mock(DigitalOceanBalanceRepository::class, function (MockInterface $mock) {
-            $mock->shouldReceive('all')->once()->andReturn(Collection::make());
+            $mock->shouldReceive('get')->once()->andReturn(Collection::make());
         });
 
         $this->artisan(BalanceReconcileCommand::class, ['service' => Service::DIGITALOCEAN()->key])->expectsOutput("0 Balances created, $deletedBalanceCount Balances deleted, 0 Balances updated");
@@ -132,7 +132,7 @@ class BalanceReconcileTest extends TestCase
             ]);
 
         $this->mock(DigitalOceanBalanceRepository::class, function (MockInterface $mock) use ($sourceBalances) {
-            $mock->shouldReceive('all')->once()->andReturn(collect([$sourceBalances]));
+            $mock->shouldReceive('get')->once()->andReturn(collect([$sourceBalances]));
         });
 
         $this->artisan(BalanceReconcileCommand::class, ['service' => Service::DIGITALOCEAN()->key])->expectsOutput('0 Balances created, 0 Balances deleted, 1 Balances updated');

--- a/tests/Feature/Console/Commands/Billing/TransactionReconcileTest.php
+++ b/tests/Feature/Console/Commands/Billing/TransactionReconcileTest.php
@@ -56,7 +56,7 @@ class TransactionReconcileTest extends TestCase
     public function testNoResults(): void
     {
         $this->mock(DigitalOceanTransactionRepository::class, function (MockInterface $mock) {
-            $mock->shouldReceive('all')->once()->andReturn(Collection::make());
+            $mock->shouldReceive('get')->once()->andReturn(Collection::make());
         });
 
         $this->artisan(TransactionReconcileCommand::class, ['service' => Service::DIGITALOCEAN()->key])->expectsOutput('No Transactions created or deleted or updated');
@@ -80,7 +80,7 @@ class TransactionReconcileTest extends TestCase
             ]);
 
         $this->mock(DigitalOceanTransactionRepository::class, function (MockInterface $mock) use ($transactions) {
-            $mock->shouldReceive('all')->once()->andReturn($transactions);
+            $mock->shouldReceive('get')->once()->andReturn($transactions);
         });
 
         $this->artisan(TransactionReconcileCommand::class, ['service' => Service::DIGITALOCEAN()->key])->expectsOutput("$createdTransactionCount Transactions created, 0 Transactions deleted, 0 Transactions updated");
@@ -102,7 +102,7 @@ class TransactionReconcileTest extends TestCase
             ]);
 
         $this->mock(DigitalOceanTransactionRepository::class, function (MockInterface $mock) {
-            $mock->shouldReceive('all')->once()->andReturn(Collection::make());
+            $mock->shouldReceive('get')->once()->andReturn(Collection::make());
         });
 
         $this->artisan(TransactionReconcileCommand::class, ['service' => Service::DIGITALOCEAN()->key])->expectsOutput("0 Transactions created, $deletedTransactionCount Transactions deleted, 0 Transactions updated");

--- a/tests/Feature/Console/Commands/Wiki/VideoReconcileTest.php
+++ b/tests/Feature/Console/Commands/Wiki/VideoReconcileTest.php
@@ -29,7 +29,7 @@ class VideoReconcileTest extends TestCase
     public function testNoResults(): void
     {
         $this->mock(VideoRepository::class, function (MockInterface $mock) {
-            $mock->shouldReceive('all')->once()->andReturn(Collection::make());
+            $mock->shouldReceive('get')->once()->andReturn(Collection::make());
         });
 
         $this->artisan(VideoReconcileCommand::class)->expectsOutput('No Videos created or deleted or updated');
@@ -49,7 +49,7 @@ class VideoReconcileTest extends TestCase
         $videos = Video::factory()->count($createdVideoCount)->make();
 
         $this->mock(VideoRepository::class, function (MockInterface $mock) use ($videos) {
-            $mock->shouldReceive('all')->once()->andReturn($videos);
+            $mock->shouldReceive('get')->once()->andReturn($videos);
         });
 
         $this->artisan(VideoReconcileCommand::class)->expectsOutput("$createdVideoCount Videos created, 0 Videos deleted, 0 Videos updated");
@@ -67,7 +67,7 @@ class VideoReconcileTest extends TestCase
         Video::factory()->count($deletedVideoCount)->create();
 
         $this->mock(VideoRepository::class, function (MockInterface $mock) {
-            $mock->shouldReceive('all')->once()->andReturn(Collection::make());
+            $mock->shouldReceive('get')->once()->andReturn(Collection::make());
         });
 
         $this->artisan(VideoReconcileCommand::class)->expectsOutput("0 Videos created, $deletedVideoCount Videos deleted, 0 Videos updated");
@@ -95,7 +95,7 @@ class VideoReconcileTest extends TestCase
             ->create();
 
         $this->mock(VideoRepository::class, function (MockInterface $mock) use ($sourceVideos) {
-            $mock->shouldReceive('all')->once()->andReturn($sourceVideos);
+            $mock->shouldReceive('get')->once()->andReturn($sourceVideos);
         });
 
         $this->artisan(VideoReconcileCommand::class)->expectsOutput("0 Videos created, 0 Videos deleted, $updatedVideoCount Videos updated");


### PR DESCRIPTION
* Video reconciliation now accepts a path option to reconcile s3 and the database against a single path. This way we don't have to hydrate 30k+ models to pick up one or two changes.
* Don't backfill anime studios if studio relation is already set.
* Bump search result count from 5 to 10 in nova.