### PR TITLE
#487 feat(admin): attach resource from detail/inline

### DIFF
--- a/app/Nova/Resources/Wiki/Anime.php
+++ b/app/Nova/Resources/Wiki/Anime.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace App\Nova\Resources\Wiki;
 
 use App\Enums\Models\Wiki\AnimeSeason;
+use App\Enums\Models\Wiki\ResourceSite;
 use App\Models\Wiki\Anime as AnimeModel;
+use App\Models\Wiki\ExternalResource as ExternalResourceModel;
+use App\Nova\Actions\Models\Wiki\Anime\AttachAnimeResourceAction;
 use App\Nova\Actions\Models\Wiki\Anime\BackfillAnimeAction;
 use App\Nova\Lenses\Anime\Image\AnimeCoverLargeLens;
 use App\Nova\Lenses\Anime\Image\AnimeCoverSmallLens;
@@ -291,6 +294,42 @@ class Anime extends BaseResource
                     ->showOnDetail()
                     ->showInline()
                     ->canSeeWhen('update', $this),
+
+                (new AttachAnimeResourceAction(ResourceSite::ANIDB()))
+                    ->confirmButtonText(__('nova.actions.models.wiki.attach_resource.confirmButtonText'))
+                    ->cancelButtonText(__('nova.actions.base.cancelButtonText'))
+                    ->exceptOnIndex()
+                    ->canSeeWhen('create', ExternalResourceModel::class),
+
+                (new AttachAnimeResourceAction(ResourceSite::ANILIST()))
+                    ->confirmButtonText(__('nova.actions.models.wiki.attach_resource.confirmButtonText'))
+                    ->cancelButtonText(__('nova.actions.base.cancelButtonText'))
+                    ->exceptOnIndex()
+                    ->canSeeWhen('create', ExternalResourceModel::class),
+
+                (new AttachAnimeResourceAction(ResourceSite::ANIME_PLANET()))
+                    ->confirmButtonText(__('nova.actions.models.wiki.attach_resource.confirmButtonText'))
+                    ->cancelButtonText(__('nova.actions.base.cancelButtonText'))
+                    ->exceptOnIndex()
+                    ->canSeeWhen('create', ExternalResourceModel::class),
+
+                (new AttachAnimeResourceAction(ResourceSite::ANN()))
+                    ->confirmButtonText(__('nova.actions.models.wiki.attach_resource.confirmButtonText'))
+                    ->cancelButtonText(__('nova.actions.base.cancelButtonText'))
+                    ->exceptOnIndex()
+                    ->canSeeWhen('create', ExternalResourceModel::class),
+
+                (new AttachAnimeResourceAction(ResourceSite::KITSU()))
+                    ->confirmButtonText(__('nova.actions.models.wiki.attach_resource.confirmButtonText'))
+                    ->cancelButtonText(__('nova.actions.base.cancelButtonText'))
+                    ->exceptOnIndex()
+                    ->canSeeWhen('create', ExternalResourceModel::class),
+
+                (new AttachAnimeResourceAction(ResourceSite::MAL()))
+                    ->confirmButtonText(__('nova.actions.models.wiki.attach_resource.confirmButtonText'))
+                    ->cancelButtonText(__('nova.actions.base.cancelButtonText'))
+                    ->exceptOnIndex()
+                    ->canSeeWhen('create', ExternalResourceModel::class),
             ]
         );
     }

--- a/app/Nova/Resources/Wiki/Artist.php
+++ b/app/Nova/Resources/Wiki/Artist.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace App\Nova\Resources\Wiki;
 
+use App\Enums\Models\Wiki\ResourceSite;
 use App\Models\Wiki\Artist as ArtistModel;
+use App\Models\Wiki\ExternalResource as ExternalResourceModel;
+use App\Nova\Actions\Models\Wiki\Artist\AttachArtistResourceAction;
 use App\Nova\Lenses\Artist\Image\ArtistCoverLargeLens;
 use App\Nova\Lenses\Artist\Image\ArtistCoverSmallLens;
 use App\Nova\Lenses\Artist\Resource\ArtistAniDbResourceLens;
@@ -252,6 +255,44 @@ class Artist extends BaseResource
             Panel::make(__('nova.fields.base.timestamps'), $this->timestamps())
                 ->collapsable(),
         ];
