### PR TITLE
feat(api): restrict destroy & update actions to active models

### DIFF
--- a/app/Policies/Admin/AnnouncementPolicy.php
+++ b/app/Policies/Admin/AnnouncementPolicy.php
@@ -59,22 +59,24 @@ class AnnouncementPolicy
      * Determine whether the user can update the model.
      *
      * @param  User  $user
+     * @param  Announcement  $announcement
      * @return bool
      */
-    public function update(User $user): bool
+    public function update(User $user, Announcement $announcement): bool
     {
-        return $user->can('update announcement');
+        return ! $announcement->trashed() && $user->can('update announcement');
     }
 
     /**
      * Determine whether the user can delete the model.
      *
      * @param  User  $user
+     * @param  Announcement  $announcement
      * @return bool
      */
-    public function delete(User $user): bool
+    public function delete(User $user, Announcement $announcement): bool
     {
-        return $user->can('delete announcement');
+        return ! $announcement->trashed() && $user->can('delete announcement');
     }
 
     /**

--- a/app/Policies/Admin/DumpPolicy.php
+++ b/app/Policies/Admin/DumpPolicy.php
@@ -59,22 +59,24 @@ class DumpPolicy
      * Determine whether the user can update the model.
      *
      * @param  User  $user
+     * @param  Dump  $dump
      * @return bool
      */
-    public function update(User $user): bool
+    public function update(User $user, Dump $dump): bool
     {
-        return $user->can('update dump');
+        return ! $dump->trashed() && $user->can('update dump');
     }
 
     /**
      * Determine whether the user can delete the model.
      *
      * @param  User  $user
+     * @param  Dump  $dump
      * @return bool
      */
-    public function delete(User $user): bool
+    public function delete(User $user, Dump $dump): bool
     {
-        return $user->can('delete dump');
+        return ! $dump->trashed() && $user->can('delete dump');
     }
 
     /**

--- a/app/Policies/Billing/BalancePolicy.php
+++ b/app/Policies/Billing/BalancePolicy.php
@@ -59,22 +59,24 @@ class BalancePolicy
      * Determine whether the user can update the model.
      *
      * @param  User  $user
+     * @param  Balance  $balance
      * @return bool
      */
-    public function update(User $user): bool
+    public function update(User $user, Balance $balance): bool
     {
-        return $user->can('update balance');
+        return ! $balance->trashed() && $user->can('update balance');
     }
 
     /**
      * Determine whether the user can delete the model.
      *
      * @param  User  $user
+     * @param  Balance  $balance
      * @return bool
      */
-    public function delete(User $user): bool
+    public function delete(User $user, Balance $balance): bool
     {
-        return $user->can('delete balance');
+        return ! $balance->trashed() && $user->can('delete balance');
     }
 
     /**

--- a/app/Policies/Billing/TransactionPolicy.php
+++ b/app/Policies/Billing/TransactionPolicy.php
@@ -59,22 +59,24 @@ class TransactionPolicy
      * Determine whether the user can update the model.
      *
      * @param  User  $user
+     * @param  Transaction  $transaction
      * @return bool
      */
-    public function update(User $user): bool
+    public function update(User $user, Transaction $transaction): bool
     {
-        return $user->can('update transaction');
+        return ! $transaction->trashed() && $user->can('update transaction');
     }
 
     /**
      * Determine whether the user can delete the model.
      *
      * @param  User  $user
+     * @param  Transaction  $transaction
      * @return bool
      */
-    public function delete(User $user): bool
+    public function delete(User $user, Transaction $transaction): bool
     {
-        return $user->can('delete transaction');
+        return ! $transaction->trashed() && $user->can('delete transaction');
     }
 
     /**

--- a/app/Policies/Document/PagePolicy.php
+++ b/app/Policies/Document/PagePolicy.php
@@ -59,22 +59,24 @@ class PagePolicy
      * Determine whether the user can update the model.
      *
      * @param  User  $user
+     * @param  Page  $page
      * @return bool
      */
-    public function update(User $user): bool
+    public function update(User $user, Page $page): bool
     {
-        return $user->can('update page');
+        return ! $page->trashed() && $user->can('update page');
     }
 
     /**
      * Determine whether the user can delete the model.
      *
      * @param  User  $user
+     * @param  Page  $page
      * @return bool
      */
-    public function delete(User $user): bool
+    public function delete(User $user, Page $page): bool
     {
-        return $user->can('delete page');
+        return ! $page->trashed() && $user->can('delete page');
     }
 
     /**

--- a/app/Policies/List/Playlist/PlaylistTrackPolicy.php
+++ b/app/Policies/List/Playlist/PlaylistTrackPolicy.php
@@ -89,11 +89,11 @@ class PlaylistTrackPolicy
     {
         return Nova::whenServing(
             fn (): bool => $user->hasRole('Admin'),
-            function (Request $request) use ($user): bool {
+            function (Request $request) use ($user, $track): bool {
                 /** @var Playlist|null $playlist */
                 $playlist = $request->route('playlist');
 
-                return $user->can('update playlist track') && $user->getKey() === $playlist?->user_id;
+                return ! $track->trashed() && $user->getKey() === $playlist?->user_id && $user->can('update playlist track');
             }
         );
     }
