### PR TITLE
feat(api): initial support for aggregate fields

### DIFF
--- a/app/Enums/Http/Api/Filter/Clause.php
+++ b/app/Enums/Http/Api/Filter/Clause.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums\Http\Api\Filter;
+
+use App\Enums\BaseEnum;
+
+/**
+ * Class Clause.
+ *
+ * @method static static WHERE()
+ * @method static static HAVING()
+ */
+final class Clause extends BaseEnum
+{
+    public const WHERE = 0;
+    public const HAVING = 1;
+}

--- a/app/Enums/Http/Api/QualifyColumn.php
+++ b/app/Enums/Http/Api/QualifyColumn.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums\Http\Api;
+
+use App\Enums\BaseEnum;
+
+/**
+ * Class QualifyColumn.
+ *
+ * @method static static YES()
+ * @method static static NO()
+ */
+final class QualifyColumn extends BaseEnum
+{
+    public const YES = 0;
+    public const NO = 1;
+}

--- a/app/Http/Api/Criteria/Sort/FieldCriteria.php
+++ b/app/Http/Api/Criteria/Sort/FieldCriteria.php
@@ -45,6 +45,10 @@ class FieldCriteria extends Criteria
      */
     public function sort(Builder $builder, Sort $sort): Builder
     {
-        return $builder->orderBy($builder->qualifyColumn($sort->getColumn()), $this->direction->value);
+        $column = $sort->shouldQualifyColumn()
+            ? $builder->qualifyColumn($sort->getColumn())
+            : $sort->getColumn();
+
+        return $builder->orderBy($column, $this->direction->value);
     }
 }

--- a/app/Http/Api/Field/AggregateField.php
+++ b/app/Http/Api/Field/AggregateField.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Api\Field;
+
+use App\Contracts\Http\Api\Field\SortableField;
+use App\Enums\Http\Api\QualifyColumn;
+use App\Http\Api\Criteria\Field\Criteria;
+use App\Http\Api\Sort\Sort;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Class AggregateField.
+ */
+abstract class AggregateField extends Field implements SortableField
+{
+    /**
+     * Create a new field instance.
+     *
+     * @param  string  $key
+     */
+    public function __construct(string $key)
+    {
+        parent::__construct($key);
+    }
+
+    /**
+     * Get the sort that can be applied to the field.
+     *
+     * @return Sort
+     */
+    public function getSort(): Sort
+    {
+        return new Sort($this->getKey(), static::format($this->getKey()), QualifyColumn::NO());
+    }
+
+    /**
+     * Determine if the aggregate value should be included in the select clause of our query.
+     *
+     * @param  Criteria|null  $criteria
+     * @return bool
+     */
+    public function shouldAggregate(?Criteria $criteria): bool
+    {
+        return $criteria !== null && $criteria->isAllowedField($this->getKey());
+    }
+
+    /**
+     * Load the aggregate field value for the model.
+     *
+     * @param  Model  $model
+     * @return Model
+     */
+    abstract public function load(Model $model): Model;
+
+    /**
+     * Eager load the aggregate value for the query builder.
+     *
+     * @param  Builder  $builder
+     * @return Builder
+     */
+    abstract public function with(Builder $builder): Builder;
+
+    /**
+     * Format the aggregate value to its sub-select alias / model attribute.
+     *
+     * @param  string  $key
+     * @return string
+     */
+    abstract public static function format(string $key): string;
+}

