### PR TITLE
fix(api): validate untrimmed and empty values with custom delimited validation rule

### DIFF
--- a/app/Concerns/Http/Requests/Api/ValidatesFilters.php
+++ b/app/Concerns/Http/Requests/Api/ValidatesFilters.php
@@ -11,11 +11,11 @@ use App\Enums\Http\Api\Filter\UnaryLogicalOperator;
 use App\Http\Api\Criteria\Filter\Criteria;
 use App\Http\Api\Filter\Filter;
 use App\Http\Api\Parser\FilterParser;
+use App\Rules\Api\DelimitedRule;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Validator;
-use Spatie\ValidationRules\Rules\Delimited;
 
 /**
  * Trait ValidatesFilters.
@@ -121,7 +121,7 @@ trait ValidatesFilters
 
         $multiValueRules = [];
         foreach ($filter->getRules() as $rule) {
-            $multiValueRules[] = new Delimited($rule);
+            $multiValueRules[] = new DelimitedRule($rule);
         }
 
         $multiValueFilterFormats = $this->getFilterFormats($filter, UnaryLogicalOperator::getInstances());

--- a/app/Concerns/Http/Requests/Api/ValidatesParameters.php
+++ b/app/Concerns/Http/Requests/Api/ValidatesParameters.php
@@ -54,7 +54,7 @@ trait ValidatesParameters
                     'sometimes',
                     'required',
                     'string',
-                    new DelimitedRule(['required', Rule::in($values)->__toString()])
+                    new DelimitedRule(['required', Rule::in($values)->__toString()]),
                 ],
                 $customRules,
             ),

--- a/app/Concerns/Http/Requests/Api/ValidatesParameters.php
+++ b/app/Concerns/Http/Requests/Api/ValidatesParameters.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\Concerns\Http\Requests\Api;
 
+use App\Rules\Api\DelimitedRule;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Validation\Rule;
-use Spatie\ValidationRules\Rules\Delimited;
 
 /**
  * Trait ValidatesParameters.
@@ -49,7 +49,13 @@ trait ValidatesParameters
     {
         return [
             $param => array_merge(
-                ['bail', 'sometimes', 'required', 'string', new Delimited(Rule::in($values))],
+                [
+                    'bail',
+                    'sometimes',
+                    'required',
+                    'string',
+                    new DelimitedRule(['required', Rule::in($values)->__toString()])
+                ],
                 $customRules,
             ),
         ];

--- a/app/Http/Api/Filter/BooleanFilter.php
+++ b/app/Http/Api/Filter/BooleanFilter.php
@@ -63,6 +63,7 @@ class BooleanFilter extends Filter
     public function getRules(): array
     {
         return [
+            'required',
             new IsValidBoolean(),
         ];
     }

--- a/app/Http/Api/Filter/DateFilter.php
+++ b/app/Http/Api/Filter/DateFilter.php
@@ -83,6 +83,7 @@ class DateFilter extends Filter
         $dateFormats = implode(',', AllowedDateFormat::getValues());
 
         return [
+            'required',
             "date_format:$dateFormats",
         ];
     }

--- a/app/Http/Api/Filter/EnumFilter.php
+++ b/app/Http/Api/Filter/EnumFilter.php
@@ -74,6 +74,7 @@ class EnumFilter extends Filter
     public function getRules(): array
     {
         return [
+            'required',
             new EnumDescriptionRule($this->enumClass),
         ];
     }

--- a/app/Http/Api/Filter/FloatFilter.php
+++ b/app/Http/Api/Filter/FloatFilter.php
@@ -61,6 +61,7 @@ class FloatFilter extends Filter
     public function getRules(): array
     {
         return [
+            'required',
             'numeric',
         ];
     }

--- a/app/Http/Api/Filter/HasFilter.php
+++ b/app/Http/Api/Filter/HasFilter.php
@@ -71,7 +71,8 @@ class HasFilter extends Filter
         $paths = Arr::map($this->allowedIncludePaths, fn (AllowedInclude $allowedInclude) => $allowedInclude->path());
 
         return [
-            Rule::in($paths),
+            'required',
+            Rule::in($paths)->__toString(),
         ];
     }
 

--- a/app/Http/Api/Filter/IntFilter.php
+++ b/app/Http/Api/Filter/IntFilter.php
@@ -61,6 +61,7 @@ class IntFilter extends Filter
     public function getRules(): array
     {
         return [
+            'required',
             'integer',
         ];
     }

--- a/app/Http/Api/Filter/StringFilter.php
+++ b/app/Http/Api/Filter/StringFilter.php
@@ -53,6 +53,7 @@ class StringFilter extends Filter
     public function getRules(): array
     {
         return [
+            'required',
             'string',
         ];
     }

--- a/app/Http/Requests/Api/IndexRequest.php
+++ b/app/Http/Requests/Api/IndexRequest.php
@@ -172,7 +172,7 @@ abstract class IndexRequest extends ReadRequest
             [
                 'sometimes',
                 'required',
-                Str::of('array:')->append(implode(',', $types))->__toString()
+                Str::of('array:')->append(implode(',', $types))->__toString(),
             ],
             fn (Fluent $fluent) => is_array($fluent->get(SortParser::param()))
         );

--- a/app/Http/Requests/Api/IndexRequest.php
+++ b/app/Http/Requests/Api/IndexRequest.php
@@ -13,9 +13,7 @@ use App\Http\Api\Parser\SortParser;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Str;
-use Illuminate\Validation\Rule;
 use Illuminate\Validation\Validator;
-use Spatie\ValidationRules\Rules\Delimited;
 
 /**
  * Class IndexRequest.
@@ -161,15 +159,21 @@ abstract class IndexRequest extends ReadRequest
             $types[] = $relationSchema->type();
         }
 
+        $rules = $this->restrictAllowedSortValues(SortParser::param(), $schema);
+
         $validator->sometimes(
             SortParser::param(),
-            ['sometimes', 'required', new Delimited(Rule::in($this->formatAllowedSortValues($schema)))],
+            Arr::get($rules, SortParser::param()),
             fn (Fluent $fluent) => Arr::has($fluent->toArray(), SortParser::param()) && ! is_array($fluent->get(SortParser::param()))
         );
 
         $validator->sometimes(
             SortParser::param(),
-            ['sometimes', 'required', Str::of('array:')->append(implode(',', $types))->__toString()],
+            [
+                'sometimes',
+                'required',
+                Str::of('array:')->append(implode(',', $types))->__toString()
+            ],
             fn (Fluent $fluent) => is_array($fluent->get(SortParser::param()))
         );
     }

--- a/app/Rules/Api/DelimitedRule.php
+++ b/app/Rules/Api/DelimitedRule.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Rules\Api;
+
+use Closure;
+use Illuminate\Contracts\Validation\InvokableRule;
+use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Str;
+use Illuminate\Translation\PotentiallyTranslatedString;
+
+/**
+ * Class DelimitedRule.
+ */
+class DelimitedRule implements InvokableRule
+{
+    /**
+     * Create a new rule instance.
+     *
+     * @param  string|array|Rule  $rule
+     */
+    public function __construct(protected readonly string|array|Rule $rule)
+    {
+    }
+
+    /**
+     * Run the validation rule.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
+     * @return void
+     */
+    public function __invoke($attribute, $value, $fail): void
+    {
+        $key = Str::of($attribute)->explode('.')->last();
+        $items = Str::of($value)->explode(',');
+
+        if ($items->unique()->count() !== $items->count()) {
+            $fail(__('validation.api.unique'));
+
+            return;
+        }
+
+        foreach ($items as $item) {
+            $validator = Validator::make(
+                [$key => $item],
+                [$key => $this->rule]
+            );
+
+            if ($validator->fails()) {
+                $fail($validator->getMessageBag()->first($key));
+
+                return;
+            }
+        }
+    }
+}