@@ -111,11 +111,11 @@ class PlaylistTrackPolicy
     {
         return Nova::whenServing(
             fn (): bool => $user->hasRole('Admin'),
-            function (Request $request) use ($user): bool {
+            function (Request $request) use ($user, $track): bool {
                 /** @var Playlist|null $playlist */
                 $playlist = $request->route('playlist');
 
-                return $user->can('delete playlist track') && $user->getKey() === $playlist?->user_id;
+                return ! $track->trashed() && $user->getKey() === $playlist?->user_id && $user->can('delete playlist track');
             }
         );
     }

--- a/app/Policies/List/PlaylistPolicy.php
+++ b/app/Policies/List/PlaylistPolicy.php
@@ -75,7 +75,7 @@ class PlaylistPolicy
     {
         return Nova::whenServing(
             fn (): bool => $user->hasRole('Admin'),
-            fn (): bool => $user->can('update playlist') && $user->getKey() === $playlist->user_id
+            fn (): bool => ! $playlist->trashed() && $user->getKey() === $playlist->user_id && $user->can('update playlist')
         );
     }
 
@@ -90,7 +90,7 @@ class PlaylistPolicy
     {
         return Nova::whenServing(
             fn (): bool => $user->hasRole('Admin'),
-            fn (): bool => $user->can('delete playlist') && $user->getKey() === $playlist->user_id
+            fn (): bool => ! $playlist->trashed() && $user->getKey() === $playlist->user_id && $user->can('delete playlist')
         );
     }
 

--- a/app/Policies/Wiki/Anime/AnimeSynonymPolicy.php
+++ b/app/Policies/Wiki/Anime/AnimeSynonymPolicy.php
@@ -59,22 +59,24 @@ class AnimeSynonymPolicy
      * Determine whether the user can update the model.
      *
      * @param  User  $user
+     * @param  AnimeSynonym  $animesynonym
      * @return bool
      */
-    public function update(User $user): bool
+    public function update(User $user, AnimeSynonym $animesynonym): bool
     {
-        return $user->can('update anime synonym');
+        return ! $animesynonym->trashed() && $user->can('update anime synonym');
     }
 
     /**
      * Determine whether the user can delete the model.
      *
      * @param  User  $user
+     * @param  AnimeSynonym  $animesynonym
      * @return bool
      */
-    public function delete(User $user): bool
+    public function delete(User $user, AnimeSynonym $animesynonym): bool
     {
-        return $user->can('delete anime synonym');
+        return ! $animesynonym->trashed() && $user->can('delete anime synonym');
     }
 
     /**

--- a/app/Policies/Wiki/Anime/AnimeThemePolicy.php
+++ b/app/Policies/Wiki/Anime/AnimeThemePolicy.php
@@ -59,22 +59,24 @@ class AnimeThemePolicy
      * Determine whether the user can update the model.
      *
      * @param  User  $user
+     * @param  AnimeTheme  $animetheme
      * @return bool
      */
-    public function update(User $user): bool
+    public function update(User $user, AnimeTheme $animetheme): bool
     {
-        return $user->can('update anime theme');
+        return ! $animetheme->trashed() && $user->can('update anime theme');
     }
 
     /**
      * Determine whether the user can delete the model.
      *
      * @param  User  $user
+     * @param  AnimeTheme  $animetheme
      * @return bool
      */
-    public function delete(User $user): bool
+    public function delete(User $user, AnimeTheme $animetheme): bool
     {
-        return $user->can('delete anime theme');
+        return ! $animetheme->trashed() && $user->can('delete anime theme');
     }
 
     /**

--- a/app/Policies/Wiki/Anime/Theme/AnimeThemeEntryPolicy.php
+++ b/app/Policies/Wiki/Anime/Theme/AnimeThemeEntryPolicy.php
@@ -61,22 +61,24 @@ class AnimeThemeEntryPolicy
      * Determine whether the user can update the model.
      *
      * @param  User  $user
+     * @param  AnimeThemeEntry  $animethemeentry
      * @return bool
      */
-    public function update(User $user): bool
+    public function update(User $user, AnimeThemeEntry $animethemeentry): bool
     {
-        return $user->can('update anime theme entry');
+        return ! $animethemeentry->trashed() && $user->can('update anime theme entry');
     }
 
     /**
      * Determine whether the user can delete the model.
      *
      * @param  User  $user
+     * @param  AnimeThemeEntry  $animethemeentry
      * @return bool
      */
-    public function delete(User $user): bool
+    public function delete(User $user, AnimeThemeEntry $animethemeentry): bool
     {
-        return $user->can('delete anime theme entry');
+        return ! $animethemeentry->trashed() && $user->can('delete anime theme entry');
     }
 
     /**

--- a/app/Policies/Wiki/AnimePolicy.php
+++ b/app/Policies/Wiki/AnimePolicy.php
@@ -65,22 +65,24 @@ class AnimePolicy
      * Determine whether the user can update the model.
      *
      * @param  User  $user
+     * @param  Anime  $anime
      * @return bool
      */
-    public function update(User $user): bool
+    public function update(User $user, Anime $anime): bool
     {
-        return $user->can('update anime');
+        return ! $anime->trashed() && $user->can('update anime');
     }
 
     /**
      * Determine whether the user can delete the model.
      *
      * @param  User  $user
+     * @param  Anime  $anime
      * @return bool
      */
-    public function delete(User $user): bool
+    public function delete(User $user, Anime $anime): bool
     {
-        return $user->can('delete anime');
+        return ! $anime->trashed() && $user->can('delete anime');
     }
 
     /**

--- a/app/Policies/Wiki/ArtistPolicy.php
+++ b/app/Policies/Wiki/ArtistPolicy.php
@@ -61,22 +61,24 @@ class ArtistPolicy
      * Determine whether the user can update the model.
      *
      * @param  User  $user
+     * @param  Artist  $artist
      * @return bool
      */
-    public function update(User $user): bool
+    public function update(User $user, Artist $artist): bool
     {
-        return $user->can('update artist');
+        return ! $artist->trashed() && $user->can('update artist');
     }
 
     /**
      * Determine whether the user can delete the model.
      *
      * @param  User  $user
+     * @param  Artist  $artist
      * @return bool
      */
-    public function delete(User $user): bool
+    public function delete(User $user, Artist $artist): bool
     {
-        return $user->can('delete artist');
+        return ! $artist->trashed() && $user->can('delete artist');
     }
 
     /**

--- a/app/Policies/Wiki/AudioPolicy.php
+++ b/app/Policies/Wiki/AudioPolicy.php
@@ -59,22 +59,24 @@ class AudioPolicy
      * Determine whether the user can update the model.
      *
      * @param  User  $user
+     * @param  Audio  $audio
      * @return bool
      */
-    public function update(User $user): bool
+    public function update(User $user, Audio $audio): bool
     {
-        return $user->can('update audio');
+        return ! $audio->trashed() && $user->can('update audio');
     }
 
     /**
      * Determine whether the user can delete the model.
      *
      * @param  User  $user
+     * @param  Audio  $audio
      * @return bool
      */
-    public function delete(User $user): bool
+    public function delete(User $user, Audio $audio): bool
     {
-        return $user->can('delete audio');
+        return ! $audio->trashed() && $user->can('delete audio');
     }
 
     /**

--- a/app/Policies/Wiki/ExternalResourcePolicy.php
+++ b/app/Policies/Wiki/ExternalResourcePolicy.php
@@ -59,22 +59,24 @@ class ExternalResourcePolicy
      * Determine whether the user can update the model.
      *
      * @param  User  $user
+     * @param  ExternalResource  $resource
      * @return bool
      */
-    public function update(User $user): bool
+    public function update(User $user, ExternalResource $resource): bool
     {
-        return $user->can('update external resource');
+        return ! $resource->trashed() && $user->can('update external resource');
     }
 
     /**
      * Determine whether the user can delete the model.
      *
      * @param  User  $user
+     * @param  ExternalResource  $resource
      * @return bool
      */
-    public function delete(User $user): bool
+    public function delete(User $user, ExternalResource $resource): bool
     {
-        return $user->can('delete external resource');
+        return ! $resource->trashed() && $user->can('delete external resource');
     }
 
     /**

--- a/app/Policies/Wiki/ImagePolicy.php
+++ b/app/Policies/Wiki/ImagePolicy.php
@@ -67,22 +67,24 @@ class ImagePolicy
      * Determine whether the user can update the model.
      *
      * @param  User  $user
+     * @param  Image  $image
      * @return bool
      */
-    public function update(User $user): bool
+    public function update(User $user, Image $image): bool
     {
-        return $user->can('update image');
+        return ! $image->trashed() && $user->can('update image');
     }
 
     /**
      * Determine whether the user can delete the model.
      *
      * @param  User  $user
+     * @param  Image  $image
      * @return bool
      */
-    public function delete(User $user): bool
+    public function delete(User $user, Image $image): bool
     {
-        return $user->can('delete image');
+        return ! $image->trashed() && $user->can('delete image');
     }
 
     /**

--- a/app/Policies/Wiki/SeriesPolicy.php
+++ b/app/Policies/Wiki/SeriesPolicy.php
@@ -61,22 +61,24 @@ class SeriesPolicy
      * Determine whether the user can update the model.
      *
      * @param  User  $user
+     * @param  Series  $series
      * @return bool
      */
-    public function update(User $user): bool
+    public function update(User $user, Series $series): bool
     {
-        return $user->can('update series');
+        return ! $series->trashed() && $user->can('update series');
     }
 
     /**
      * Determine whether the user can delete the model.
      *
      * @param  User  $user
+     * @param  Series  $series
      * @return bool
      */
-    public function delete(User $user): bool
+    public function delete(User $user, Series $series): bool
     {
-        return $user->can('delete series');
+        return ! $series->trashed() && $user->can('delete series');
     }
 
     /**

--- a/app/Policies/Wiki/SongPolicy.php
+++ b/app/Policies/Wiki/SongPolicy.php
@@ -59,22 +59,24 @@ class SongPolicy
      * Determine whether the user can update the model.
      *
      * @param  User  $user
+     * @param  Song  $song
      * @return bool
      */
-    public function update(User $user): bool
+    public function update(User $user, Song $song): bool
     {
-        return $user->can('update song');
+        return ! $song->trashed() && $user->can('update song');
     }
 
     /**
      * Determine whether the user can delete the model.
      *
      * @param  User  $user
+     * @param  Song  $song
      * @return bool
      */
-    public function delete(User $user): bool
+    public function delete(User $user, Song $song): bool
     {
-        return $user->can('delete song');
+        return ! $song->trashed() && $user->can('delete song');
     }
 
     /**

--- a/app/Policies/Wiki/StudioPolicy.php
+++ b/app/Policies/Wiki/StudioPolicy.php
@@ -63,22 +63,24 @@ class StudioPolicy
      * Determine whether the user can update the model.
      *
      * @param  User  $user
+     * @param  Studio  $studio
      * @return bool
      */
-    public function update(User $user): bool
+    public function update(User $user, Studio $studio): bool
     {
-        return $user->can('update studio');
+        return ! $studio->trashed() && $user->can('update studio');
     }
 
     /**
      * Determine whether the user can delete the model.
      *
      * @param  User  $user
+     * @param  Studio  $studio
      * @return bool
      */
-    public function delete(User $user): bool
+    public function delete(User $user, Studio $studio): bool
     {
-        return $user->can('delete studio');
+        return ! $studio->trashed() && $user->can('delete studio');
     }
 
     /**

--- a/app/Policies/Wiki/Video/VideoScriptPolicy.php
+++ b/app/Policies/Wiki/Video/VideoScriptPolicy.php
@@ -59,22 +59,24 @@ class VideoScriptPolicy
      * Determine whether the user can update the model.
      *
      * @param  User  $user
+     * @param  VideoScript  $videoscript
      * @return bool
      */
-    public function update(User $user): bool
+    public function update(User $user, VideoScript $videoscript): bool
     {
-        return $user->can('update video script');
+        return ! $videoscript->trashed() && $user->can('update video script');
     }
 
     /**
      * Determine whether the user can delete the model.
      *
      * @param  User  $user
+     * @param  VideoScript  $videoscript
      * @return bool
      */
-    public function delete(User $user): bool
+    public function delete(User $user, VideoScript $videoscript): bool
     {
-        return $user->can('delete video script');
+        return ! $videoscript->trashed() && $user->can('delete video script');
     }
 
     /**

--- a/app/Policies/Wiki/VideoPolicy.php
+++ b/app/Policies/Wiki/VideoPolicy.php
@@ -59,22 +59,24 @@ class VideoPolicy
      * Determine whether the user can update the model.
      *
      * @param  User  $user
+     * @param  Video  $video
      * @return bool
      */
-    public function update(User $user): bool
+    public function update(User $user, Video $video): bool
     {
-        return $user->can('update video');
+        return ! $video->trashed() && $user->can('update video');
     }
 
     /**
      * Determine whether the user can delete the model.
      *
      * @param  User  $user
+     * @param  Video  $video
      * @return bool
      */
-    public function delete(User $user): bool
+    public function delete(User $user, Video $video): bool
     {
-        return $user->can('delete video');
+        return ! $video->trashed() && $user->can('delete video');
     }
 
     /**

--- a/tests/Feature/Http/Api/Admin/Announcement/AnnouncementDestroyTest.php
+++ b/tests/Feature/Http/Api/Admin/Announcement/AnnouncementDestroyTest.php
@@ -50,6 +50,26 @@ class AnnouncementDestroyTest extends TestCase
     }
 
     /**
+     * The Announcement Destroy Endpoint shall forbid users from updating an announcement that is trashed.
+     *
+     * @return void
+     */
+    public function testTrashed(): void
+    {
+        $announcement = Announcement::factory()->createOne();
+
+        $announcement->delete();
+
+        $user = User::factory()->withPermission('delete announcement')->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->delete(route('api.announcement.destroy', ['announcement' => $announcement]));
+
+        $response->assertNotFound();
+    }
+
+    /**
      * The Announcement Destroy Endpoint shall delete the announcement.
      *
      * @return void

--- a/tests/Feature/Http/Api/Admin/Announcement/AnnouncementUpdateTest.php
+++ b/tests/Feature/Http/Api/Admin/Announcement/AnnouncementUpdateTest.php
@@ -54,6 +54,28 @@ class AnnouncementUpdateTest extends TestCase
     }
 
     /**
+     * The Announcement Update Endpoint shall forbid users from updating an announcement that is trashed.
+     *
+     * @return void
+     */
+    public function testTrashed(): void
+    {
+        $announcement = Announcement::factory()->createOne();
+
+        $announcement->delete();
+
+        $parameters = Announcement::factory()->raw();
+
+        $user = User::factory()->withPermission('update announcement')->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->put(route('api.announcement.update', ['announcement' => $announcement] + $parameters));
+
+        $response->assertForbidden();
+    }
+
+    /**
      * The Announcement Update Endpoint shall update an announcement.
      *
      * @return void

--- a/tests/Feature/Http/Api/Admin/Dump/DumpDestroyTest.php
+++ b/tests/Feature/Http/Api/Admin/Dump/DumpDestroyTest.php
@@ -50,6 +50,26 @@ class DumpDestroyTest extends TestCase
     }
 
     /**
+     * The Dump Destroy Endpoint shall forbid users from updating a dump that is trashed.
+     *
+     * @return void
+     */
+    public function testTrashed(): void
+    {
+        $dump = Dump::factory()->createOne();
+
+        $dump->delete();
+
+        $user = User::factory()->withPermission('delete dump')->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->delete(route('api.dump.destroy', ['dump' => $dump]));
+
+        $response->assertNotFound();
+    }
+
+    /**
      * The Dump Destroy Endpoint shall delete the dump.
      *
      * @return void

--- a/tests/Feature/Http/Api/Admin/Dump/DumpUpdateTest.php
+++ b/tests/Feature/Http/Api/Admin/Dump/DumpUpdateTest.php
@@ -54,6 +54,28 @@ class DumpUpdateTest extends TestCase
     }
 
     /**
+     * The Dump Update Endpoint shall forbid users from updating a dump that is trashed.
+     *
+     * @return void
+     */
+    public function testTrashed(): void
+    {
+        $dump = Dump::factory()->createOne();
+
+        $dump->delete();
+
+        $parameters = Dump::factory()->raw();
+
+        $user = User::factory()->withPermission('update dump')->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->put(route('api.dump.update', ['dump' => $dump] + $parameters));
+
+        $response->assertForbidden();
+    }
+
+    /**
      * The Dump Update Endpoint shall update a dump.
      *
      * @return void

--- a/tests/Feature/Http/Api/Billing/Balance/BalanceDestroyTest.php
+++ b/tests/Feature/Http/Api/Billing/Balance/BalanceDestroyTest.php
@@ -50,6 +50,26 @@ class BalanceDestroyTest extends TestCase
     }
 
     /**
+     * The Balance Destroy Endpoint shall forbid users from updating a balance that is trashed.
+     *
+     * @return void
+     */
+    public function testTrashed(): void
+    {
+        $balance = Balance::factory()->createOne();
+
+        $balance->delete();
+
+        $user = User::factory()->withPermission('delete balance')->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->delete(route('api.balance.destroy', ['balance' => $balance]));
+
+        $response->assertNotFound();
+    }
+
+    /**
      * The Balance Destroy Endpoint shall delete the balance.
      *
      * @return void

--- a/tests/Feature/Http/Api/Billing/Balance/BalanceUpdateTest.php
+++ b/tests/Feature/Http/Api/Billing/Balance/BalanceUpdateTest.php
@@ -68,6 +68,34 @@ class BalanceUpdateTest extends TestCase
     }
 
     /**
+     * The Balance Update Endpoint shall forbid users from updating a balance that is trashed.
+     *
+     * @return void
+     */
+    public function testTrashed(): void
+    {
+        $balance = Balance::factory()->createOne();
+
+        $balance->delete();
+
+        $parameters = array_merge(
+            Balance::factory()->raw(),
+            [
+                Balance::ATTRIBUTE_FREQUENCY => BalanceFrequency::getRandomInstance()->description,
+                Balance::ATTRIBUTE_SERVICE => Service::getRandomInstance()->description,
+            ]
+        );
+
+        $user = User::factory()->withPermission('update balance')->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->put(route('api.balance.update', ['balance' => $balance] + $parameters));
+
+        $response->assertForbidden();
+    }
+
+    /**
      * The Balance Update Endpoint shall update a balance.
      *
      * @return void

--- a/tests/Feature/Http/Api/Billing/Transaction/TransactionDestroyTest.php
+++ b/tests/Feature/Http/Api/Billing/Transaction/TransactionDestroyTest.php
@@ -50,6 +50,26 @@ class TransactionDestroyTest extends TestCase
     }
 
     /**
+     * The Transaction Destroy Endpoint shall forbid users from updating a transaction that is trashed.
+     *
+     * @return void
+     */
+    public function testTrashed(): void
+    {
+        $transaction = Transaction::factory()->createOne();
+
+        $transaction->delete();
+
+        $user = User::factory()->withPermission('delete transaction')->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->delete(route('api.transaction.destroy', ['transaction' => $transaction]));
+
+        $response->assertNotFound();
+    }
+
+    /**
      * The Transaction Destroy Endpoint shall delete the transaction.
      *
      * @return void

--- a/tests/Feature/Http/Api/Billing/Transaction/TransactionUpdateTest.php
+++ b/tests/Feature/Http/Api/Billing/Transaction/TransactionUpdateTest.php
@@ -61,6 +61,31 @@ class TransactionUpdateTest extends TestCase
     }
 
     /**
+     * The Transaction Update Endpoint shall forbid users from updating a transaction that is trashed.
+     *
+     * @return void
+     */
+    public function testTrashed(): void
+    {
+        $transaction = Transaction::factory()->createOne();
+
+        $transaction->delete();
+
+        $parameters = array_merge(
+            Transaction::factory()->raw(),
+            [Transaction::ATTRIBUTE_SERVICE => Service::getRandomInstance()->description]
+        );
+
+        $user = User::factory()->withPermission('update transaction')->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->put(route('api.transaction.update', ['transaction' => $transaction] + $parameters));
+
+        $response->assertForbidden();
+    }
+
+    /**
      * The Transaction Update Endpoint shall update a transaction.
      *
      * @return void

--- a/tests/Feature/Http/Api/Document/Page/PageDestroyTest.php
+++ b/tests/Feature/Http/Api/Document/Page/PageDestroyTest.php
@@ -50,6 +50,26 @@ class PageDestroyTest extends TestCase
     }
 
     /**
+     * The Page Destroy Endpoint shall forbid users from updating a page that is trashed.
+     *
+     * @return void
+     */
+    public function testTrashed(): void
+    {
+        $page = Page::factory()->createOne();
+
+        $page->delete();
+
+        $user = User::factory()->withPermission('delete page')->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->delete(route('api.page.destroy', ['page' => $page]));
+
+        $response->assertNotFound();
+    }
+
+    /**
      * The Page Destroy Endpoint shall delete the page.
      *
      * @return void

--- a/tests/Feature/Http/Api/Document/Page/PageUpdateTest.php
+++ b/tests/Feature/Http/Api/Document/Page/PageUpdateTest.php
@@ -54,6 +54,28 @@ class PageUpdateTest extends TestCase
     }
 
     /**
+     * The Page Update Endpoint shall forbid users from updating a page that is trashed.
+     *
+     * @return void
+     */
+    public function testTrashed(): void
+    {
+        $page = Page::factory()->createOne();
+
+        $page->delete();
+
+        $parameters = Page::factory()->raw();
+
+        $user = User::factory()->withPermission('update page')->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->put(route('api.page.update', ['page' => $page] + $parameters));
+
+        $response->assertForbidden();
+    }
+
+    /**
      * The Page Update Endpoint shall update an page.
      *
      * @return void

--- a/tests/Feature/Http/Api/List/Playlist/PlaylistDestroyTest.php
+++ b/tests/Feature/Http/Api/List/Playlist/PlaylistDestroyTest.php
@@ -70,6 +70,28 @@ class PlaylistDestroyTest extends TestCase
     }
 
     /**
+     * The Playlist Destroy Endpoint shall forbid users from updating a playlist that is trashed.
+     *
+     * @return void
+     */
+    public function testTrashed(): void
+    {
+        $user = User::factory()->withPermission('delete playlist')->createOne();
+
+        $playlist = Playlist::factory()
+            ->for($user)
+            ->createOne();
+
+        $playlist->delete();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->delete(route('api.playlist.destroy', ['playlist' => $playlist]));
+
+        $response->assertNotFound();
+    }
+
+    /**
      * The Playlist Destroy Endpoint shall delete the playlist.
      *
      * @return void

--- a/tests/Feature/Http/Api/List/Playlist/Track/TrackDestroyTest.php
+++ b/tests/Feature/Http/Api/List/Playlist/Track/TrackDestroyTest.php
@@ -105,6 +105,28 @@ class TrackDestroyTest extends TestCase
     }
 
     /**
+     * The Track Destroy Endpoint shall forbid users from updating a track that is trashed.
+     *
+     * @return void
+     */
+    public function testTrashed(): void
+    {
+        $user = User::factory()->withPermission('delete playlist track')->createOne();
+
+        $track = PlaylistTrack::factory()
+            ->for(Playlist::factory()->for($user))
+            ->createOne();
+
+        $track->delete();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->delete(route('api.playlist.playlisttrack.destroy', ['playlist' => $track->playlist, 'playlisttrack' => $track]));
+
+        $response->assertNotFound();
+    }
+
+    /**
      * The Track Destroy Endpoint shall delete the track.
      *
      * @return void

--- a/tests/Feature/Http/Api/Wiki/Anime/AnimeDestroyTest.php
+++ b/tests/Feature/Http/Api/Wiki/Anime/AnimeDestroyTest.php
@@ -50,6 +50,26 @@ class AnimeDestroyTest extends TestCase
     }
 
     /**
+     * The Anime Destroy Endpoint shall forbid users from updating an anime that is trashed.
+     *
+     * @return void
+     */
+    public function testTrashed(): void
+    {
+        $anime = Anime::factory()->createOne();
+
+        $anime->delete();
+
+        $user = User::factory()->withPermission('delete anime')->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->delete(route('api.anime.destroy', ['anime' => $anime]));
+
+        $response->assertNotFound();
+    }
+
+    /**
      * The Anime Destroy Endpoint shall delete the anime.
      *
      * @return void

--- a/tests/Feature/Http/Api/Wiki/Anime/AnimeUpdateTest.php
+++ b/tests/Feature/Http/Api/Wiki/Anime/AnimeUpdateTest.php
@@ -61,6 +61,31 @@ class AnimeUpdateTest extends TestCase
     }
 
     /**
+     * The Anime Update Endpoint shall forbid users from updating an anime that is trashed.
+     *
+     * @return void
+     */
+    public function testTrashed(): void
+    {
+        $anime = Anime::factory()->createOne();
+
+        $anime->delete();
+
+        $parameters = array_merge(
+            Anime::factory()->raw(),
+            [Anime::ATTRIBUTE_SEASON => AnimeSeason::getRandomInstance()->description],
+        );
+
+        $user = User::factory()->withPermission('update anime')->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->put(route('api.anime.update', ['anime' => $anime] + $parameters));
+
+        $response->assertForbidden();
+    }
+
+    /**
      * The Anime Update Endpoint shall update an anime.
      *
      * @return void

--- a/tests/Feature/Http/Api/Wiki/Anime/Synonym/SynonymDestroyTest.php
+++ b/tests/Feature/Http/Api/Wiki/Anime/Synonym/SynonymDestroyTest.php
@@ -51,6 +51,26 @@ class SynonymDestroyTest extends TestCase
     }
 
     /**
+     * The Synonym Destroy Endpoint shall forbid users from updating an anime synonym that is trashed.
+     *
+     * @return void
+     */
+    public function testTrashed(): void
+    {
+        $synonym = AnimeSynonym::factory()->for(Anime::factory())->createOne();
+
+        $synonym->delete();
+
+        $user = User::factory()->withPermission('delete anime synonym')->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->delete(route('api.animesynonym.destroy', ['animesynonym' => $synonym]));
+
+        $response->assertNotFound();
+    }
+
+    /**
      * The Synonym Destroy Endpoint shall delete the synonym.
      *
      * @return void

--- a/tests/Feature/Http/Api/Wiki/Anime/Synonym/SynonymUpdateTest.php
+++ b/tests/Feature/Http/Api/Wiki/Anime/Synonym/SynonymUpdateTest.php
@@ -55,6 +55,28 @@ class SynonymUpdateTest extends TestCase
     }
 
     /**
+     * The Synonym Update Endpoint shall forbid users from updating an anime synonym that is trashed.
+     *
+     * @return void
+     */
+    public function testTrashed(): void
+    {
+        $synonym = AnimeSynonym::factory()->for(Anime::factory())->createOne();
+
+        $synonym->delete();
+
+        $parameters = AnimeSynonym::factory()->raw();
+
+        $user = User::factory()->withPermission('update anime synonym')->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->put(route('api.animesynonym.update', ['animesynonym' => $synonym] + $parameters));
+
+        $response->assertForbidden();
+    }
+
+    /**
      * The Synonym Update Endpoint shall update a synonym.
      *
      * @return void

--- a/tests/Feature/Http/Api/Wiki/Anime/Theme/Entry/EntryDestroyTest.php
+++ b/tests/Feature/Http/Api/Wiki/Anime/Theme/Entry/EntryDestroyTest.php
@@ -56,6 +56,28 @@ class EntryDestroyTest extends TestCase
     }
 
     /**
+     * The Entry Destroy Endpoint shall forbid users from updating an anime theme entry that is trashed.
+     *
+     * @return void
+     */
+    public function testTrashed(): void
+    {
+        $entry = AnimeThemeEntry::factory()
+            ->for(AnimeTheme::factory()->for(Anime::factory()))
+            ->createOne();
+
+        $entry->delete();
+
+        $user = User::factory()->withPermission('delete anime theme entry')->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->delete(route('api.animethemeentry.destroy', ['animethemeentry' => $entry]));
+
+        $response->assertNotFound();
+    }
+
+    /**
      * The Entry Destroy Endpoint shall delete the entry.
      *
      * @return void

--- a/tests/Feature/Http/Api/Wiki/Anime/Theme/Entry/EntryUpdateTest.php
+++ b/tests/Feature/Http/Api/Wiki/Anime/Theme/Entry/EntryUpdateTest.php
@@ -60,6 +60,30 @@ class EntryUpdateTest extends TestCase
     }
 
     /**
+     * The Entry Update Endpoint shall forbid users from updating an anime theme entry that is trashed.
+     *
+     * @return void
+     */
+    public function testTrashed(): void
+    {
+        $entry = AnimeThemeEntry::factory()
+            ->for(AnimeTheme::factory()->for(Anime::factory()))
+            ->createOne();
+
+        $entry->delete();
+
+        $parameters = AnimeThemeEntry::factory()->raw();
+
+        $user = User::factory()->withPermission('update anime theme entry')->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->put(route('api.animethemeentry.update', ['animethemeentry' => $entry] + $parameters));
+
+        $response->assertForbidden();
+    }
+
+    /**
      * The Entry Update Endpoint shall update an entry.
      *
      * @return void

--- a/tests/Feature/Http/Api/Wiki/Anime/Theme/ThemeDestroyTest.php
+++ b/tests/Feature/Http/Api/Wiki/Anime/Theme/ThemeDestroyTest.php
@@ -51,6 +51,26 @@ class ThemeDestroyTest extends TestCase
     }
 
     /**
+     * The Theme Destroy Endpoint shall forbid users from updating an anime theme that is trashed.
+     *
+     * @return void
+     */
+    public function testTrashed(): void
+    {
+        $theme = AnimeTheme::factory()->for(Anime::factory())->createOne();
+
+        $theme->delete();
+
+        $user = User::factory()->withPermission('delete anime theme')->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->delete(route('api.animetheme.destroy', ['animetheme' => $theme]));
+
+        $response->assertNotFound();
+    }
+
+    /**
      * The Theme Destroy Endpoint shall delete the theme.
      *
      * @return void

--- a/tests/Feature/Http/Api/Wiki/Anime/Theme/ThemeUpdateTest.php
+++ b/tests/Feature/Http/Api/Wiki/Anime/Theme/ThemeUpdateTest.php
@@ -62,6 +62,31 @@ class ThemeUpdateTest extends TestCase
     }
 
     /**
+     * The Theme Update Endpoint shall forbid users from updating an anime theme that is trashed.
+     *
+     * @return void
+     */
+    public function testTrashed(): void
+    {
+        $theme = AnimeTheme::factory()->for(Anime::factory())->createOne();
+
+        $theme->delete();
+
+        $parameters = array_merge(
+            AnimeTheme::factory()->raw(),
+            [AnimeTheme::ATTRIBUTE_TYPE => ThemeType::getRandomInstance()->description],
+        );
+
+        $user = User::factory()->withPermission('update anime theme')->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->put(route('api.animetheme.update', ['animetheme' => $theme] + $parameters));
+
+        $response->assertForbidden();
+    }
+
+    /**
      * The Theme Update Endpoint shall update a theme.
      *
      * @return void

--- a/tests/Feature/Http/Api/Wiki/Artist/ArtistDestroyTest.php
+++ b/tests/Feature/Http/Api/Wiki/Artist/ArtistDestroyTest.php
@@ -50,6 +50,26 @@ class ArtistDestroyTest extends TestCase
     }
 
     /**
+     * The Artist Destroy Endpoint shall forbid users from updating an artist that is trashed.
+     *
+     * @return void
+     */
+    public function testTrashed(): void
+    {
+        $artist = Artist::factory()->createOne();
+
+        $artist->delete();
+
+        $user = User::factory()->withPermission('delete artist')->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->delete(route('api.artist.destroy', ['artist' => $artist]));
+
+        $response->assertNotFound();
+    }
+
+    /**
      * The Artist Destroy Endpoint shall delete the artist.
      *
      * @return void

--- a/tests/Feature/Http/Api/Wiki/Artist/ArtistUpdateTest.php
+++ b/tests/Feature/Http/Api/Wiki/Artist/ArtistUpdateTest.php
@@ -54,6 +54,28 @@ class ArtistUpdateTest extends TestCase
     }
 
     /**
+     * The Artist Update Endpoint shall forbid users from updating an artist that is trashed.
+     *
+     * @return void
+     */
+    public function testTrashed(): void
+    {
+        $artist = Artist::factory()->createOne();
+
+        $artist->delete();
+
+        $parameters = Artist::factory()->raw();
+
+        $user = User::factory()->withPermission('update artist')->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->put(route('api.artist.update', ['artist' => $artist] + $parameters));
+
+        $response->assertForbidden();
+    }
+
+    /**
      * The Artist Update Endpoint shall update an artist.
      *
      * @return void

--- a/tests/Feature/Http/Api/Wiki/Audio/AudioDestroyTest.php
+++ b/tests/Feature/Http/Api/Wiki/Audio/AudioDestroyTest.php
@@ -50,6 +50,26 @@ class AudioDestroyTest extends TestCase
     }
 
     /**
+     * The Audio Destroy Endpoint shall forbid users from updating an audio that is trashed.
+     *
+     * @return void
+     */
+    public function testTrashed(): void
+    {
+        $audio = Audio::factory()->createOne();
+
+        $audio->delete();
+
+        $user = User::factory()->withPermission('delete audio')->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->delete(route('api.audio.destroy', ['audio' => $audio]));
+
+        $response->assertNotFound();
+    }
+
+    /**
      * The Audio Destroy Endpoint shall delete the audio.
      *
      * @return void

--- a/tests/Feature/Http/Api/Wiki/Audio/AudioShowTest.php
+++ b/tests/Feature/Http/Api/Wiki/Audio/AudioShowTest.php
@@ -26,7 +26,7 @@ class AudioShowTest extends TestCase
     use WithoutEvents;
 
     /**
-     * By default, the Audio Show Endpoint shall return a Audio Resource.
+     * By default, the Audio Show Endpoint shall return an Audio Resource.
      *
      * @return void
      */
@@ -49,7 +49,7 @@ class AudioShowTest extends TestCase
     }
 
     /**
-     * The Audio Show Endpoint shall return a Audio Resource for soft deleted audios.
+     * The Audio Show Endpoint shall return an Audio Resource for soft deleted audios.
      *
      * @return void
      */