--- a/app/Http/Api/Field/CountField.php
+++ b/app/Http/Api/Field/CountField.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Api\Field;
+
+use App\Contracts\Http\Api\Field\FilterableField;
+use App\Enums\Http\Api\Filter\Clause;
+use App\Enums\Http\Api\QualifyColumn;
+use App\Http\Api\Filter\Filter;
+use App\Http\Api\Filter\IntFilter;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+
+/**
+ * Class CountField.
+ */
+abstract class CountField extends AggregateField implements FilterableField
+{
+    /**
+     * Create a new field instance.
+     *
+     * @param  string  $key
+     */
+    public function __construct(string $key)
+    {
+        parent::__construct($key);
+    }
+
+    /**
+     * Get the filters that can be applied to the field.
+     *
+     * @return Filter
+     */
+    public function getFilter(): Filter
+    {
+        return new IntFilter($this->getKey(), static::format($this->getKey()), QualifyColumn::NO(), Clause::HAVING());
+    }
+
+    /**
+     * Load the aggregate field value for the model.
+     *
+     * @param  Model  $model
+     * @return Model
+     */
+    public function load(Model $model): Model
+    {
+        return $model->loadCount($this->getKey());
+    }
+
+    /**
+     * Eager load the aggregate value for the query builder.
+     *
+     * @param  Builder  $builder
+     * @return Builder
+     */
+    public function with(Builder $builder): Builder
+    {
+        return $builder->withCount($this->getKey());
+    }
+
+    /**
+     * Format the aggregate value to its sub-select alias / model attribute.
+     *
+     * @param  string  $key
+     * @return string
+     */
+    public static function format(string $key): string
+    {
+        return Str::of($key)
+            ->append('_count')
+            ->__toString();
+    }
+}

--- a/app/Http/Api/Field/Wiki/Video/VideoViewCountField.php
+++ b/app/Http/Api/Field/Wiki/Video/VideoViewCountField.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Api\Field\Wiki\Video;
+
+use App\Http\Api\Field\CountField;
+use App\Models\Wiki\Video;
+
+/**
+ * Class VideoViewCountField.
+ */
+class VideoViewCountField extends CountField
+{
+    /**
+     * Create a new field instance.
+     */
+    public function __construct()
+    {
+        parent::__construct(Video::RELATION_VIEWS);
+    }
+}

--- a/app/Http/Api/Filter/Filter.php
+++ b/app/Http/Api/Filter/Filter.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Http\Api\Filter;
 
+use App\Enums\Http\Api\Filter\Clause;
 use App\Enums\Http\Api\Filter\ComparisonOperator;
 use App\Enums\Http\Api\Filter\LogicalOperator;
+use App\Enums\Http\Api\QualifyColumn;
 use App\Http\Api\Criteria\Filter\Criteria;
 use Illuminate\Support\Str;
 
@@ -19,9 +21,15 @@ abstract class Filter
      *
      * @param  string  $key
      * @param  string|null  $column
+     * @param  QualifyColumn  $qualifyColumn
+     * @param  Clause  $clause
      */
