### PR TITLE
fix(api): validate null values for filter and sort parameters

### DIFF
--- a/app/Concerns/Http/Requests/Api/ValidatesFilters.php
+++ b/app/Concerns/Http/Requests/Api/ValidatesFilters.php
@@ -113,7 +113,7 @@ trait ValidatesFilters
                     $validator->sometimes(
                         $formattedParameter,
                         $filter->getRules(),
-                        fn (Fluent $fluent) => is_string(Arr::get($fluent->toArray(), $formattedParameter)) && ! Str::of(Arr::get($fluent->toArray(), $formattedParameter))->contains(Criteria::VALUE_SEPARATOR)
+                        fn (Fluent $fluent) => Arr::has($fluent->toArray(), $formattedParameter) && ! Str::of(Arr::get($fluent->toArray(), $formattedParameter))->contains(Criteria::VALUE_SEPARATOR)
                     );
                 }
             }
@@ -131,7 +131,7 @@ trait ValidatesFilters
                     $validator->sometimes(
                         $formattedParameter,
                         $multiValueRules,
-                        fn (Fluent $fluent) => is_string(Arr::get($fluent->toArray(), $formattedParameter)) && Str::of(Arr::get($fluent->toArray(), $formattedParameter))->contains(Criteria::VALUE_SEPARATOR)
+                        fn (Fluent $fluent) => Arr::has($fluent->toArray(), $formattedParameter) && Str::of(Arr::get($fluent->toArray(), $formattedParameter))->contains(Criteria::VALUE_SEPARATOR)
                     );
                 }
             }

--- a/app/Http/Requests/Api/IndexRequest.php
+++ b/app/Http/Requests/Api/IndexRequest.php
@@ -164,7 +164,7 @@ abstract class IndexRequest extends ReadRequest
         $validator->sometimes(
             SortParser::param(),
             ['sometimes', 'required', new Delimited(Rule::in($this->formatAllowedSortValues($schema)))],
-            fn (Fluent $fluent) => Arr::has($fluent->toArray(), SortParser::param()) && ! Arr::accessible($fluent->get(SortParser::param()))
+            fn (Fluent $fluent) => Arr::has($fluent->toArray(), SortParser::param()) && ! is_array($fluent->get(SortParser::param()))
         );
 
         $validator->sometimes(

--- a/app/Http/Requests/Api/IndexRequest.php
+++ b/app/Http/Requests/Api/IndexRequest.php
@@ -164,12 +164,12 @@ abstract class IndexRequest extends ReadRequest
         $validator->sometimes(
             SortParser::param(),
             ['sometimes', 'required', new Delimited(Rule::in($this->formatAllowedSortValues($schema)))],
-            fn (Fluent $fluent) => is_string($fluent->get(SortParser::param()))
+            fn (Fluent $fluent) => Arr::has($fluent->toArray(), SortParser::param()) && ! Arr::accessible($fluent->get(SortParser::param()))
         );
 
         $validator->sometimes(
             SortParser::param(),
-            ['nullable', Str::of('array:')->append(implode(',', $types))->__toString()],
+            ['sometimes', 'required', Str::of('array:')->append(implode(',', $types))->__toString()],
             fn (Fluent $fluent) => is_array($fluent->get(SortParser::param()))
         );
     }


### PR DESCRIPTION
Follow-up to yesterday's production log exception, closing another gap in API validation by validating null values for top-level parameters.