--- a/tests/Feature/Http/Api/Wiki/Audio/AudioStoreTest.php
+++ b/tests/Feature/Http/Api/Wiki/Audio/AudioStoreTest.php
@@ -72,7 +72,7 @@ class AudioStoreTest extends TestCase
     }
 
     /**
-     * The Audio Store Endpoint shall create a audio.
+     * The Audio Store Endpoint shall create an audio.
      *
      * @return void
      */

--- a/tests/Feature/Http/Api/Wiki/Audio/AudioUpdateTest.php
+++ b/tests/Feature/Http/Api/Wiki/Audio/AudioUpdateTest.php
@@ -54,7 +54,29 @@ class AudioUpdateTest extends TestCase
     }
 
     /**
-     * The Audio Update Endpoint shall update a audio.
+     * The Audio Update Endpoint shall forbid users from updating an audio that is trashed.
+     *
+     * @return void
+     */
+    public function testTrashed(): void
+    {
+        $audio = Audio::factory()->createOne();
+
+        $audio->delete();
+
+        $parameters = Audio::factory()->raw();
+
+        $user = User::factory()->withPermission('update audio')->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->put(route('api.audio.update', ['audio' => $audio] + $parameters));
+
+        $response->assertForbidden();
+    }
+
+    /**
+     * The Audio Update Endpoint shall update an audio.
      *
      * @return void
      */