-    public function __construct(protected readonly string $key, protected readonly ?string $column = null)
-    {
+    public function __construct(
+        protected readonly string $key,
+        protected readonly ?string $column = null,
+        protected readonly QualifyColumn $qualifyColumn = new QualifyColumn(QualifyColumn::YES),
+        protected readonly Clause $clause = new Clause(Clause::WHERE)
+    ) {
     }
 
     /**
@@ -42,6 +50,26 @@ abstract class Filter
     public function getColumn(): string
     {
         return $this->column ?? $this->key;
+    }
+
+    /**
+     * Determine if the column should be qualified for the filter.
+     *
+     * @return bool
+     */
+    public function shouldQualifyColumn(): bool
+    {
+        return QualifyColumn::YES()->is($this->qualifyColumn);
+    }
+
+    /**
+     * Get filter clause.
+     *
+     * @return Clause
+     */
+    public function clause(): Clause
+    {
+        return $this->clause;
     }
 
     /**

--- a/app/Http/Api/Schema/Wiki/VideoSchema.php
+++ b/app/Http/Api/Schema/Wiki/VideoSchema.php
@@ -21,6 +21,7 @@ use App\Http\Api\Field\Wiki\Video\VideoSourceField;
 use App\Http\Api\Field\Wiki\Video\VideoSubbedField;
 use App\Http\Api\Field\Wiki\Video\VideoTagsField;
 use App\Http\Api\Field\Wiki\Video\VideoUncenField;
+use App\Http\Api\Field\Wiki\Video\VideoViewCountField;
 use App\Http\Api\Include\AllowedInclude;
 use App\Http\Api\Schema\EloquentSchema;
 use App\Http\Api\Schema\Wiki\Anime\Theme\EntrySchema;
@@ -96,6 +97,7 @@ class VideoSchema extends EloquentSchema
                 new VideoUncenField(),
                 new VideoTagsField(),
                 new VideoLinkField(),
+                new VideoViewCountField(),
             ],
         );
     }

--- a/app/Http/Api/Sort/Sort.php
+++ b/app/Http/Api/Sort/Sort.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Api\Sort;
 
+use App\Enums\Http\Api\QualifyColumn;
 use App\Enums\Http\Api\Sort\Direction;
 
 /**
@@ -16,9 +17,13 @@ class Sort
      *
      * @param  string  $key
      * @param  string|null  $column
+     * @param  QualifyColumn  $qualifyColumn
      */
-    public function __construct(protected readonly string $key, protected readonly ?string $column = null)
-    {
+    public function __construct(
+        protected readonly string $key,
+        protected readonly ?string $column = null,
+        protected readonly QualifyColumn $qualifyColumn = new QualifyColumn(QualifyColumn::YES)
+    ) {
     }
 
     /**
@@ -39,6 +44,16 @@ class Sort
     public function getColumn(): string
     {
         return $this->column ?? $this->key;
+    }
+
+    /**
+     * Determine if the column should be qualified for the sort.
+     *
+     * @return bool
+     */
+    public function shouldQualifyColumn(): bool
+    {
+        return QualifyColumn::YES()->is($this->qualifyColumn);
     }
 
     /**

--- a/app/Http/Resources/BaseResource.php
+++ b/app/Http/Resources/BaseResource.php
@@ -30,12 +30,15 @@ abstract class BaseResource extends JsonResource
      * Determine if field should be included in the response for this resource.
      *
      * @param  string  $field
+     * @param  bool  $default
      * @return bool
      */
-    protected function isAllowedField(string $field): bool
+    protected function isAllowedField(string $field, bool $default = true): bool
     {
         $criteria = $this->query->getFieldCriteria(static::$wrap);
 
-        return $criteria === null || $criteria->isAllowedField($field);
+        return $criteria === null
+            ? $default
+            : $criteria->isAllowedField($field);
     }
 }

--- a/app/Http/Resources/Wiki/Resource/VideoResource.php
+++ b/app/Http/Resources/Wiki/Resource/VideoResource.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Resources\Wiki\Resource;
 
+use App\Http\Api\Field\CountField;
 use App\Http\Api\Query\ReadQuery;
 use App\Http\Resources\BaseResource;
 use App\Http\Resources\Wiki\Anime\Theme\Collection\EntryCollection;
@@ -123,6 +124,10 @@ class VideoResource extends BaseResource
 
         if ($this->isAllowedField(VideoResource::ATTRIBUTE_LINK)) {
             $result[VideoResource::ATTRIBUTE_LINK] = route('video.show', $this);
+        }
+
+        if ($this->isAllowedField(Video::RELATION_VIEWS, false)) {
+            $result[Video::RELATION_VIEWS] = $this->getAttribute(CountField::format(Video::RELATION_VIEWS));
         }
 
         $result[Video::RELATION_ANIMETHEMEENTRIES] = new EntryCollection($this->whenLoaded(Video::RELATION_ANIMETHEMEENTRIES), $this->query);

--- a/app/Models/Wiki/Video.php
+++ b/app/Models/Wiki/Video.php
@@ -86,6 +86,7 @@ class Video extends BaseModel implements Streamable, Viewable
     final public const RELATION_SCRIPT = 'videoscript';
     final public const RELATION_SONG = 'animethemeentries.animetheme.song';
     final public const RELATION_TRACKS = 'tracks';
+    final public const RELATION_VIEWS = 'views';
 
     /**
      * The attributes that are mass assignable.


### PR DESCRIPTION
Initial support for aggregate fields. Includes sparse fieldset, sorting & filtering support. However, the video views field is excluded by default. It might be explicitly included.

Unfortunately this required a lot of optional parameters, sry.