--- a/app/Rules/Api/RandomSoleRule.php
+++ b/app/Rules/Api/RandomSoleRule.php
@@ -34,6 +34,6 @@ class RandomSoleRule implements Rule
      */
     public function message(): string
     {
-        return __('validation.random_sole');
+        return __('validation.api.random_sole');
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,6 @@
         "spatie/db-dumper": "^3.1.1",
         "spatie/laravel-permission": "^5.5",
         "spatie/laravel-route-discovery": "^1.0",
-        "spatie/laravel-validation-rules": "^3.2",
         "staudenmeir/belongs-to-through": "^2.12",
         "symfony/http-client": "^6.0",
         "symfony/mailgun-mailer": "^6.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2164b0a34d6ab36ac61e96636a8559ba",
+    "content-hash": "50c52e29f0b2692755dfedf769fa3362",
     "packages": [
         {
             "name": "akaunting/laravel-setting",
@@ -6779,78 +6779,6 @@
                 }
             ],
             "time": "2022-03-08T14:54:07+00:00"
-        },
-        {
-            "name": "spatie/laravel-validation-rules",
-            "version": "3.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/spatie/laravel-validation-rules.git",
-                "reference": "47a63a724e10d72432d0dcdf438d1fecbc963bae"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-validation-rules/zipball/47a63a724e10d72432d0dcdf438d1fecbc963bae",
-                "reference": "47a63a724e10d72432d0dcdf438d1fecbc963bae",
-                "shasum": ""
-            },
-            "require": {
-                "illuminate/support": "^8.0|^9.0",
-                "php": "^7.4|^8.0"
-            },
-            "require-dev": {
-                "league/iso3166": "^3.0",
-                "myclabs/php-enum": "^1.6",
-                "orchestra/testbench": "^6.23|^7.0",
-                "phpunit/phpunit": "^9.4",
-                "spatie/enum": "^2.2|^3.0"
-            },
-            "suggest": {
-                "league/iso3166": "Needed for the CountryCode rule and Currency rule"
-            },
-            "type": "library",
-            "extra": {
-                "laravel": {
-                    "providers": [
-                        "Spatie\\ValidationRules\\ValidationRulesServiceProvider"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Spatie\\ValidationRules\\": "src",
-                    "Spatie\\ValidationRules\\Database\\Factories\\": "database/factories"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Freek Van der Herten",
-                    "email": "freek@spatie.be",
-                    "homepage": "https://spatie.be",
-                    "role": "Developer"
-                }
-            ],
-            "description": "A set of useful Laravel validation rules",
-            "homepage": "https://github.com/spatie/laravel-validation-rules",
-            "keywords": [
-                "laravel-validation-rules",
-                "spatie"
-            ],
-            "support": {
-                "issues": "https://github.com/spatie/laravel-validation-rules/issues",
-                "source": "https://github.com/spatie/laravel-validation-rules/tree/3.2.1"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/spatie",
-                    "type": "github"
-                }
-            ],
-            "time": "2022-08-01T11:52:01+00:00"
         },
         {
             "name": "spatie/once",

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -23,6 +23,10 @@ return [
     'alpha' => 'The :attribute must only contain letters.',
     'alpha_dash' => 'The :attribute must only contain letters, numbers, dashes and underscores.',
     'alpha_num' => 'The :attribute must only contain letters and numbers.',
+    'api' => [
+        'random_sole' => 'The :attribute field prohibits random unless it is the sole value.',
+        'unique' => 'You may not specify duplicates.',
+    ],
     'array' => 'The :attribute must be an array.',
     'before' => 'The :attribute must be a date before :date.',
     'before_or_equal' => 'The :attribute must be a date before or equal to :date.',
@@ -129,7 +133,6 @@ return [
     'required_without' => 'The :attribute field is required when :values is not present.',
     'required_without_all' => 'The :attribute field is required when none of :values are present.',
     'resource_link_site_mismatch' => 'The link does not match the site domain',
-    'random_sole' => 'The :attribute field prohibits random unless it is the sole value.',
     'same' => 'The :attribute and :other must match.',
     'size' => [
         'array' => 'The :attribute must contain :size items.',

--- a/tests/Unit/Rules/Api/DelimitedTest.php
+++ b/tests/Unit/Rules/Api/DelimitedTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Rules\Api;
+
+use App\Rules\Api\DelimitedRule;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Validator;
+use Tests\TestCase;
+
+/**
+ * Class DelimitedTest.
+ */
+class DelimitedTest extends TestCase
+{
+    use WithFaker;
+
+    /**
+     * The Delimited Rule shall pass if all values pass the given rules.
+     *
+     * @return void
+     */
+    public function testPassesIfAllValuesPass(): void
+    {
+        $attribute = $this->faker->word();
+
+        $values = collect($this->faker->words());
+
+        $validator = Validator::make(
+            [$attribute => $values->implode(',')],
+            [$attribute => new DelimitedRule(['required', 'string'])]
+        );
+
+        static::assertTrue($validator->passes());
+    }
+
+    /**
+     * The Delimited Rule shall fail if there exist duplicate values.
+     *
+     * @return void
+     */
+    public function testFailsForDuplicateValues(): void
+    {
+        $attribute = $this->faker->word();
+
+        $duplicate = $this->faker->word();
+
+        $values = collect([$duplicate, $this->faker->word(), $duplicate]);
+
+        $validator = Validator::make(
+            [$attribute => $values->implode(',')],
+            [$attribute => new DelimitedRule(['required', 'string'])]
+        );
+
+        static::assertFalse($validator->passes());
+    }
+
+    /**
+     * The Delimited Rule shall fail if any value fails a rule.
+     *
+     * @return void
+     */
+    public function testFailsForInvalidValue(): void
+    {
+        $attribute = $this->faker->word();
+
+        $values = collect([$this->faker->randomDigitNotNull(), $this->faker->word(), $this->faker->randomDigitNotNull()]);
+
+        $validator = Validator::make(
+            [$attribute => $values->implode(',')],
+            [$attribute => new DelimitedRule(['required', 'integer'])]
+        );
+
+        static::assertFalse($validator->passes());
+    }
+
+    /**
+     * The Delimited Rule shall validate empty values.
+     *
+     * @return void
+     */
+    public function testValidatesEmptyValues(): void
+    {
+        $attribute = $this->faker->word();
+
+        $values = collect(array_merge($this->faker->words(), ['']));
+
+        $validator = Validator::make(
+            [$attribute => $values->implode(',')],
+            [$attribute => new DelimitedRule(['required', 'string'])]
+        );
+
+        static::assertFalse($validator->passes());
+    }
+}


### PR DESCRIPTION
Dropping spatie dependency since it filters out empty values without allowing us to override this behavior.

Since empty values raise a runtime exception for invalid include values, we are extracting their Delimited class to our own rule.