--- a/tests/Feature/Http/Api/Wiki/ExternalResource/ExternalResourceDestroyTest.php
+++ b/tests/Feature/Http/Api/Wiki/ExternalResource/ExternalResourceDestroyTest.php
@@ -50,6 +50,26 @@ class ExternalResourceDestroyTest extends TestCase
     }
 
     /**
+     * The External Resource Destroy Endpoint shall forbid users from updating a resource that is trashed.
+     *
+     * @return void
+     */
+    public function testTrashed(): void
+    {
+        $resource = ExternalResource::factory()->createOne();
+
+        $resource->delete();
+
+        $user = User::factory()->withPermission('delete external resource')->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->delete(route('api.resource.destroy', ['resource' => $resource]));
+
+        $response->assertNotFound();
+    }
+
+    /**
      * The External Resource Destroy Endpoint shall delete the resource.
      *
      * @return void

--- a/tests/Feature/Http/Api/Wiki/ExternalResource/ExternalResourceUpdateTest.php
+++ b/tests/Feature/Http/Api/Wiki/ExternalResource/ExternalResourceUpdateTest.php
@@ -61,6 +61,33 @@ class ExternalResourceUpdateTest extends TestCase
     }
 
     /**
+     * The External Resource Update Endpoint shall forbid users from updating a resource that is trashed.
+     *
+     * @return void
+     */
+    public function testTrashed(): void
+    {
+        $resource = ExternalResource::factory()->createOne([
+            ExternalResource::ATTRIBUTE_SITE => ResourceSite::OFFICIAL_SITE,
+        ]);
+
+        $resource->delete();
+
+        $parameters = array_merge(
+            ExternalResource::factory()->raw(),
+            [ExternalResource::ATTRIBUTE_SITE => ResourceSite::getDescription(ResourceSite::OFFICIAL_SITE)]
+        );
+
+        $user = User::factory()->withPermission('update external resource')->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->put(route('api.resource.update', ['resource' => $resource] + $parameters));
+
+        $response->assertForbidden();
+    }
+
+    /**
      * The External Resource Update Endpoint shall update a resource.
      *
      * @return void

--- a/tests/Feature/Http/Api/Wiki/Image/ImageDestroyTest.php
+++ b/tests/Feature/Http/Api/Wiki/Image/ImageDestroyTest.php
@@ -50,6 +50,26 @@ class ImageDestroyTest extends TestCase
     }
 
     /**
+     * The Image Destroy Endpoint shall forbid users from deleting an image that is trashed.
+     *
+     * @return void
+     */
+    public function testTrashed(): void
+    {
+        $image = Image::factory()->createOne();
+
+        $image->delete();
+
+        $user = User::factory()->withPermission('delete image')->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->delete(route('api.image.destroy', ['image' => $image]));
+
+        $response->assertNotFound();
+    }
+
+    /**
      * The Image Destroy Endpoint shall delete the image.
      *
      * @return void

--- a/tests/Feature/Http/Api/Wiki/Image/ImageUpdateTest.php
+++ b/tests/Feature/Http/Api/Wiki/Image/ImageUpdateTest.php
@@ -61,6 +61,31 @@ class ImageUpdateTest extends TestCase
     }
 
     /**
+     * The Image Update Endpoint shall forbid users from updating an image that is trashed.
+     *
+     * @return void
+     */
+    public function testTrashed(): void
+    {
+        $image = Image::factory()->createOne();
+
+        $image->delete();
+
+        $parameters = array_merge(
+            Image::factory()->raw(),
+            [Image::ATTRIBUTE_FACET => ImageFacet::getRandomInstance()->description],
+        );
+
+        $user = User::factory()->withPermission('update image')->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->put(route('api.image.update', ['image' => $image] + $parameters));
+
+        $response->assertForbidden();
+    }
+
+    /**
      * The Image Update Endpoint shall update an image.
      *
      * @return void

--- a/tests/Feature/Http/Api/Wiki/Series/SeriesDestroyTest.php
+++ b/tests/Feature/Http/Api/Wiki/Series/SeriesDestroyTest.php
@@ -50,6 +50,26 @@ class SeriesDestroyTest extends TestCase
     }
 
     /**
+     * The Series Destroy Endpoint shall forbid users from updating a series that is trashed.
+     *
+     * @return void
+     */
+    public function testTrashed(): void
+    {
+        $series = Series::factory()->createOne();
+
+        $series->delete();
+
+        $user = User::factory()->withPermission('delete series')->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->delete(route('api.series.destroy', ['series' => $series]));
+
+        $response->assertNotFound();
+    }
+
+    /**
      * The Series Destroy Endpoint shall delete the series.
      *
      * @return void

--- a/tests/Feature/Http/Api/Wiki/Series/SeriesUpdateTest.php
+++ b/tests/Feature/Http/Api/Wiki/Series/SeriesUpdateTest.php
@@ -54,6 +54,28 @@ class SeriesUpdateTest extends TestCase
     }
 
     /**
+     * The Series Update Endpoint shall forbid users from updating a series that is trashed.
+     *
+     * @return void
+     */
+    public function testTrashed(): void
+    {
+        $series = Series::factory()->createOne();
+
+        $series->delete();
+
+        $parameters = Series::factory()->raw();
+
+        $user = User::factory()->withPermission('update series')->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->put(route('api.series.update', ['series' => $series] + $parameters));
+
+        $response->assertForbidden();
+    }
+
+    /**
      * The Series Update Endpoint shall update a series.
      *
      * @return void

--- a/tests/Feature/Http/Api/Wiki/Song/SongDestroyTest.php
+++ b/tests/Feature/Http/Api/Wiki/Song/SongDestroyTest.php
@@ -50,6 +50,26 @@ class SongDestroyTest extends TestCase
     }
 
     /**
+     * The Song Destroy Endpoint shall forbid users from updating a song that is trashed.
+     *
+     * @return void
+     */
+    public function testTrashed(): void
+    {
+        $song = Song::factory()->createOne();
+
+        $song->delete();
+
+        $user = User::factory()->withPermission('delete song')->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->delete(route('api.song.destroy', ['song' => $song]));
+
+        $response->assertNotFound();
+    }
+
+    /**
      * The Song Destroy Endpoint shall delete the song.
      *
      * @return void

--- a/tests/Feature/Http/Api/Wiki/Song/SongUpdateTest.php
+++ b/tests/Feature/Http/Api/Wiki/Song/SongUpdateTest.php
@@ -54,6 +54,28 @@ class SongUpdateTest extends TestCase
     }
 
     /**
+     * The Song Update Endpoint shall forbid users from updating a song that is trashed.
+     *
+     * @return void
+     */
+    public function testTrashed(): void
+    {
+        $song = Song::factory()->createOne();
+
+        $song->delete();
+
+        $parameters = Song::factory()->raw();
+
+        $user = User::factory()->withPermission('update song')->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->put(route('api.song.update', ['song' => $song] + $parameters));
+
+        $response->assertForbidden();
+    }
+
+    /**
      * The Song Update Endpoint shall update a song.
      *
      * @return void

--- a/tests/Feature/Http/Api/Wiki/Studio/StudioDestroyTest.php
+++ b/tests/Feature/Http/Api/Wiki/Studio/StudioDestroyTest.php
@@ -50,6 +50,26 @@ class StudioDestroyTest extends TestCase
     }
 
     /**
+     * The Studio Destroy Endpoint shall forbid users from updating a studio that is trashed.
+     *
+     * @return void
+     */
+    public function testTrashed(): void
+    {
+        $studio = Studio::factory()->createOne();
+
+        $studio->delete();
+
+        $user = User::factory()->withPermission('delete studio')->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->delete(route('api.studio.destroy', ['studio' => $studio]));
+
+        $response->assertNotFound();
+    }
+
+    /**
      * The Studio Destroy Endpoint shall delete the studio.
      *
      * @return void

--- a/tests/Feature/Http/Api/Wiki/Studio/StudioUpdateTest.php
+++ b/tests/Feature/Http/Api/Wiki/Studio/StudioUpdateTest.php
@@ -54,6 +54,28 @@ class StudioUpdateTest extends TestCase
     }
 
     /**
+     * The Studio Update Endpoint shall forbid users from updating a studio that is trashed.
+     *
+     * @return void
+     */
+    public function testTrashed(): void
+    {
+        $studio = Studio::factory()->createOne();
+
+        $studio->delete();
+
+        $parameters = Studio::factory()->raw();
+
+        $user = User::factory()->withPermission('update studio')->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->put(route('api.studio.update', ['studio' => $studio] + $parameters));
+
+        $response->assertForbidden();
+    }
+
+    /**
      * The Studio Update Endpoint shall update a studio.
      *
      * @return void

--- a/tests/Feature/Http/Api/Wiki/Video/Script/ScriptDestroyTest.php
+++ b/tests/Feature/Http/Api/Wiki/Video/Script/ScriptDestroyTest.php
@@ -50,6 +50,26 @@ class ScriptDestroyTest extends TestCase
     }
 
     /**
+     * The Script Destroy Endpoint shall forbid users from updating a script that is trashed.
+     *
+     * @return void
+     */
+    public function testTrashed(): void
+    {
+        $script = VideoScript::factory()->createOne();
+
+        $script->delete();
+
+        $user = User::factory()->withPermission('delete video script')->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->delete(route('api.videoscript.destroy', ['videoscript' => $script]));
+
+        $response->assertNotFound();
+    }
+
+    /**
      * The Script Destroy Endpoint shall delete the script.
      *
      * @return void

--- a/tests/Feature/Http/Api/Wiki/Video/Script/ScriptUpdateTest.php
+++ b/tests/Feature/Http/Api/Wiki/Video/Script/ScriptUpdateTest.php
@@ -54,6 +54,28 @@ class ScriptUpdateTest extends TestCase
     }
 
     /**
+     * The Script Update Endpoint shall forbid users from updating a script that is trashed.
+     *
+     * @return void
+     */
+    public function testTrashed(): void
+    {
+        $script = VideoScript::factory()->createOne();
+
+        $script->delete();
+
+        $parameters = VideoScript::factory()->raw();
+
+        $user = User::factory()->withPermission('update video script')->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->put(route('api.videoscript.update', ['videoscript' => $script] + $parameters));
+
+        $response->assertForbidden();
+    }
+
+    /**
      * The Script Update Endpoint shall update a script.
      *
      * @return void

--- a/tests/Feature/Http/Api/Wiki/Video/VideoDestroyTest.php
+++ b/tests/Feature/Http/Api/Wiki/Video/VideoDestroyTest.php
@@ -50,6 +50,26 @@ class VideoDestroyTest extends TestCase
     }
 
     /**
+     * The Video Destroy Endpoint shall forbid users from updating a video that is trashed.
+     *
+     * @return void
+     */
+    public function testTrashed(): void
+    {
+        $video = Video::factory()->createOne();
+
+        $video->delete();
+
+        $user = User::factory()->withPermission('delete video')->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->delete(route('api.video.destroy', ['video' => $video]));
+
+        $response->assertNotFound();
+    }
+
+    /**
      * The Video Destroy Endpoint shall delete the video.
      *
      * @return void

--- a/tests/Feature/Http/Api/Wiki/Video/VideoUpdateTest.php
+++ b/tests/Feature/Http/Api/Wiki/Video/VideoUpdateTest.php
@@ -68,6 +68,34 @@ class VideoUpdateTest extends TestCase
     }
 
     /**
+     * The Video Update Endpoint shall forbid users from updating a video that is trashed.
+     *
+     * @return void
+     */
+    public function testTrashed(): void
+    {
+        $video = Video::factory()->createOne();
+
+        $video->delete();
+
+        $parameters = array_merge(
+            Video::factory()->raw(),
+            [
+                Video::ATTRIBUTE_OVERLAP => VideoOverlap::getRandomInstance()->description,
+                Video::ATTRIBUTE_SOURCE => VideoSource::getRandomInstance()->description,
+            ]
+        );
+
+        $user = User::factory()->withPermission('update video')->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->put(route('api.video.update', ['video' => $video] + $parameters));
+
+        $response->assertForbidden();
+    }
+
+    /**
      * The Video Update Endpoint shall update a video.
      *
      * @return void


### PR DESCRIPTION
Note: Resource registration with trashed option enabled doesn't apply to destroy action, thus we check for a 404 rather than a 403.