+    }
+
+    /**
+     * Get the actions available for the resource.
+     *
+     * @param  NovaRequest  $request
+     * @return array
+     */
+    public function actions(NovaRequest $request): array
+    {
+        return array_merge(
+            parent::actions($request),
+            [
+                (new AttachArtistResourceAction(ResourceSite::ANIDB()))
+                    ->confirmButtonText(__('nova.actions.models.wiki.attach_resource.confirmButtonText'))
+                    ->cancelButtonText(__('nova.actions.base.cancelButtonText'))
+                    ->exceptOnIndex()
+                    ->canSeeWhen('create', ExternalResourceModel::class),
+
+                (new AttachArtistResourceAction(ResourceSite::ANILIST()))
+                    ->confirmButtonText(__('nova.actions.models.wiki.attach_resource.confirmButtonText'))
+                    ->cancelButtonText(__('nova.actions.base.cancelButtonText'))
+                    ->exceptOnIndex()
+                    ->canSeeWhen('create', ExternalResourceModel::class),
+
+                (new AttachArtistResourceAction(ResourceSite::ANN()))
+                    ->confirmButtonText(__('nova.actions.models.wiki.attach_resource.confirmButtonText'))
+                    ->cancelButtonText(__('nova.actions.base.cancelButtonText'))
+                    ->exceptOnIndex()
+                    ->canSeeWhen('create', ExternalResourceModel::class),
+
+                (new AttachArtistResourceAction(ResourceSite::MAL()))
+                    ->confirmButtonText(__('nova.actions.models.wiki.attach_resource.confirmButtonText'))
+                    ->cancelButtonText(__('nova.actions.base.cancelButtonText'))
+                    ->exceptOnIndex()
+                    ->canSeeWhen('create', ExternalResourceModel::class),
+            ]
+        );
     }
 
     /**

--- a/app/Nova/Resources/Wiki/Studio.php
+++ b/app/Nova/Resources/Wiki/Studio.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace App\Nova\Resources\Wiki;
 
+use App\Enums\Models\Wiki\ResourceSite;
+use App\Models\Wiki\ExternalResource as ExternalResourceModel;
 use App\Models\Wiki\Studio as StudioModel;
+use App\Nova\Actions\Models\Wiki\Studio\AttachStudioResourceAction;
 use App\Nova\Actions\Models\Wiki\Studio\BackfillStudioAction;
 use App\Nova\Lenses\Studio\Image\StudioCoverLargeLens;
 use App\Nova\Lenses\Studio\Resource\StudioAniDbResourceLens;
@@ -219,6 +222,36 @@ class Studio extends BaseResource
                     ->showOnDetail()
                     ->showInline()
                     ->canSeeWhen('update', $this),
+
+                (new AttachStudioResourceAction(ResourceSite::ANIDB()))
+                    ->confirmButtonText(__('nova.actions.models.wiki.attach_resource.confirmButtonText'))
+                    ->cancelButtonText(__('nova.actions.base.cancelButtonText'))
+                    ->exceptOnIndex()
+                    ->canSeeWhen('create', ExternalResourceModel::class),
+
+                (new AttachStudioResourceAction(ResourceSite::ANILIST()))
+                    ->confirmButtonText(__('nova.actions.models.wiki.attach_resource.confirmButtonText'))
+                    ->cancelButtonText(__('nova.actions.base.cancelButtonText'))
+                    ->exceptOnIndex()
+                    ->canSeeWhen('create', ExternalResourceModel::class),
+
+                (new AttachStudioResourceAction(ResourceSite::ANIME_PLANET()))
+                    ->confirmButtonText(__('nova.actions.models.wiki.attach_resource.confirmButtonText'))
+                    ->cancelButtonText(__('nova.actions.base.cancelButtonText'))
+                    ->exceptOnIndex()
+                    ->canSeeWhen('create', ExternalResourceModel::class),
+
+                (new AttachStudioResourceAction(ResourceSite::ANN()))
+                    ->confirmButtonText(__('nova.actions.models.wiki.attach_resource.confirmButtonText'))
+                    ->cancelButtonText(__('nova.actions.base.cancelButtonText'))
+                    ->exceptOnIndex()
+                    ->canSeeWhen('create', ExternalResourceModel::class),
+
+                (new AttachStudioResourceAction(ResourceSite::MAL()))
+                    ->confirmButtonText(__('nova.actions.models.wiki.attach_resource.confirmButtonText'))
+                    ->cancelButtonText(__('nova.actions.base.cancelButtonText'))
+                    ->exceptOnIndex()
+                    ->canSeeWhen('create', ExternalResourceModel::class),
             ]
         );
     }


### PR DESCRIPTION
QoL update for new anime/artist/studio workflow. Rather than navigating away from the detail/index screen to attach a new resource, this can now be done inline or from the detail screen.