### PR TITLE
refactor(api): mark fields as renderable for display to the user with custom logic [incremental]

### DIFF
--- a/app/Contracts/Http/Api/Field/RenderableField.php
+++ b/app/Contracts/Http/Api/Field/RenderableField.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Contracts\Http\Api\Field;
+
+use App\Http\Api\Query\ReadQuery;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Interface RenderableField.
+ */
+interface RenderableField
+{
+    /**
+     * Determine if the field should be displayed to the user.
+     *
+     * @param  ReadQuery  $query
+     * @return bool
+     */
+    public function shouldRender(ReadQuery $query): bool;
+
+    /**
+     * Get the value to display to the user.
+     *
+     * @param  Model  $model
+     * @return mixed
+     */
+    public function render(Model $model): mixed;
+}

--- a/app/Http/Api/Field/Admin/Dump/DumpIdField.php
+++ b/app/Http/Api/Field/Admin/Dump/DumpIdField.php
@@ -2,27 +2,26 @@
 
 declare(strict_types=1);
 
-namespace App\Http\Api\Field\Base;
+namespace App\Http\Api\Field\Admin\Dump;
 
-use App\Http\Api\Field\IntField;
+use App\Http\Api\Field\Base\IdField;
 use App\Http\Api\Query\ReadQuery;
 use App\Http\Api\Schema\Schema;
-use App\Http\Resources\BaseResource;
+use App\Models\Admin\Dump;
 
 /**
- * Class IdField.
+ * Class DumpIdField.
  */
-class IdField extends IntField
+class DumpIdField extends IdField
 {
     /**
      * Create a new field instance.
      *
      * @param  Schema  $schema
-     * @param  string  $column
      */
-    public function __construct(Schema $schema, string $column)
+    public function __construct(Schema $schema)
     {
-        parent::__construct($schema, BaseResource::ATTRIBUTE_ID, $column);
+        parent::__construct($schema, Dump::ATTRIBUTE_ID);
     }
 
     /**
@@ -33,13 +32,13 @@ class IdField extends IntField
      */
     public function shouldSelect(ReadQuery $query): bool
     {
-        // We can only exclude ID fields for top-level models that are not including related resources.
         $includeCriteria = $query->getIncludeCriteria($this->schema->type());
+        $linkField = new DumpLinkField($this->schema);
         if (
             $this->schema->type() === $query->schema()->type()
             && ($includeCriteria === null || $includeCriteria->getPaths()->isEmpty())
         ) {
-            return parent::shouldSelect($query);
+            return parent::shouldSelect($query) || $linkField->shouldRender($query);
         }
 
         return true;

--- a/app/Http/Api/Field/Admin/Dump/DumpLinkField.php
+++ b/app/Http/Api/Field/Admin/Dump/DumpLinkField.php
@@ -4,14 +4,17 @@ declare(strict_types=1);
 
 namespace App\Http\Api\Field\Admin\Dump;
 
+use App\Contracts\Http\Api\Field\RenderableField;
 use App\Http\Api\Field\Field;
+use App\Http\Api\Query\ReadQuery;
 use App\Http\Api\Schema\Schema;
 use App\Http\Resources\Admin\Resource\DumpResource;
+use Illuminate\Database\Eloquent\Model;
 
 /**
  * Class DumpLinkField.
  */
-class DumpLinkField extends Field
+class DumpLinkField extends Field implements RenderableField
 {
     /**
      * Create a new field instance.
@@ -21,5 +24,29 @@ class DumpLinkField extends Field
     public function __construct(Schema $schema)
     {
         parent::__construct($schema, DumpResource::ATTRIBUTE_LINK);
+    }
+
+    /**
+     * Determine if the field should be displayed to the user.
+     *
+     * @param  ReadQuery  $query
+     * @return bool
+     */
+    public function shouldRender(ReadQuery $query): bool
+    {
+        $criteria = $query->getFieldCriteria($this->schema->type());
+
+        return $criteria === null || $criteria->isAllowedField($this->getKey());
+    }
+
+    /**
+     * Get the value to display to the user.
+     *
+     * @param  Model  $model
+     * @return string
+     */
+    public function render(Model $model): string
+    {
+        return route('dump.show', $model);
     }
 }

--- a/app/Http/Api/Field/AggregateField.php
+++ b/app/Http/Api/Field/AggregateField.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Api\Field;
 
 use App\Contracts\Http\Api\Field\FilterableField;
+use App\Contracts\Http\Api\Field\RenderableField;
 use App\Contracts\Http\Api\Field\SortableField;
 use App\Enums\Http\Api\QualifyColumn;
 use App\Http\Api\Query\ReadQuery;
@@ -17,7 +18,7 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * Class AggregateField.
  */
-abstract class AggregateField extends Field implements FilterableField, SortableField
+abstract class AggregateField extends Field implements FilterableField, RenderableField, SortableField
 {
     /**
      * Create a new field instance.
@@ -28,6 +29,30 @@ abstract class AggregateField extends Field implements FilterableField, Sortable
     public function __construct(Schema $schema, string $key)
     {
         parent::__construct($schema, $key);
+    }
+
+    /**
+     * Determine if the field should be displayed to the user.
+     *
+     * @param  ReadQuery  $query
+     * @return bool
+     */
+    public function shouldRender(ReadQuery $query): bool
+    {
+        $criteria = $query->getFieldCriteria($this->schema->type());
+
+        return $criteria !== null && $criteria->isAllowedField($this->getKey());
+    }
+
+    /**
+     * Get the value to display to the user.
+     *
+     * @param  Model  $model
+     * @return mixed
+     */
+    public function render(Model $model): mixed
+    {
+        return $model->getAttribute(static::format($this->getColumn()));
     }
 
     /**

--- a/app/Http/Api/Field/Base/CreatedAtField.php
+++ b/app/Http/Api/Field/Base/CreatedAtField.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Api\Field\Base;
 
 use App\Http\Api\Field\DateField;
+use App\Http\Api\Query\ReadQuery;
 use App\Http\Api\Schema\Schema;
 use App\Models\BaseModel;
 
@@ -21,5 +22,31 @@ class CreatedAtField extends DateField
     public function __construct(Schema $schema)
     {
         parent::__construct($schema, BaseModel::ATTRIBUTE_CREATED_AT);
+    }
+
+    /**
+     * Determine if the field should be displayed to the user.
+     *
+     * @param  ReadQuery  $query
+     * @return bool
+     */
+    public function shouldRender(ReadQuery $query): bool
+    {
+        $criteria = $query->getFieldCriteria($this->schema->type());
+
+        return $criteria !== null && $criteria->isAllowedField($this->getKey());
+    }
+
+    /**
+     * Determine if the field should be included in the select clause of our query.
+     *
+     * @param  ReadQuery  $query
+     * @return bool
+     */
+    public function shouldSelect(ReadQuery $query): bool
+    {
+        $criteria = $query->getFieldCriteria($this->schema->type());
+
+        return $criteria !== null && $criteria->isAllowedField($this->getKey());
     }
 }

--- a/app/Http/Api/Field/Base/DeletedAtField.php
+++ b/app/Http/Api/Field/Base/DeletedAtField.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Api\Field\Base;
 
 use App\Http\Api\Field\DateField;
+use App\Http\Api\Query\ReadQuery;
 use App\Http\Api\Schema\Schema;
 use App\Models\BaseModel;
 
@@ -21,5 +22,31 @@ class DeletedAtField extends DateField
     public function __construct(Schema $schema)
     {
         parent::__construct($schema, BaseModel::ATTRIBUTE_DELETED_AT);
+    }
+
+    /**
+     * Determine if the field should be displayed to the user.
+     *
+     * @param  ReadQuery  $query
+     * @return bool
+     */
+    public function shouldRender(ReadQuery $query): bool
+    {
+        $criteria = $query->getFieldCriteria($this->schema->type());
+
+        return $criteria !== null && $criteria->isAllowedField($this->getKey());
+    }
+
+    /**
+     * Determine if the field should be included in the select clause of our query.
+     *
+     * @param  ReadQuery  $query
+     * @return bool
+     */
+    public function shouldSelect(ReadQuery $query): bool
+    {
+        $criteria = $query->getFieldCriteria($this->schema->type());
+
+        return $criteria !== null && $criteria->isAllowedField($this->getKey());
     }
 }

--- a/app/Http/Api/Field/Base/UpdatedAtField.php
+++ b/app/Http/Api/Field/Base/UpdatedAtField.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Api\Field\Base;
 
 use App\Http\Api\Field\DateField;
+use App\Http\Api\Query\ReadQuery;
 use App\Http\Api\Schema\Schema;
 use App\Models\BaseModel;
 
@@ -21,5 +22,31 @@ class UpdatedAtField extends DateField
     public function __construct(Schema $schema)
     {
         parent::__construct($schema, BaseModel::ATTRIBUTE_UPDATED_AT);
+    }
+
+    /**
+     * Determine if the field should be displayed to the user.
+     *
+     * @param  ReadQuery  $query
+     * @return bool
+     */
+    public function shouldRender(ReadQuery $query): bool
+    {
+        $criteria = $query->getFieldCriteria($this->schema->type());
+
+        return $criteria !== null && $criteria->isAllowedField($this->getKey());
+    }
+
+    /**
+     * Determine if the field should be included in the select clause of our query.
+     *
+     * @param  ReadQuery  $query
+     * @return bool
+     */
+    public function shouldSelect(ReadQuery $query): bool
+    {
+        $criteria = $query->getFieldCriteria($this->schema->type());
+
+        return $criteria !== null && $criteria->isAllowedField($this->getKey());
     }
 }

--- a/app/Http/Api/Field/BooleanField.php
+++ b/app/Http/Api/Field/BooleanField.php
@@ -5,17 +5,19 @@ declare(strict_types=1);
 namespace App\Http\Api\Field;
 
 use App\Contracts\Http\Api\Field\FilterableField;
+use App\Contracts\Http\Api\Field\RenderableField;
 use App\Contracts\Http\Api\Field\SelectableField;
 use App\Contracts\Http\Api\Field\SortableField;
 use App\Http\Api\Filter\BooleanFilter;
 use App\Http\Api\Filter\Filter;
 use App\Http\Api\Query\ReadQuery;
 use App\Http\Api\Sort\Sort;
+use Illuminate\Database\Eloquent\Model;
 
 /**
  * Class BooleanField.
  */
-abstract class BooleanField extends Field implements FilterableField, SelectableField, SortableField
+abstract class BooleanField extends Field implements FilterableField, RenderableField, SelectableField, SortableField
 {
     /**
      * Get the filter that can be applied to the field.
@@ -25,6 +27,30 @@ abstract class BooleanField extends Field implements FilterableField, Selectable
     public function getFilter(): Filter
     {
         return new BooleanFilter($this->getKey(), $this->getColumn());
+    }
+
+    /**
+     * Determine if the field should be displayed to the user.
+     *
+     * @param  ReadQuery  $query
+     * @return bool
+     */
+    public function shouldRender(ReadQuery $query): bool
+    {
+        $criteria = $query->getFieldCriteria($this->schema->type());
+
+        return $criteria === null || $criteria->isAllowedField($this->getKey());
+    }
+
+    /**
+     * Get the value to display to the user.
+     *
+     * @param  Model  $model
+     * @return mixed
+     */
+    public function render(Model $model): mixed
+    {
+        return $model->getAttribute($this->getColumn());
     }
 
     /**

--- a/app/Http/Api/Field/DateField.php
+++ b/app/Http/Api/Field/DateField.php
@@ -5,17 +5,19 @@ declare(strict_types=1);
 namespace App\Http\Api\Field;
 
 use App\Contracts\Http\Api\Field\FilterableField;
+use App\Contracts\Http\Api\Field\RenderableField;
 use App\Contracts\Http\Api\Field\SelectableField;
 use App\Contracts\Http\Api\Field\SortableField;
 use App\Http\Api\Filter\DateFilter;
 use App\Http\Api\Filter\Filter;
 use App\Http\Api\Query\ReadQuery;
 use App\Http\Api\Sort\Sort;
+use Illuminate\Database\Eloquent\Model;
 
 /**
  * Class DateField.
  */
-abstract class DateField extends Field implements FilterableField, SelectableField, SortableField
+abstract class DateField extends Field implements FilterableField, RenderableField, SelectableField, SortableField
 {
     /**
      * Get the filter that can be applied to the field.
@@ -25,6 +27,30 @@ abstract class DateField extends Field implements FilterableField, SelectableFie
     public function getFilter(): Filter
     {
         return new DateFilter($this->getKey(), $this->getColumn());
+    }
+
+    /**
+     * Determine if the field should be displayed to the user.
+     *
+     * @param  ReadQuery  $query
+     * @return bool
+     */
+    public function shouldRender(ReadQuery $query): bool
+    {
+        $criteria = $query->getFieldCriteria($this->schema->type());
+
+        return $criteria === null || $criteria->isAllowedField($this->getKey());
+    }
+
+    /**
+     * Get the value to display to the user.
+     *
+     * @param  Model  $model
+     * @return mixed
+     */
+    public function render(Model $model): mixed
+    {
+        return $model->getAttribute($this->getColumn());
     }
 
     /**

--- a/app/Http/Api/Field/Document/Page/PageBodyField.php
+++ b/app/Http/Api/Field/Document/Page/PageBodyField.php
@@ -5,18 +5,20 @@ declare(strict_types=1);
 namespace App\Http\Api\Field\Document\Page;
 
 use App\Contracts\Http\Api\Field\CreatableField;
+use App\Contracts\Http\Api\Field\RenderableField;
 use App\Contracts\Http\Api\Field\SelectableField;
 use App\Contracts\Http\Api\Field\UpdatableField;
 use App\Http\Api\Field\Field;
 use App\Http\Api\Query\ReadQuery;
 use App\Http\Api\Schema\Schema;
 use App\Models\Document\Page;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 
 /**
  * Class PageBodyField.
  */
-class PageBodyField extends Field implements CreatableField, SelectableField, UpdatableField
+class PageBodyField extends Field implements CreatableField, RenderableField, SelectableField, UpdatableField
 {
     /**
      * Create a new field instance.
@@ -44,6 +46,30 @@ class PageBodyField extends Field implements CreatableField, SelectableField, Up
     }
 
     /**
+     * Determine if the field should be displayed to the user.
+     *
+     * @param  ReadQuery  $query
+     * @return bool
+     */
+    public function shouldRender(ReadQuery $query): bool
+    {
+        $criteria = $query->getFieldCriteria($this->schema->type());
+
+        return $criteria !== null && $criteria->isAllowedField($this->getKey());
+    }
+
+    /**
+     * Get the value to display to the user.
+     *
+     * @param  Model  $model
+     * @return mixed
+     */
+    public function render(Model $model): mixed
+    {
+        return $model->getAttribute($this->getColumn());
+    }
+
+    /**
      * Determine if the field should be included in the select clause of our query.
      *
      * @param  ReadQuery  $query
@@ -53,8 +79,7 @@ class PageBodyField extends Field implements CreatableField, SelectableField, Up
     {
         $criteria = $query->getFieldCriteria($this->schema->type());
 
-        // TODO: Only return this attribute if specified due to potential size.
-        return $criteria === null || $criteria->isAllowedField($this->getKey());
+        return $criteria !== null && $criteria->isAllowedField($this->getKey());
     }
 
     /**

--- a/app/Http/Api/Field/FloatField.php
+++ b/app/Http/Api/Field/FloatField.php
@@ -5,17 +5,19 @@ declare(strict_types=1);
 namespace App\Http\Api\Field;
 
 use App\Contracts\Http\Api\Field\FilterableField;
+use App\Contracts\Http\Api\Field\RenderableField;
 use App\Contracts\Http\Api\Field\SelectableField;
 use App\Contracts\Http\Api\Field\SortableField;
 use App\Http\Api\Filter\Filter;
 use App\Http\Api\Filter\FloatFilter;
 use App\Http\Api\Query\ReadQuery;
 use App\Http\Api\Sort\Sort;
+use Illuminate\Database\Eloquent\Model;
 
 /**
  * Class FloatField.
  */
-abstract class FloatField extends Field implements FilterableField, SelectableField, SortableField
+abstract class FloatField extends Field implements FilterableField, RenderableField, SelectableField, SortableField
 {
     /**
      * Get the filter that can be applied to the field.
@@ -25,6 +27,30 @@ abstract class FloatField extends Field implements FilterableField, SelectableFi
     public function getFilter(): Filter
     {
         return new FloatFilter($this->getKey(), $this->getColumn());
+    }
+
+    /**
+     * Determine if the field should be displayed to the user.
+     *
+     * @param  ReadQuery  $query
+     * @return bool
+     */
+    public function shouldRender(ReadQuery $query): bool
+    {
+        $criteria = $query->getFieldCriteria($this->schema->type());
+
+        return $criteria === null || $criteria->isAllowedField($this->getKey());
+    }
+
+    /**
+     * Get the value to display to the user.
+     *
+     * @param  Model  $model
+     * @return mixed
+     */
+    public function render(Model $model): mixed
+    {
+        return $model->getAttribute($this->getColumn());
     }
 
     /**

--- a/app/Http/Api/Field/IntField.php
+++ b/app/Http/Api/Field/IntField.php
@@ -5,17 +5,19 @@ declare(strict_types=1);
 namespace App\Http\Api\Field;
 
 use App\Contracts\Http\Api\Field\FilterableField;
+use App\Contracts\Http\Api\Field\RenderableField;
 use App\Contracts\Http\Api\Field\SelectableField;
 use App\Contracts\Http\Api\Field\SortableField;
 use App\Http\Api\Filter\Filter;
 use App\Http\Api\Filter\IntFilter;
 use App\Http\Api\Query\ReadQuery;
 use App\Http\Api\Sort\Sort;
+use Illuminate\Database\Eloquent\Model;
 
 /**
  * Class IntField.
  */
-abstract class IntField extends Field implements FilterableField, SelectableField, SortableField
+abstract class IntField extends Field implements FilterableField, RenderableField, SelectableField, SortableField
 {
     /**
      * Get the filter that can be applied to the field.
@@ -25,6 +27,30 @@ abstract class IntField extends Field implements FilterableField, SelectableFiel
     public function getFilter(): Filter
     {
         return new IntFilter($this->getKey(), $this->getColumn());
+    }
+
+    /**
+     * Determine if the field should be displayed to the user.
+     *
+     * @param  ReadQuery  $query
+     * @return bool
+     */
+    public function shouldRender(ReadQuery $query): bool
+    {
+        $criteria = $query->getFieldCriteria($this->schema->type());
+
+        return $criteria === null || $criteria->isAllowedField($this->getKey());
+    }
+
+    /**
+     * Get the value to display to the user.
+     *
+     * @param  Model  $model
+     * @return mixed
+     */
+    public function render(Model $model): mixed
+    {
+        return $model->getAttribute($this->getColumn());
     }
 
     /**

--- a/app/Http/Api/Field/Pivot/Wiki/AnimeThemeEntryVideo/AnimeThemeEntryVideoEntryIdField.php
+++ b/app/Http/Api/Field/Pivot/Wiki/AnimeThemeEntryVideo/AnimeThemeEntryVideoEntryIdField.php
@@ -2,19 +2,22 @@
 
 declare(strict_types=1);
 
-namespace App\Http\Api\Field\Wiki\Video;
+namespace App\Http\Api\Field\Pivot\Wiki\AnimeThemeEntryVideo;
 
 use App\Contracts\Http\Api\Field\CreatableField;
-use App\Http\Api\Field\StringField;
+use App\Contracts\Http\Api\Field\SelectableField;
+use App\Http\Api\Field\Field;
 use App\Http\Api\Query\ReadQuery;
 use App\Http\Api\Schema\Schema;
-use App\Models\Wiki\Video;
+use App\Models\Wiki\Anime\Theme\AnimeThemeEntry;
+use App\Pivots\Wiki\AnimeThemeEntryVideo;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 
 /**
- * Class VideoBasenameField.
+ * Class AnimeThemeEntryVideoEntryIdField.
  */
-class VideoBasenameField extends StringField implements CreatableField
+class AnimeThemeEntryVideoEntryIdField extends Field implements CreatableField, SelectableField
 {
     /**
      * Create a new field instance.
@@ -23,7 +26,7 @@ class VideoBasenameField extends StringField implements CreatableField
      */
     public function __construct(Schema $schema)
     {
-        parent::__construct($schema, Video::ATTRIBUTE_BASENAME);
+        parent::__construct($schema, AnimeThemeEntryVideo::ATTRIBUTE_ENTRY);
     }
 
     /**
@@ -36,8 +39,8 @@ class VideoBasenameField extends StringField implements CreatableField
     {
         return [
             'required',
-            'string',
-            'max:192',
+            'integer',
+            Rule::exists(AnimeThemeEntry::TABLE, AnimeThemeEntry::ATTRIBUTE_ID),
         ];
     }
 
@@ -49,9 +52,7 @@ class VideoBasenameField extends StringField implements CreatableField
      */
     public function shouldSelect(ReadQuery $query): bool
     {
-        $linkField = new VideoLinkField($this->schema);
-
-        // The link field is dependent on this field to build the route.
-        return parent::shouldSelect($query) || $linkField->shouldRender($query);
+        // Needed to match entry relation.
+        return true;
     }
 }

--- a/app/Http/Api/Field/Pivot/Wiki/AnimeThemeEntryVideo/AnimeThemeEntryVideoVideoIdField.php
+++ b/app/Http/Api/Field/Pivot/Wiki/AnimeThemeEntryVideo/AnimeThemeEntryVideoVideoIdField.php
@@ -2,20 +2,22 @@
 
 declare(strict_types=1);
 
-namespace App\Http\Api\Field\Wiki\Video;
+namespace App\Http\Api\Field\Pivot\Wiki\AnimeThemeEntryVideo;
 
 use App\Contracts\Http\Api\Field\CreatableField;
-use App\Contracts\Http\Api\Field\UpdatableField;
-use App\Http\Api\Field\BooleanField;
+use App\Contracts\Http\Api\Field\SelectableField;
+use App\Http\Api\Field\Field;
 use App\Http\Api\Query\ReadQuery;
 use App\Http\Api\Schema\Schema;
 use App\Models\Wiki\Video;
+use App\Pivots\Wiki\AnimeThemeEntryVideo;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 
 /**
- * Class VideoLyricsField.
+ * Class AnimeThemeEntryVideoVideoIdField.
  */
-class VideoLyricsField extends BooleanField implements CreatableField, UpdatableField
+class AnimeThemeEntryVideoVideoIdField extends Field implements CreatableField, SelectableField
 {
     /**
      * Create a new field instance.
@@ -24,7 +26,7 @@ class VideoLyricsField extends BooleanField implements CreatableField, Updatable
      */
     public function __construct(Schema $schema)
     {
-        parent::__construct($schema, Video::ATTRIBUTE_LYRICS);
+        parent::__construct($schema, AnimeThemeEntryVideo::ATTRIBUTE_VIDEO);
     }
 
     /**
@@ -36,9 +38,9 @@ class VideoLyricsField extends BooleanField implements CreatableField, Updatable
     public function getCreationRules(Request $request): array
     {
         return [
-            'sometimes',
             'required',
-            'boolean',
+            'integer',
+            Rule::exists(Video::TABLE, Video::ATTRIBUTE_ID),
         ];
     }
 
@@ -50,24 +52,7 @@ class VideoLyricsField extends BooleanField implements CreatableField, Updatable
      */
     public function shouldSelect(ReadQuery $query): bool
     {
-        $tagsField = new VideoTagsField($this->schema);
-
-        // The tags attribute is dependent on this field.
-        return parent::shouldSelect($query) || $tagsField->shouldRender($query);
-    }
-
-    /**
-     * Set the update validation rules for the field.
-     *
-     * @param  Request  $request
-     * @return array
-     */
-    public function getUpdateRules(Request $request): array
-    {
-        return [
-            'sometimes',
-            'required',
-            'boolean',
-        ];
+        // Needed to match entry relation.
+        return true;
     }
 }

--- a/app/Http/Api/Field/StringField.php
+++ b/app/Http/Api/Field/StringField.php
@@ -5,17 +5,19 @@ declare(strict_types=1);
 namespace App\Http\Api\Field;
 
 use App\Contracts\Http\Api\Field\FilterableField;
+use App\Contracts\Http\Api\Field\RenderableField;
 use App\Contracts\Http\Api\Field\SelectableField;
 use App\Contracts\Http\Api\Field\SortableField;
 use App\Http\Api\Filter\Filter;
 use App\Http\Api\Filter\StringFilter;
 use App\Http\Api\Query\ReadQuery;
 use App\Http\Api\Sort\Sort;
+use Illuminate\Database\Eloquent\Model;
 
 /**
  * Class StringField.
  */
-abstract class StringField extends Field implements FilterableField, SelectableField, SortableField
+abstract class StringField extends Field implements FilterableField, RenderableField, SelectableField, SortableField
 {
     /**
      * Get the filter that can be applied to the field.
@@ -25,6 +27,30 @@ abstract class StringField extends Field implements FilterableField, SelectableF
     public function getFilter(): Filter
     {
         return new StringFilter($this->getKey(), $this->getColumn());
+    }
+
+    /**
+     * Determine if the field should be displayed to the user.
+     *
+     * @param  ReadQuery  $query
+     * @return bool
+     */
+    public function shouldRender(ReadQuery $query): bool
+    {
+        $criteria = $query->getFieldCriteria($this->schema->type());
+
+        return $criteria === null || $criteria->isAllowedField($this->getKey());
+    }
+
+    /**
+     * Get the value to display to the user.
+     *
+     * @param  Model  $model
+     * @return mixed
+     */
+    public function render(Model $model): mixed
+    {
+        return $model->getAttribute($this->getColumn());
     }
 
     /**

--- a/app/Http/Api/Field/Wiki/Audio/AudioBasenameField.php
+++ b/app/Http/Api/Field/Wiki/Audio/AudioBasenameField.php
@@ -8,7 +8,6 @@ use App\Contracts\Http\Api\Field\CreatableField;
 use App\Http\Api\Field\StringField;
 use App\Http\Api\Query\ReadQuery;
 use App\Http\Api\Schema\Schema;
-use App\Http\Resources\Wiki\Resource\AudioResource;
 use App\Models\Wiki\Audio;
 use Illuminate\Http\Request;
 
@@ -50,9 +49,9 @@ class AudioBasenameField extends StringField implements CreatableField
      */
     public function shouldSelect(ReadQuery $query): bool
     {
-        $criteria = $query->getFieldCriteria($this->schema->type());
+        $linkField = new AudioLinkField($this->schema);
 
         // The link field is dependent on this field to build the route.
-        return parent::shouldSelect($query) || $criteria->isAllowedField(AudioResource::ATTRIBUTE_LINK);
+        return parent::shouldSelect($query) || $linkField->shouldRender($query);
     }
 }

--- a/app/Http/Api/Field/Wiki/Audio/AudioLinkField.php
+++ b/app/Http/Api/Field/Wiki/Audio/AudioLinkField.php
@@ -4,14 +4,17 @@ declare(strict_types=1);
 
 namespace App\Http\Api\Field\Wiki\Audio;
 
+use App\Contracts\Http\Api\Field\RenderableField;
 use App\Http\Api\Field\Field;
+use App\Http\Api\Query\ReadQuery;
 use App\Http\Api\Schema\Schema;
 use App\Http\Resources\Wiki\Resource\AudioResource;
+use Illuminate\Database\Eloquent\Model;
 
 /**
  * Class AudioLinkField.
  */
-class AudioLinkField extends Field
+class AudioLinkField extends Field implements RenderableField
 {
     /**
      * Create a new field instance.
@@ -21,5 +24,29 @@ class AudioLinkField extends Field
     public function __construct(Schema $schema)
     {
         parent::__construct($schema, AudioResource::ATTRIBUTE_LINK);
+    }
+
+    /**
+     * Determine if the field should be displayed to the user.
+     *
+     * @param  ReadQuery  $query
+     * @return bool
+     */
+    public function shouldRender(ReadQuery $query): bool
+    {
+        $criteria = $query->getFieldCriteria($this->schema->type());
+
+        return $criteria === null || $criteria->isAllowedField($this->getKey());
+    }
+
+    /**
+     * Get the value to display to the user.
+     *
+     * @param  Model  $model
+     * @return string
+     */
+    public function render(Model $model): string
+    {
+        return route('audio.show', $model);
     }
 }

--- a/app/Http/Api/Field/Wiki/Audio/AudioMimeTypeField.php
+++ b/app/Http/Api/Field/Wiki/Audio/AudioMimeTypeField.php
@@ -6,6 +6,7 @@ namespace App\Http\Api\Field\Wiki\Audio;
 
 use App\Contracts\Http\Api\Field\CreatableField;
 use App\Http\Api\Field\StringField;
+use App\Http\Api\Query\ReadQuery;
 use App\Http\Api\Schema\Schema;
 use App\Models\Wiki\Audio;
 use Illuminate\Http\Request;
@@ -38,5 +39,31 @@ class AudioMimeTypeField extends StringField implements CreatableField
             'string',
             'max:192',
         ];
+    }
+
+    /**
+     * Determine if the field should be displayed to the user.
+     *
+     * @param  ReadQuery  $query
+     * @return bool
+     */
+    public function shouldRender(ReadQuery $query): bool
+    {
+        $criteria = $query->getFieldCriteria($this->schema->type());
+
+        return $criteria !== null && $criteria->isAllowedField($this->getKey());
+    }
+
+    /**
+     * Determine if the field should be included in the select clause of our query.
+     *
+     * @param  ReadQuery  $query
+     * @return bool
+     */
+    public function shouldSelect(ReadQuery $query): bool
+    {
+        $criteria = $query->getFieldCriteria($this->schema->type());
+
+        return $criteria !== null && $criteria->isAllowedField($this->getKey());
     }
 }

--- a/app/Http/Api/Field/Wiki/Image/ImageIdField.php
+++ b/app/Http/Api/Field/Wiki/Image/ImageIdField.php
@@ -2,27 +2,26 @@
 
 declare(strict_types=1);
 
-namespace App\Http\Api\Field\Base;
+namespace App\Http\Api\Field\Wiki\Image;
 
-use App\Http\Api\Field\IntField;
+use App\Http\Api\Field\Base\IdField;
 use App\Http\Api\Query\ReadQuery;
 use App\Http\Api\Schema\Schema;
-use App\Http\Resources\BaseResource;
+use App\Models\Wiki\Image;
 
 /**
- * Class IdField.
+ * Class ImageIdField.
  */
-class IdField extends IntField
+class ImageIdField extends IdField
 {
     /**
      * Create a new field instance.
      *
      * @param  Schema  $schema
-     * @param  string  $column
      */
-    public function __construct(Schema $schema, string $column)
+    public function __construct(Schema $schema)
     {
-        parent::__construct($schema, BaseResource::ATTRIBUTE_ID, $column);
+        parent::__construct($schema, Image::ATTRIBUTE_ID);
     }
 
     /**
@@ -33,13 +32,13 @@ class IdField extends IntField
      */
     public function shouldSelect(ReadQuery $query): bool
     {
-        // We can only exclude ID fields for top-level models that are not including related resources.
         $includeCriteria = $query->getIncludeCriteria($this->schema->type());
+        $linkField = new ImageLinkField($this->schema);
         if (
             $this->schema->type() === $query->schema()->type()
             && ($includeCriteria === null || $includeCriteria->getPaths()->isEmpty())
         ) {
-            return parent::shouldSelect($query);
+            return parent::shouldSelect($query) || $linkField->shouldRender($query);
         }
 
         return true;

--- a/app/Http/Api/Field/Wiki/Image/ImageLinkField.php
+++ b/app/Http/Api/Field/Wiki/Image/ImageLinkField.php
@@ -4,14 +4,20 @@ declare(strict_types=1);
 
 namespace App\Http\Api\Field\Wiki\Image;
 
+use App\Contracts\Http\Api\Field\RenderableField;
 use App\Http\Api\Field\Field;
+use App\Http\Api\Query\ReadQuery;
 use App\Http\Api\Schema\Schema;
 use App\Http\Resources\Wiki\Resource\ImageResource;
+use App\Models\Wiki\Image;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Storage;
 
 /**
  * Class ImageLinkField.
  */
-class ImageLinkField extends Field
+class ImageLinkField extends Field implements RenderableField
 {
     /**
      * Create a new field instance.
@@ -21,5 +27,31 @@ class ImageLinkField extends Field
     public function __construct(Schema $schema)
     {
         parent::__construct($schema, ImageResource::ATTRIBUTE_LINK);
+    }
+
+    /**
+     * Determine if the field should be displayed to the user.
+     *
+     * @param  ReadQuery  $query
+     * @return bool
+     */
+    public function shouldRender(ReadQuery $query): bool
+    {
+        $criteria = $query->getFieldCriteria($this->schema->type());
+
+        return $criteria === null || $criteria->isAllowedField($this->getKey());
+    }
+
+    /**
+     * Get the value to display to the user.
+     *
+     * @param  Model  $model
+     * @return string
+     */
+    public function render(Model $model): string
+    {
+        $fs = Storage::disk(Config::get('image.disk'));
+
+        return $fs->url($model->getAttribute(Image::ATTRIBUTE_PATH));
     }
 }

--- a/app/Http/Api/Field/Wiki/Video/Script/ScriptIdField.php
+++ b/app/Http/Api/Field/Wiki/Video/Script/ScriptIdField.php
@@ -2,27 +2,26 @@
 
 declare(strict_types=1);
 
-namespace App\Http\Api\Field\Base;
+namespace App\Http\Api\Field\Wiki\Video\Script;
 
-use App\Http\Api\Field\IntField;
+use App\Http\Api\Field\Base\IdField;
 use App\Http\Api\Query\ReadQuery;
 use App\Http\Api\Schema\Schema;
-use App\Http\Resources\BaseResource;
+use App\Models\Wiki\Video\VideoScript;
 
 /**
- * Class IdField.
+ * Class ScriptIdField.
  */
-class IdField extends IntField
+class ScriptIdField extends IdField
 {
     /**
      * Create a new field instance.
      *
      * @param  Schema  $schema
-     * @param  string  $column
      */
-    public function __construct(Schema $schema, string $column)
+    public function __construct(Schema $schema)
     {
-        parent::__construct($schema, BaseResource::ATTRIBUTE_ID, $column);
+        parent::__construct($schema, VideoScript::ATTRIBUTE_ID);
     }
 
     /**
@@ -33,13 +32,13 @@ class IdField extends IntField
      */
     public function shouldSelect(ReadQuery $query): bool
     {
-        // We can only exclude ID fields for top-level models that are not including related resources.
         $includeCriteria = $query->getIncludeCriteria($this->schema->type());
+        $linkField = new ScriptLinkField($this->schema);
         if (
             $this->schema->type() === $query->schema()->type()
             && ($includeCriteria === null || $includeCriteria->getPaths()->isEmpty())
         ) {
-            return parent::shouldSelect($query);
+            return parent::shouldSelect($query) || $linkField->shouldRender($query);
         }
 
         return true;

--- a/app/Http/Api/Field/Wiki/Video/Script/ScriptLinkField.php
+++ b/app/Http/Api/Field/Wiki/Video/Script/ScriptLinkField.php
@@ -4,14 +4,17 @@ declare(strict_types=1);
 
 namespace App\Http\Api\Field\Wiki\Video\Script;
 
+use App\Contracts\Http\Api\Field\RenderableField;
 use App\Http\Api\Field\Field;
+use App\Http\Api\Query\ReadQuery;
 use App\Http\Api\Schema\Schema;
 use App\Http\Resources\Wiki\Video\Resource\ScriptResource;
+use Illuminate\Database\Eloquent\Model;
 
 /**
  * Class ScriptLinkField.
  */
-class ScriptLinkField extends Field
+class ScriptLinkField extends Field implements RenderableField
 {
     /**
      * Create a new field instance.
@@ -21,5 +24,29 @@ class ScriptLinkField extends Field
     public function __construct(Schema $schema)
     {
         parent::__construct($schema, ScriptResource::ATTRIBUTE_LINK);
+    }
+
+    /**
+     * Determine if the field should be displayed to the user.
+     *
+     * @param  ReadQuery  $query
+     * @return bool
+     */
+    public function shouldRender(ReadQuery $query): bool
+    {
+        $criteria = $query->getFieldCriteria($this->schema->type());
+
+        return $criteria === null || $criteria->isAllowedField($this->getKey());
+    }
+
+    /**
+     * Get the value to display to the user.
+     *
+     * @param  Model  $model
+     * @return string
+     */
+    public function render(Model $model): string
+    {
+        return route('videoscript.show', $model);
     }
 }

--- a/app/Http/Api/Field/Wiki/Video/VideoLinkField.php
+++ b/app/Http/Api/Field/Wiki/Video/VideoLinkField.php
@@ -4,14 +4,17 @@ declare(strict_types=1);
 
 namespace App\Http\Api\Field\Wiki\Video;
 
+use App\Contracts\Http\Api\Field\RenderableField;
 use App\Http\Api\Field\Field;
+use App\Http\Api\Query\ReadQuery;
 use App\Http\Api\Schema\Schema;
 use App\Http\Resources\Wiki\Resource\VideoResource;
+use Illuminate\Database\Eloquent\Model;
 
 /**
  * Class VideoLinkField.
  */
-class VideoLinkField extends Field
+class VideoLinkField extends Field implements RenderableField
 {
     /**
      * Create a new field instance.
@@ -21,5 +24,29 @@ class VideoLinkField extends Field
     public function __construct(Schema $schema)
     {
         parent::__construct($schema, VideoResource::ATTRIBUTE_LINK);
+    }
+
+    /**
+     * Determine if the field should be displayed to the user.
+     *
+     * @param  ReadQuery  $query
+     * @return bool
+     */
+    public function shouldRender(ReadQuery $query): bool
+    {
+        $criteria = $query->getFieldCriteria($this->schema->type());
+
+        return $criteria === null || $criteria->isAllowedField($this->getKey());
+    }
+
+    /**
+     * Get the value to display to the user.
+     *
+     * @param  Model  $model
+     * @return string
+     */
+    public function render(Model $model): string
+    {
+        return route('video.show', $model);
     }
 }

--- a/app/Http/Api/Field/Wiki/Video/VideoMimeTypeField.php
+++ b/app/Http/Api/Field/Wiki/Video/VideoMimeTypeField.php
@@ -18,6 +18,7 @@ class VideoMimeTypeField extends StringField implements CreatableField
 {
     /**
      * Create a new field instance.
+     *
      * @param  Schema  $schema
      */
     public function __construct(Schema $schema)

--- a/app/Http/Api/Field/Wiki/Video/VideoMimeTypeField.php
+++ b/app/Http/Api/Field/Wiki/Video/VideoMimeTypeField.php
@@ -6,6 +6,7 @@ namespace App\Http\Api\Field\Wiki\Video;
 
 use App\Contracts\Http\Api\Field\CreatableField;
 use App\Http\Api\Field\StringField;
+use App\Http\Api\Query\ReadQuery;
 use App\Http\Api\Schema\Schema;
 use App\Models\Wiki\Video;
 use Illuminate\Http\Request;
@@ -17,7 +18,6 @@ class VideoMimeTypeField extends StringField implements CreatableField
 {
     /**
      * Create a new field instance.
-     *
      * @param  Schema  $schema
      */
     public function __construct(Schema $schema)
@@ -38,5 +38,31 @@ class VideoMimeTypeField extends StringField implements CreatableField
             'string',
             'max:192',
         ];
+    }
+
+    /**
+     * Determine if the field should be displayed to the user.
+     *
+     * @param  ReadQuery  $query
+     * @return bool
+     */
+    public function shouldRender(ReadQuery $query): bool
+    {
+        $criteria = $query->getFieldCriteria($this->schema->type());
+
+        return $criteria !== null && $criteria->isAllowedField($this->getKey());
+    }
+
+    /**
+     * Determine if the field should be included in the select clause of our query.
+     *
+     * @param  ReadQuery  $query
+     * @return bool
+     */
+    public function shouldSelect(ReadQuery $query): bool
+    {
+        $criteria = $query->getFieldCriteria($this->schema->type());
+
+        return $criteria !== null && $criteria->isAllowedField($this->getKey());
     }
 }

--- a/app/Http/Api/Field/Wiki/Video/VideoNcField.php
+++ b/app/Http/Api/Field/Wiki/Video/VideoNcField.php
@@ -50,10 +50,10 @@ class VideoNcField extends BooleanField implements CreatableField, UpdatableFiel
      */
     public function shouldSelect(ReadQuery $query): bool
     {
-        $criteria = $query->getFieldCriteria($this->schema->type());
+        $tagsField = new VideoTagsField($this->schema);
 
         // The tags attribute is dependent on this field.
-        return parent::shouldSelect($query) || $criteria->isAllowedField(Video::ATTRIBUTE_TAGS);
+        return parent::shouldSelect($query) || $tagsField->shouldRender($query);
     }
 
     /**

--- a/app/Http/Api/Field/Wiki/Video/VideoResolutionField.php
+++ b/app/Http/Api/Field/Wiki/Video/VideoResolutionField.php
@@ -52,10 +52,10 @@ class VideoResolutionField extends IntField implements CreatableField, Updatable
      */
     public function shouldSelect(ReadQuery $query): bool
     {
-        $criteria = $query->getFieldCriteria($this->schema->type());
+        $tagsField = new VideoTagsField($this->schema);
 
         // The tags attribute is dependent on this field.
-        return parent::shouldSelect($query) || $criteria->isAllowedField(Video::ATTRIBUTE_TAGS);
+        return parent::shouldSelect($query) || $tagsField->shouldRender($query);
     }
 
     /**

--- a/app/Http/Api/Field/Wiki/Video/VideoSourceField.php
+++ b/app/Http/Api/Field/Wiki/Video/VideoSourceField.php
@@ -52,10 +52,10 @@ class VideoSourceField extends EnumField implements CreatableField, UpdatableFie
      */
     public function shouldSelect(ReadQuery $query): bool
     {
-        $criteria = $query->getFieldCriteria($this->schema->type());
+        $tagsField = new VideoTagsField($this->schema);
 
         // The tags attribute is dependent on this field.
-        return parent::shouldSelect($query) || $criteria->isAllowedField(Video::ATTRIBUTE_TAGS);
+        return parent::shouldSelect($query) || $tagsField->shouldRender($query);
     }
 
     /**

--- a/app/Http/Api/Field/Wiki/Video/VideoSubbedField.php
+++ b/app/Http/Api/Field/Wiki/Video/VideoSubbedField.php
@@ -50,10 +50,10 @@ class VideoSubbedField extends BooleanField implements CreatableField, Updatable
      */
     public function shouldSelect(ReadQuery $query): bool
     {
-        $criteria = $query->getFieldCriteria($this->schema->type());
+        $tagsField = new VideoTagsField($this->schema);
 
         // The tags attribute is dependent on this field.
-        return parent::shouldSelect($query) || $criteria->isAllowedField(Video::ATTRIBUTE_TAGS);
+        return parent::shouldSelect($query) || $tagsField->shouldRender($query);
     }
 
     /**

--- a/app/Http/Api/Field/Wiki/Video/VideoTagsField.php
+++ b/app/Http/Api/Field/Wiki/Video/VideoTagsField.php
@@ -4,14 +4,17 @@ declare(strict_types=1);
 
 namespace App\Http\Api\Field\Wiki\Video;
 
+use App\Contracts\Http\Api\Field\RenderableField;
 use App\Http\Api\Field\Field;
+use App\Http\Api\Query\ReadQuery;
 use App\Http\Api\Schema\Schema;
 use App\Models\Wiki\Video;
+use Illuminate\Database\Eloquent\Model;
 
 /**
  * Class VideoTagsField.
  */
-class VideoTagsField extends Field
+class VideoTagsField extends Field implements RenderableField
 {
     /**
      * Create a new field instance.
@@ -21,5 +24,29 @@ class VideoTagsField extends Field
     public function __construct(Schema $schema)
     {
         parent::__construct($schema, Video::ATTRIBUTE_TAGS);
+    }
+
+    /**
+     * Determine if the field should be displayed to the user.
+     *
+     * @param  ReadQuery  $query
+     * @return bool
+     */
+    public function shouldRender(ReadQuery $query): bool
+    {
+        $criteria = $query->getFieldCriteria($this->schema->type());
+
+        return $criteria === null || $criteria->isAllowedField($this->getKey());
+    }
+
+    /**
+     * Get the value to display to the user.
+     *
+     * @param  Model  $model
+     * @return mixed
+     */
+    public function render(Model $model): mixed
+    {
+        return $model->getAttribute($this->getColumn());
     }
 }

--- a/app/Http/Api/Query/Base/EloquentReadQuery.php
+++ b/app/Http/Api/Query/Base/EloquentReadQuery.php
@@ -42,7 +42,6 @@ abstract class EloquentReadQuery extends ReadQuery
         $model->load($this->constrainEagerLoads());
 
         // Load aggregate relation values
-        $fieldCriteria = $this->getFieldCriteria($schema->type());
         collect($schema->fields())
             ->filter(fn (Field $field) => $field instanceof AggregateField && $field->shouldAggregate($this))
             ->each(fn (AggregateField $selectedAggregate) => $selectedAggregate->load($model));
@@ -66,7 +65,6 @@ abstract class EloquentReadQuery extends ReadQuery
         $builder->with($this->constrainEagerLoads());
 
         // select fields
-        $fieldCriteria = $this->getFieldCriteria($schema->type());
         $selectedFields = collect($schema->fields())
             ->filter(fn (Field $field) => $field instanceof SelectableField && $field->shouldSelect($this))
             ->map(fn (Field $field) => $field->getColumn());
@@ -143,7 +141,6 @@ abstract class EloquentReadQuery extends ReadQuery
                 $relationBuilder = $relation->getQuery();
 
                 // select fields
-                $fieldCriteria = $this->getFieldCriteria($relationSchema->type());
                 $selectedFields = collect($relationSchema->fields())
                     ->filter(fn (Field $field) => $field instanceof SelectableField && $field->shouldSelect($this))
                     ->map(fn (Field $field) => $field->getColumn());

--- a/app/Http/Api/Schema/Admin/DumpSchema.php
+++ b/app/Http/Api/Schema/Admin/DumpSchema.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\Http\Api\Schema\Admin;
 
+use App\Http\Api\Field\Admin\Dump\DumpIdField;
 use App\Http\Api\Field\Admin\Dump\DumpLinkField;
 use App\Http\Api\Field\Admin\Dump\DumpPathField;
-use App\Http\Api\Field\Base\IdField;
 use App\Http\Api\Field\Field;
 use App\Http\Api\Include\AllowedInclude;
 use App\Http\Api\Schema\EloquentSchema;
@@ -58,7 +58,7 @@ class DumpSchema extends EloquentSchema
         return array_merge(
             parent::fields(),
             [
-                new IdField($this, Dump::ATTRIBUTE_ID),
+                new DumpIdField($this),
                 new DumpPathField($this),
                 new DumpLinkField($this),
             ],

--- a/app/Http/Api/Schema/Pivot/Wiki/AnimeThemeEntryVideoSchema.php
+++ b/app/Http/Api/Schema/Pivot/Wiki/AnimeThemeEntryVideoSchema.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Api\Schema\Pivot\Wiki;
+
+use App\Http\Api\Field\Base\CreatedAtField;
+use App\Http\Api\Field\Base\UpdatedAtField;
+use App\Http\Api\Field\Field;
+use App\Http\Api\Field\Pivot\Wiki\AnimeThemeEntryVideo\AnimeThemeEntryVideoEntryIdField;
+use App\Http\Api\Field\Pivot\Wiki\AnimeThemeEntryVideo\AnimeThemeEntryVideoVideoIdField;
+use App\Http\Api\Include\AllowedInclude;
+use App\Http\Api\Schema\EloquentSchema;
+use App\Http\Api\Schema\Wiki\Anime\Theme\EntrySchema;
+use App\Http\Api\Schema\Wiki\VideoSchema;
+use App\Http\Resources\Pivot\Wiki\Resource\AnimeThemeEntryVideoResource;
+use App\Pivots\Wiki\AnimeThemeEntryVideo;
+
+/**
+ * Class AnimeThemeEntryVideoSchema.
+ */
+class AnimeThemeEntryVideoSchema extends EloquentSchema
+{
+    /**
+     * The model this schema represents.
+     *
+     * @return string
+     */
+    public function model(): string
+    {
+        return AnimeThemeEntryVideoResource::class;
+    }
+
+    /**
+     * Get the type of the resource.
+     *
+     * @return string
+     */
+    public function type(): string
+    {
+        return AnimeThemeEntryVideoResource::$wrap;
+    }
+
+    /**
+     * Get the allowed includes.
+     *
+     * @return AllowedInclude[]
+     */
+    public function allowedIncludes(): array
+    {
+        return [
+            new AllowedInclude(new EntrySchema(), AnimeThemeEntryVideo::RELATION_ENTRY),
+            new AllowedInclude(new VideoSchema(), AnimeThemeEntryVideo::RELATION_VIDEO),
+        ];
+    }
+
+    /**
+     * Get the direct fields of the resource.
+     *
+     * @return Field[]
+     *
+     * @noinspection PhpMissingParentCallCommonInspection
+     */
+    public function fields(): array
+    {
+        return [
+            new CreatedAtField($this),
+            new UpdatedAtField($this),
+            new AnimeThemeEntryVideoEntryIdField($this),
+            new AnimeThemeEntryVideoVideoIdField($this),
+        ];
+    }
+}

--- a/app/Http/Api/Schema/Wiki/ImageSchema.php
+++ b/app/Http/Api/Schema/Wiki/ImageSchema.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace App\Http\Api\Schema\Wiki;
 
-use App\Http\Api\Field\Base\IdField;
 use App\Http\Api\Field\Field;
 use App\Http\Api\Field\Wiki\Image\ImageFacetField;
 use App\Http\Api\Field\Wiki\Image\ImageFileField;
+use App\Http\Api\Field\Wiki\Image\ImageIdField;
 use App\Http\Api\Field\Wiki\Image\ImageLinkField;
 use App\Http\Api\Field\Wiki\Image\ImagePathField;
 use App\Http\Api\Include\AllowedInclude;
@@ -64,7 +64,7 @@ class ImageSchema extends EloquentSchema
         return array_merge(
             parent::fields(),
             [
-                new IdField($this, Image::ATTRIBUTE_ID),
+                new ImageIdField($this),
                 new ImageFacetField($this),
                 new ImagePathField($this),
                 new ImageLinkField($this),

--- a/app/Http/Api/Schema/Wiki/Video/ScriptSchema.php
+++ b/app/Http/Api/Schema/Wiki/Video/ScriptSchema.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\Http\Api\Schema\Wiki\Video;
 
-use App\Http\Api\Field\Base\IdField;
 use App\Http\Api\Field\Field;
+use App\Http\Api\Field\Wiki\Video\Script\ScriptIdField;
 use App\Http\Api\Field\Wiki\Video\Script\ScriptLinkField;
 use App\Http\Api\Field\Wiki\Video\Script\ScriptPathField;
 use App\Http\Api\Field\Wiki\Video\Script\ScriptVideoIdField;
@@ -62,7 +62,7 @@ class ScriptSchema extends EloquentSchema
         return array_merge(
             parent::fields(),
             [
-                new IdField($this, VideoScript::ATTRIBUTE_ID),
+                new ScriptIdField($this),
                 new ScriptPathField($this),
                 new ScriptLinkField($this),
                 new ScriptVideoIdField($this),

--- a/app/Http/Resources/Admin/Resource/AnnouncementResource.php
+++ b/app/Http/Resources/Admin/Resource/AnnouncementResource.php
@@ -5,16 +5,14 @@ declare(strict_types=1);
 namespace App\Http\Resources\Admin\Resource;
 
 use App\Http\Api\Query\ReadQuery;
+use App\Http\Api\Schema\Admin\AnnouncementSchema;
+use App\Http\Api\Schema\Schema;
 use App\Http\Resources\BaseResource;
 use App\Models\Admin\Announcement;
-use App\Models\BaseModel;
-use Illuminate\Http\Request;
 use Illuminate\Http\Resources\MissingValue;
 
 /**
  * Class AnnouncementResource.
- *
- * @mixin Announcement
  */
 class AnnouncementResource extends BaseResource
 {
@@ -38,37 +36,12 @@ class AnnouncementResource extends BaseResource
     }
 
     /**
-     * Transform the resource into an array.
+     * Get the resource schema.
      *
-     * @param  Request  $request
-     * @return array
-     *
-     * @noinspection PhpMissingParentCallCommonInspection
+     * @return Schema
      */
-    public function toArray($request): array
+    protected function schema(): Schema
     {
-        $result = [];
-
-        if ($this->isAllowedField(BaseResource::ATTRIBUTE_ID)) {
-            $result[BaseResource::ATTRIBUTE_ID] = $this->getKey();
-        }
-
-        if ($this->isAllowedField(Announcement::ATTRIBUTE_CONTENT)) {
-            $result[Announcement::ATTRIBUTE_CONTENT] = $this->content;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_CREATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_CREATED_AT] = $this->created_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_UPDATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_UPDATED_AT] = $this->updated_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_DELETED_AT)) {
-            $result[BaseModel::ATTRIBUTE_DELETED_AT] = $this->deleted_at;
-        }
-
-        return $result;
+        return new AnnouncementSchema();
     }
 }

--- a/app/Http/Resources/Admin/Resource/DumpResource.php
+++ b/app/Http/Resources/Admin/Resource/DumpResource.php
@@ -5,16 +5,14 @@ declare(strict_types=1);
 namespace App\Http\Resources\Admin\Resource;
 
 use App\Http\Api\Query\ReadQuery;
+use App\Http\Api\Schema\Admin\DumpSchema;
+use App\Http\Api\Schema\Schema;
 use App\Http\Resources\BaseResource;
 use App\Models\Admin\Dump;
-use App\Models\BaseModel;
-use Illuminate\Http\Request;
 use Illuminate\Http\Resources\MissingValue;
 
 /**
  * Class DumpResource.
- *
- * @mixin Dump
  */
 class DumpResource extends BaseResource
 {
@@ -40,41 +38,12 @@ class DumpResource extends BaseResource
     }
 
     /**
-     * Transform the resource into an array.
+     * Get the resource schema.
      *
-     * @param  Request  $request
-     * @return array
-     *
-     * @noinspection PhpMissingParentCallCommonInspection
+     * @return Schema
      */
-    public function toArray($request): array
+    protected function schema(): Schema
     {
-        $result = [];
-
-        if ($this->isAllowedField(BaseResource::ATTRIBUTE_ID)) {
-            $result[BaseResource::ATTRIBUTE_ID] = $this->getKey();
-        }
-
-        if ($this->isAllowedField(Dump::ATTRIBUTE_PATH)) {
-            $result[Dump::ATTRIBUTE_PATH] = $this->path;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_CREATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_CREATED_AT] = $this->created_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_UPDATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_UPDATED_AT] = $this->updated_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_DELETED_AT)) {
-            $result[BaseModel::ATTRIBUTE_DELETED_AT] = $this->deleted_at;
-        }
-
-        if ($this->isAllowedField(DumpResource::ATTRIBUTE_LINK)) {
-            $result[DumpResource::ATTRIBUTE_LINK] = route('dump.show', $this);
-        }
-
-        return $result;
+        return new DumpSchema();
     }
 }

--- a/app/Http/Resources/Auth/Resource/UserResource.php
+++ b/app/Http/Resources/Auth/Resource/UserResource.php
@@ -5,16 +5,14 @@ declare(strict_types=1);
 namespace App\Http\Resources\Auth\Resource;
 
 use App\Http\Api\Query\ReadQuery;
+use App\Http\Api\Schema\Auth\UserSchema;
+use App\Http\Api\Schema\Schema;
 use App\Http\Resources\BaseResource;
 use App\Models\Auth\User;
-use App\Models\BaseModel;
-use Illuminate\Http\Request;
 use Illuminate\Http\Resources\MissingValue;
 
 /**
  * Class UserResource.
- *
- * @mixin User
  */
 class UserResource extends BaseResource
 {
@@ -38,37 +36,12 @@ class UserResource extends BaseResource
     }
 
     /**
-     * Transform the resource into an array.
+     * Get the resource schema.
      *
-     * @param  Request  $request
-     * @return array
-     *
-     * @noinspection PhpMissingParentCallCommonInspection
+     * @return Schema
      */
-    public function toArray($request): array
+    protected function schema(): Schema
     {
-        $result = [];
-
-        if ($this->isAllowedField(BaseResource::ATTRIBUTE_ID)) {
-            $result[BaseResource::ATTRIBUTE_ID] = $this->getKey();
-        }
-
-        if ($this->isAllowedField(User::ATTRIBUTE_NAME)) {
-            $result[User::ATTRIBUTE_NAME] = $this->name;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_CREATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_CREATED_AT] = $this->created_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_UPDATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_UPDATED_AT] = $this->updated_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_DELETED_AT)) {
-            $result[BaseModel::ATTRIBUTE_DELETED_AT] = $this->deleted_at;
-        }
-
-        return $result;
+        return new UserSchema();
     }
 }

--- a/app/Http/Resources/Billing/Resource/BalanceResource.php
+++ b/app/Http/Resources/Billing/Resource/BalanceResource.php
@@ -5,16 +5,14 @@ declare(strict_types=1);
 namespace App\Http\Resources\Billing\Resource;
 
 use App\Http\Api\Query\ReadQuery;
+use App\Http\Api\Schema\Billing\BalanceSchema;
+use App\Http\Api\Schema\Schema;
 use App\Http\Resources\BaseResource;
-use App\Models\BaseModel;
 use App\Models\Billing\Balance;
-use Illuminate\Http\Request;
 use Illuminate\Http\Resources\MissingValue;
 
 /**
  * Class BalanceResource.
- *
- * @mixin Balance
  */
 class BalanceResource extends BaseResource
 {
@@ -40,53 +38,12 @@ class BalanceResource extends BaseResource
     }
 
     /**
-     * Transform the resource into an array.
+     * Get the resource schema.
      *
-     * @param  Request  $request
-     * @return array
-     *
-     * @noinspection PhpMissingParentCallCommonInspection
+     * @return Schema
      */
-    public function toArray($request): array
+    protected function schema(): Schema
     {
-        $result = [];
-
-        if ($this->isAllowedField(BaseResource::ATTRIBUTE_ID)) {
-            $result[BaseResource::ATTRIBUTE_ID] = $this->getKey();
-        }
-
-        if ($this->isAllowedField(Balance::ATTRIBUTE_DATE)) {
-            $result[Balance::ATTRIBUTE_DATE] = $this->date;
-        }
-
-        if ($this->isAllowedField(Balance::ATTRIBUTE_SERVICE)) {
-            $result[Balance::ATTRIBUTE_SERVICE] = $this->service->description;
-        }
-
-        if ($this->isAllowedField(Balance::ATTRIBUTE_FREQUENCY)) {
-            $result[Balance::ATTRIBUTE_FREQUENCY] = $this->frequency->description;
-        }
-
-        if ($this->isAllowedField(Balance::ATTRIBUTE_USAGE)) {
-            $result[Balance::ATTRIBUTE_USAGE] = $this->usage;
-        }
-
-        if ($this->isAllowedField(BalanceResource::ATTRIBUTE_BALANCE)) {
-            $result[BalanceResource::ATTRIBUTE_BALANCE] = $this->balance;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_CREATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_CREATED_AT] = $this->created_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_UPDATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_UPDATED_AT] = $this->updated_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_DELETED_AT)) {
-            $result[BaseModel::ATTRIBUTE_DELETED_AT] = $this->deleted_at;
-        }
-
-        return $result;
+        return new BalanceSchema();
     }
 }

--- a/app/Http/Resources/Billing/Resource/TransactionResource.php
+++ b/app/Http/Resources/Billing/Resource/TransactionResource.php
@@ -5,16 +5,14 @@ declare(strict_types=1);
 namespace App\Http\Resources\Billing\Resource;
 
 use App\Http\Api\Query\ReadQuery;
+use App\Http\Api\Schema\Billing\TransactionSchema;
+use App\Http\Api\Schema\Schema;
 use App\Http\Resources\BaseResource;
-use App\Models\BaseModel;
 use App\Models\Billing\Transaction;
-use Illuminate\Http\Request;
 use Illuminate\Http\Resources\MissingValue;
 
 /**
  * Class TransactionResource.
- *
- * @mixin Transaction
  */
 class TransactionResource extends BaseResource
 {
@@ -38,53 +36,12 @@ class TransactionResource extends BaseResource
     }
 
     /**
-     * Transform the resource into an array.
+     * Get the resource schema.
      *
-     * @param  Request  $request
-     * @return array
-     *
-     * @noinspection PhpMissingParentCallCommonInspection
+     * @return Schema
      */
-    public function toArray($request): array
+    protected function schema(): Schema
     {
-        $result = [];
-
-        if ($this->isAllowedField(BaseResource::ATTRIBUTE_ID)) {
-            $result[BaseResource::ATTRIBUTE_ID] = $this->getKey();
-        }
-
-        if ($this->isAllowedField(Transaction::ATTRIBUTE_DATE)) {
-            $result[Transaction::ATTRIBUTE_DATE] = $this->date;
-        }
-
-        if ($this->isAllowedField(Transaction::ATTRIBUTE_SERVICE)) {
-            $result[Transaction::ATTRIBUTE_SERVICE] = $this->service->description;
-        }
-
-        if ($this->isAllowedField(Transaction::ATTRIBUTE_DESCRIPTION)) {
-            $result[Transaction::ATTRIBUTE_DESCRIPTION] = $this->description;
-        }
-
-        if ($this->isAllowedField(Transaction::ATTRIBUTE_AMOUNT)) {
-            $result[Transaction::ATTRIBUTE_AMOUNT] = $this->amount;
-        }
-
-        if ($this->isAllowedField(Transaction::ATTRIBUTE_EXTERNAL_ID)) {
-            $result[Transaction::ATTRIBUTE_EXTERNAL_ID] = $this->external_id;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_CREATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_CREATED_AT] = $this->created_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_UPDATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_UPDATED_AT] = $this->updated_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_DELETED_AT)) {
-            $result[BaseModel::ATTRIBUTE_DELETED_AT] = $this->deleted_at;
-        }
-
-        return $result;
+        return new TransactionSchema();
     }
 }

--- a/app/Http/Resources/Config/Resource/FlagsResource.php
+++ b/app/Http/Resources/Config/Resource/FlagsResource.php
@@ -6,6 +6,8 @@ namespace App\Http\Resources\Config\Resource;
 
 use App\Constants\Config\FlagConstants;
 use App\Http\Api\Query\ReadQuery;
+use App\Http\Api\Schema\Config\FlagsSchema;
+use App\Http\Api\Schema\Schema;
 use App\Http\Resources\BaseResource;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\MissingValue;
@@ -71,5 +73,15 @@ class FlagsResource extends BaseResource
         }
 
         return $result;
+    }
+
+    /**
+     * Get the resource schema.
+     *
+     * @return Schema
+     */
+    protected function schema(): Schema
+    {
+        return new FlagsSchema();
     }
 }

--- a/app/Http/Resources/Config/Resource/WikiResource.php
+++ b/app/Http/Resources/Config/Resource/WikiResource.php
@@ -6,6 +6,8 @@ namespace App\Http\Resources\Config\Resource;
 
 use App\Constants\Config\WikiConstants;
 use App\Http\Api\Query\ReadQuery;
+use App\Http\Api\Schema\Config\WikiSchema;
+use App\Http\Api\Schema\Schema;
 use App\Http\Resources\BaseResource;
 use App\Http\Resources\Pivot\Wiki\Resource\AnimeThemeEntryVideoResource;
 use App\Pivots\Wiki\AnimeThemeEntryVideo;
@@ -66,5 +68,15 @@ class WikiResource extends BaseResource
         }
 
         return $result;
+    }
+
+    /**
+     * Get the resource schema.
+     *
+     * @return Schema
+     */
+    protected function schema(): Schema
+    {
+        return new WikiSchema();
     }
 }

--- a/app/Http/Resources/Document/Resource/PageResource.php
+++ b/app/Http/Resources/Document/Resource/PageResource.php
@@ -5,16 +5,14 @@ declare(strict_types=1);
 namespace App\Http\Resources\Document\Resource;
 
 use App\Http\Api\Query\ReadQuery;
+use App\Http\Api\Schema\Document\PageSchema;
+use App\Http\Api\Schema\Schema;
 use App\Http\Resources\BaseResource;
-use App\Models\BaseModel;
 use App\Models\Document\Page;
-use Illuminate\Http\Request;
 use Illuminate\Http\Resources\MissingValue;
 
 /**
  * Class PageResource.
- *
- * @mixin Page
  */
 class PageResource extends BaseResource
 {
@@ -38,45 +36,12 @@ class PageResource extends BaseResource
     }
 
     /**
-     * Transform the resource into an array.
+     * Get the resource schema.
      *
-     * @param  Request  $request
-     * @return array
-     *
-     * @noinspection PhpMissingParentCallCommonInspection
+     * @return Schema
      */
-    public function toArray($request): array
+    protected function schema(): Schema
     {
-        $result = [];
-
-        if ($this->isAllowedField(BaseResource::ATTRIBUTE_ID)) {
-            $result[BaseResource::ATTRIBUTE_ID] = $this->getKey();
-        }
-
-        if ($this->isAllowedField(Page::ATTRIBUTE_NAME)) {
-            $result[Page::ATTRIBUTE_NAME] = $this->name;
-        }
-
-        if ($this->isAllowedField(Page::ATTRIBUTE_SLUG)) {
-            $result[Page::ATTRIBUTE_SLUG] = $this->slug;
-        }
-
-        if ($this->isAllowedField(Page::ATTRIBUTE_BODY)) {
-            $result[Page::ATTRIBUTE_BODY] = $this->body;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_CREATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_CREATED_AT] = $this->created_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_UPDATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_UPDATED_AT] = $this->updated_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_DELETED_AT)) {
-            $result[BaseModel::ATTRIBUTE_DELETED_AT] = $this->deleted_at;
-        }
-
-        return $result;
+        return new PageSchema();
     }
 }

--- a/app/Http/Resources/List/Playlist/Resource/TrackResource.php
+++ b/app/Http/Resources/List/Playlist/Resource/TrackResource.php
@@ -5,18 +5,17 @@ declare(strict_types=1);
 namespace App\Http\Resources\List\Playlist\Resource;
 
 use App\Http\Api\Query\ReadQuery;
+use App\Http\Api\Schema\List\Playlist\TrackSchema;
+use App\Http\Api\Schema\Schema;
 use App\Http\Resources\BaseResource;
 use App\Http\Resources\List\Resource\PlaylistResource;
 use App\Http\Resources\Wiki\Resource\VideoResource;
-use App\Models\BaseModel;
 use App\Models\List\Playlist\PlaylistTrack;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\MissingValue;
 
 /**
  * Class TrackResource.
- *
- * @mixin PlaylistTrack
  */
 class TrackResource extends BaseResource
 {
@@ -44,28 +43,10 @@ class TrackResource extends BaseResource
      *
      * @param  Request  $request
      * @return array
-     *
-     * @noinspection PhpMissingParentCallCommonInspection
      */
     public function toArray($request): array
     {
-        $result = [];
-
-        if ($this->isAllowedField(BaseResource::ATTRIBUTE_ID)) {
-            $result[BaseResource::ATTRIBUTE_ID] = $this->getKey();
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_CREATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_CREATED_AT] = $this->created_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_UPDATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_UPDATED_AT] = $this->updated_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_DELETED_AT)) {
-            $result[BaseModel::ATTRIBUTE_DELETED_AT] = $this->deleted_at;
-        }
+        $result = parent::toArray($request);
 
         $result[PlaylistTrack::RELATION_PLAYLIST] = new PlaylistResource($this->whenLoaded(PlaylistTrack::RELATION_PLAYLIST), $this->query);
         $result[PlaylistTrack::RELATION_NEXT] = new TrackResource($this->whenLoaded(PlaylistTrack::RELATION_NEXT), $this->query);
@@ -73,5 +54,15 @@ class TrackResource extends BaseResource
         $result[PlaylistTrack::RELATION_VIDEO] = new VideoResource($this->whenLoaded(PlaylistTrack::RELATION_VIDEO), $this->query);
 
         return $result;
+    }
+
+    /**
+     * Get the resource schema.
+     *
+     * @return Schema
+     */
+    protected function schema(): Schema
+    {
+        return new TrackSchema();
     }
 }

--- a/app/Http/Resources/List/Resource/PlaylistResource.php
+++ b/app/Http/Resources/List/Resource/PlaylistResource.php
@@ -4,22 +4,20 @@ declare(strict_types=1);
 
 namespace App\Http\Resources\List\Resource;
 
-use App\Http\Api\Field\CountField;
 use App\Http\Api\Query\ReadQuery;
+use App\Http\Api\Schema\List\PlaylistSchema;
+use App\Http\Api\Schema\Schema;
 use App\Http\Resources\Auth\Resource\UserResource;
 use App\Http\Resources\BaseResource;
 use App\Http\Resources\List\Playlist\Collection\TrackCollection;
 use App\Http\Resources\List\Playlist\Resource\TrackResource;
 use App\Http\Resources\Wiki\Collection\ImageCollection;
-use App\Models\BaseModel;
 use App\Models\List\Playlist;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\MissingValue;
 
 /**
  * Class PlaylistResource.
- *
- * @mixin Playlist
  */
 class PlaylistResource extends BaseResource
 {
@@ -47,40 +45,10 @@ class PlaylistResource extends BaseResource
      *
      * @param  Request  $request
      * @return array
-     *
-     * @noinspection PhpMissingParentCallCommonInspection
      */
     public function toArray($request): array
     {
-        $result = [];
-
-        if ($this->isAllowedField(BaseResource::ATTRIBUTE_ID)) {
-            $result[BaseResource::ATTRIBUTE_ID] = $this->getKey();
-        }
-
-        if ($this->isAllowedField(Playlist::ATTRIBUTE_NAME)) {
-            $result[Playlist::ATTRIBUTE_NAME] = $this->name;
-        }
-
-        if ($this->isAllowedField(Playlist::ATTRIBUTE_VISIBILITY)) {
-            $result[Playlist::ATTRIBUTE_VISIBILITY] = $this->visibility->description;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_CREATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_CREATED_AT] = $this->created_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_UPDATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_UPDATED_AT] = $this->updated_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_DELETED_AT)) {
-            $result[BaseModel::ATTRIBUTE_DELETED_AT] = $this->deleted_at;
-        }
-
-        if ($this->isAllowedField(Playlist::RELATION_VIEWS, false)) {
-            $result[Playlist::RELATION_VIEWS] = $this->getAttribute(CountField::format(Playlist::RELATION_VIEWS));
-        }
+        $result = parent::toArray($request);
 
         $result[Playlist::RELATION_USER] = new UserResource($this->whenLoaded(Playlist::RELATION_USER), $this->query);
         $result[Playlist::RELATION_FIRST] = new TrackResource($this->whenLoaded(Playlist::RELATION_FIRST), $this->query);
@@ -89,5 +57,15 @@ class PlaylistResource extends BaseResource
         $result[Playlist::RELATION_TRACKS] = new TrackCollection($this->whenLoaded(Playlist::RELATION_TRACKS), $this->query);
 
         return $result;
+    }
+
+    /**
+     * Get the resource schema.
+     *
+     * @return Schema
+     */
+    protected function schema(): Schema
+    {
+        return new PlaylistSchema();
     }
 }

--- a/app/Http/Resources/Pivot/Wiki/Resource/AnimeImageResource.php
+++ b/app/Http/Resources/Pivot/Wiki/Resource/AnimeImageResource.php
@@ -5,18 +5,17 @@ declare(strict_types=1);
 namespace App\Http\Resources\Pivot\Wiki\Resource;
 
 use App\Http\Api\Query\ReadQuery;
+use App\Http\Api\Schema\Pivot\Wiki\AnimeImageSchema;
+use App\Http\Api\Schema\Schema;
 use App\Http\Resources\BaseResource;
 use App\Http\Resources\Wiki\Resource\AnimeResource;
 use App\Http\Resources\Wiki\Resource\ImageResource;
-use App\Pivots\BasePivot;
 use App\Pivots\Wiki\AnimeImage;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\MissingValue;
 
 /**
  * Class AnimeImageResource.
- *
- * @mixin AnimeImage
  */
 class AnimeImageResource extends BaseResource
 {
@@ -44,24 +43,24 @@ class AnimeImageResource extends BaseResource
      *
      * @param  Request  $request
      * @return array
-     *
-     * @noinspection PhpMissingParentCallCommonInspection
      */
     public function toArray($request): array
     {
-        $result = [];
-
-        if ($this->isAllowedField(BasePivot::ATTRIBUTE_CREATED_AT)) {
-            $result[BasePivot::ATTRIBUTE_CREATED_AT] = $this->created_at;
-        }
-
-        if ($this->isAllowedField(BasePivot::ATTRIBUTE_UPDATED_AT)) {
-            $result[BasePivot::ATTRIBUTE_UPDATED_AT] = $this->updated_at;
-        }
+        $result = parent::toArray($request);
 
         $result[AnimeImage::RELATION_ANIME] = new AnimeResource($this->whenLoaded(AnimeImage::RELATION_ANIME), $this->query);
         $result[AnimeImage::RELATION_IMAGE] = new ImageResource($this->whenLoaded(AnimeImage::RELATION_IMAGE), $this->query);
 
         return $result;
+    }
+
+    /**
+     * Get the resource schema.
+     *
+     * @return Schema
+     */
+    protected function schema(): Schema
+    {
+        return new AnimeImageSchema();
     }
 }

--- a/app/Http/Resources/Pivot/Wiki/Resource/AnimeThemeEntryVideoResource.php
+++ b/app/Http/Resources/Pivot/Wiki/Resource/AnimeThemeEntryVideoResource.php
@@ -5,18 +5,17 @@ declare(strict_types=1);
 namespace App\Http\Resources\Pivot\Wiki\Resource;
 
 use App\Http\Api\Query\ReadQuery;
+use App\Http\Api\Schema\Pivot\Wiki\AnimeThemeEntryVideoSchema;
+use App\Http\Api\Schema\Schema;
 use App\Http\Resources\BaseResource;
 use App\Http\Resources\Wiki\Anime\Theme\Resource\EntryResource;
 use App\Http\Resources\Wiki\Resource\VideoResource;
-use App\Pivots\BasePivot;
 use App\Pivots\Wiki\AnimeThemeEntryVideo;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\MissingValue;
 
 /**
  * Class AnimeThemeEntryVideoResource.
- *
- * @mixin AnimeThemeEntryVideo
  */
 class AnimeThemeEntryVideoResource extends BaseResource
 {
@@ -44,24 +43,24 @@ class AnimeThemeEntryVideoResource extends BaseResource
      *
      * @param  Request  $request
      * @return array
-     *
-     * @noinspection PhpMissingParentCallCommonInspection
      */
     public function toArray($request): array
     {
-        $result = [];
-
-        if ($this->isAllowedField(BasePivot::ATTRIBUTE_CREATED_AT)) {
-            $result[BasePivot::ATTRIBUTE_CREATED_AT] = $this->created_at;
-        }
-
-        if ($this->isAllowedField(BasePivot::ATTRIBUTE_UPDATED_AT)) {
-            $result[BasePivot::ATTRIBUTE_UPDATED_AT] = $this->updated_at;
-        }
+        $result = parent::toArray($request);
 
         $result[AnimeThemeEntryVideo::RELATION_ENTRY] = new EntryResource($this->whenLoaded(AnimeThemeEntryVideo::RELATION_ENTRY), $this->query);
         $result[AnimeThemeEntryVideo::RELATION_VIDEO] = new VideoResource($this->whenLoaded(AnimeThemeEntryVideo::RELATION_VIDEO), $this->query);
 
         return $result;
+    }
+
+    /**
+     * Get the resource schema.
+     *
+     * @return Schema
+     */
+    protected function schema(): Schema
+    {
+        return new AnimeThemeEntryVideoSchema();
     }
 }

--- a/app/Http/Resources/Wiki/Anime/Resource/SynonymResource.php
+++ b/app/Http/Resources/Wiki/Anime/Resource/SynonymResource.php
@@ -5,17 +5,16 @@ declare(strict_types=1);
 namespace App\Http\Resources\Wiki\Anime\Resource;
 
 use App\Http\Api\Query\ReadQuery;
+use App\Http\Api\Schema\Schema;
+use App\Http\Api\Schema\Wiki\Anime\SynonymSchema;
 use App\Http\Resources\BaseResource;
 use App\Http\Resources\Wiki\Resource\AnimeResource;
-use App\Models\BaseModel;
 use App\Models\Wiki\Anime\AnimeSynonym;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\MissingValue;
 
 /**
  * Class SynonymResource.
- *
- * @mixin AnimeSynonym
  */
 class SynonymResource extends BaseResource
 {
@@ -43,35 +42,23 @@ class SynonymResource extends BaseResource
      *
      * @param  Request  $request
      * @return array
-     *
-     * @noinspection PhpMissingParentCallCommonInspection
      */
     public function toArray($request): array
     {
-        $result = [];
-
-        if ($this->isAllowedField(BaseResource::ATTRIBUTE_ID)) {
-            $result[BaseResource::ATTRIBUTE_ID] = $this->getKey();
-        }
-
-        if ($this->isAllowedField(AnimeSynonym::ATTRIBUTE_TEXT)) {
-            $result[AnimeSynonym::ATTRIBUTE_TEXT] = $this->text;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_CREATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_CREATED_AT] = $this->created_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_UPDATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_UPDATED_AT] = $this->updated_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_DELETED_AT)) {
-            $result[BaseModel::ATTRIBUTE_DELETED_AT] = $this->deleted_at;
-        }
+        $result = parent::toArray($request);
 
         $result[AnimeSynonym::RELATION_ANIME] = new AnimeResource($this->whenLoaded(AnimeSynonym::RELATION_ANIME), $this->query);
 
         return $result;
+    }
+
+    /**
+     * Get the resource schema.
+     *
+     * @return Schema
+     */
+    protected function schema(): Schema
+    {
+        return new SynonymSchema();
     }
 }

--- a/app/Http/Resources/Wiki/Anime/Resource/ThemeResource.php
+++ b/app/Http/Resources/Wiki/Anime/Resource/ThemeResource.php
@@ -5,19 +5,18 @@ declare(strict_types=1);
 namespace App\Http\Resources\Wiki\Anime\Resource;
 
 use App\Http\Api\Query\ReadQuery;
+use App\Http\Api\Schema\Schema;
+use App\Http\Api\Schema\Wiki\Anime\ThemeSchema;
 use App\Http\Resources\BaseResource;
 use App\Http\Resources\Wiki\Anime\Theme\Collection\EntryCollection;
 use App\Http\Resources\Wiki\Resource\AnimeResource;
 use App\Http\Resources\Wiki\Resource\SongResource;
-use App\Models\BaseModel;
 use App\Models\Wiki\Anime\AnimeTheme;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\MissingValue;
 
 /**
  * Class ThemeResource.
- *
- * @mixin AnimeTheme
  */
 class ThemeResource extends BaseResource
 {
@@ -45,49 +44,25 @@ class ThemeResource extends BaseResource
      *
      * @param  Request  $request
      * @return array
-     *
-     * @noinspection PhpMissingParentCallCommonInspection
      */
     public function toArray($request): array
     {
-        $result = [];
-
-        if ($this->isAllowedField(BaseResource::ATTRIBUTE_ID)) {
-            $result[BaseResource::ATTRIBUTE_ID] = $this->getKey();
-        }
-
-        if ($this->isAllowedField(AnimeTheme::ATTRIBUTE_TYPE)) {
-            $result[AnimeTheme::ATTRIBUTE_TYPE] = $this->type?->description;
-        }
-
-        if ($this->isAllowedField(AnimeTheme::ATTRIBUTE_SEQUENCE)) {
-            $result[AnimeTheme::ATTRIBUTE_SEQUENCE] = $this->sequence;
-        }
-
-        if ($this->isAllowedField(AnimeTheme::ATTRIBUTE_GROUP)) {
-            $result[AnimeTheme::ATTRIBUTE_GROUP] = $this->group;
-        }
-
-        if ($this->isAllowedField(AnimeTheme::ATTRIBUTE_SLUG)) {
-            $result[AnimeTheme::ATTRIBUTE_SLUG] = $this->slug;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_CREATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_CREATED_AT] = $this->created_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_UPDATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_UPDATED_AT] = $this->updated_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_DELETED_AT)) {
-            $result[BaseModel::ATTRIBUTE_DELETED_AT] = $this->deleted_at;
-        }
+        $result = parent::toArray($request);
 
         $result[AnimeTheme::RELATION_ANIME] = new AnimeResource($this->whenLoaded(AnimeTheme::RELATION_ANIME), $this->query);
         $result[AnimeTheme::RELATION_SONG] = new SongResource($this->whenLoaded(AnimeTheme::RELATION_SONG), $this->query);
         $result[AnimeTheme::RELATION_ENTRIES] = new EntryCollection($this->whenLoaded(AnimeTheme::RELATION_ENTRIES), $this->query);
 
         return $result;
+    }
+
+    /**
+     * Get the resource schema.
+     *
+     * @return Schema
+     */
+    protected function schema(): Schema
+    {
+        return new ThemeSchema();
     }
 }

--- a/app/Http/Resources/Wiki/Anime/Theme/Resource/EntryResource.php
+++ b/app/Http/Resources/Wiki/Anime/Theme/Resource/EntryResource.php
@@ -5,18 +5,17 @@ declare(strict_types=1);
 namespace App\Http\Resources\Wiki\Anime\Theme\Resource;
 
 use App\Http\Api\Query\ReadQuery;
+use App\Http\Api\Schema\Schema;
+use App\Http\Api\Schema\Wiki\Anime\Theme\EntrySchema;
 use App\Http\Resources\BaseResource;
 use App\Http\Resources\Wiki\Anime\Resource\ThemeResource;
 use App\Http\Resources\Wiki\Collection\VideoCollection;
-use App\Models\BaseModel;
 use App\Models\Wiki\Anime\Theme\AnimeThemeEntry;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\MissingValue;
 
 /**
  * Class EntryResource.
- *
- * @mixin AnimeThemeEntry
  */
 class EntryResource extends BaseResource
 {
@@ -44,52 +43,24 @@ class EntryResource extends BaseResource
      *
      * @param  Request  $request
      * @return array
-     *
-     * @noinspection PhpMissingParentCallCommonInspection
      */
     public function toArray($request): array
     {
-        $result = [];
-
-        if ($this->isAllowedField(BaseResource::ATTRIBUTE_ID)) {
-            $result[BaseResource::ATTRIBUTE_ID] = $this->getKey();
-        }
-
-        if ($this->isAllowedField(AnimeThemeEntry::ATTRIBUTE_VERSION)) {
-            $result[AnimeThemeEntry::ATTRIBUTE_VERSION] = $this->version;
-        }
-
-        if ($this->isAllowedField(AnimeThemeEntry::ATTRIBUTE_EPISODES)) {
-            $result[AnimeThemeEntry::ATTRIBUTE_EPISODES] = $this->episodes;
-        }
-
-        if ($this->isAllowedField(AnimeThemeEntry::ATTRIBUTE_NSFW)) {
-            $result[AnimeThemeEntry::ATTRIBUTE_NSFW] = $this->nsfw;
-        }
-
-        if ($this->isAllowedField(AnimeThemeEntry::ATTRIBUTE_SPOILER)) {
-            $result[AnimeThemeEntry::ATTRIBUTE_SPOILER] = $this->spoiler;
-        }
-
-        if ($this->isAllowedField(AnimeThemeEntry::ATTRIBUTE_NOTES)) {
-            $result[AnimeThemeEntry::ATTRIBUTE_NOTES] = $this->notes;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_CREATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_CREATED_AT] = $this->created_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_UPDATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_UPDATED_AT] = $this->updated_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_DELETED_AT)) {
-            $result[BaseModel::ATTRIBUTE_DELETED_AT] = $this->deleted_at;
-        }
+        $result = parent::toArray($request);
 
         $result[AnimeThemeEntry::RELATION_THEME] = new ThemeResource($this->whenLoaded(AnimeThemeEntry::RELATION_THEME), $this->query);
         $result[AnimeThemeEntry::RELATION_VIDEOS] = new VideoCollection($this->whenLoaded(AnimeThemeEntry::RELATION_VIDEOS), $this->query);
 
         return $result;
+    }
+
+    /**
+     * Get the resource schema.
+     *
+     * @return Schema
+     */
+    protected function schema(): Schema
+    {
+        return new EntrySchema();
     }
 }

--- a/app/Http/Resources/Wiki/Resource/AnimeResource.php
+++ b/app/Http/Resources/Wiki/Resource/AnimeResource.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Http\Resources\Wiki\Resource;
 
 use App\Http\Api\Query\ReadQuery;
+use App\Http\Api\Schema\Schema;
+use App\Http\Api\Schema\Wiki\AnimeSchema;
 use App\Http\Resources\BaseResource;
 use App\Http\Resources\Wiki\Anime\Collection\SynonymCollection;
 use App\Http\Resources\Wiki\Anime\Collection\ThemeCollection;
@@ -12,7 +14,6 @@ use App\Http\Resources\Wiki\Collection\ExternalResourceCollection;
 use App\Http\Resources\Wiki\Collection\ImageCollection;
 use App\Http\Resources\Wiki\Collection\SeriesCollection;
 use App\Http\Resources\Wiki\Collection\StudioCollection;
-use App\Models\BaseModel;
 use App\Models\Wiki\Anime;
 use App\Pivots\Wiki\AnimeResource as AnimeResourcePivot;
 use Illuminate\Http\Request;
@@ -49,48 +50,10 @@ class AnimeResource extends BaseResource
      *
      * @param  Request  $request
      * @return array
-     *
-     * @noinspection PhpMissingParentCallCommonInspection
      */
     public function toArray($request): array
     {
-        $result = [];
-
-        if ($this->isAllowedField(BaseResource::ATTRIBUTE_ID)) {
-            $result[BaseResource::ATTRIBUTE_ID] = $this->getKey();
-        }
-
-        if ($this->isAllowedField(Anime::ATTRIBUTE_NAME)) {
-            $result[Anime::ATTRIBUTE_NAME] = $this->name;
-        }
-
-        if ($this->isAllowedField(Anime::ATTRIBUTE_SLUG)) {
-            $result[Anime::ATTRIBUTE_SLUG] = $this->slug;
-        }
-
-        if ($this->isAllowedField(Anime::ATTRIBUTE_YEAR)) {
-            $result[Anime::ATTRIBUTE_YEAR] = $this->year;
-        }
-
-        if ($this->isAllowedField(Anime::ATTRIBUTE_SEASON)) {
-            $result[Anime::ATTRIBUTE_SEASON] = $this->season?->description;
-        }
-
-        if ($this->isAllowedField(Anime::ATTRIBUTE_SYNOPSIS)) {
-            $result[Anime::ATTRIBUTE_SYNOPSIS] = $this->synopsis;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_CREATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_CREATED_AT] = $this->created_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_UPDATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_UPDATED_AT] = $this->updated_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_DELETED_AT)) {
-            $result[BaseModel::ATTRIBUTE_DELETED_AT] = $this->deleted_at;
-        }
+        $result = parent::toArray($request);
 
         $result[Anime::RELATION_SYNONYMS] = new SynonymCollection($this->whenLoaded(Anime::RELATION_SYNONYMS), $this->query);
         $result[Anime::RELATION_THEMES] = new ThemeCollection($this->whenLoaded(Anime::RELATION_THEMES), $this->query);
@@ -105,5 +68,15 @@ class AnimeResource extends BaseResource
         $result[Anime::RELATION_STUDIOS] = new StudioCollection($this->whenLoaded(Anime::RELATION_STUDIOS), $this->query);
 
         return $result;
+    }
+
+    /**
+     * Get the resource schema.
+     *
+     * @return Schema
+     */
+    protected function schema(): Schema
+    {
+        return new AnimeSchema();
     }
 }

--- a/app/Http/Resources/Wiki/Resource/ArtistResource.php
+++ b/app/Http/Resources/Wiki/Resource/ArtistResource.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace App\Http\Resources\Wiki\Resource;
 
 use App\Http\Api\Query\ReadQuery;
+use App\Http\Api\Schema\Schema;
+use App\Http\Api\Schema\Wiki\ArtistSchema;
 use App\Http\Resources\BaseResource;
 use App\Http\Resources\Wiki\Collection\ArtistCollection;
 use App\Http\Resources\Wiki\Collection\ExternalResourceCollection;
 use App\Http\Resources\Wiki\Collection\ImageCollection;
 use App\Http\Resources\Wiki\Collection\SongCollection;
-use App\Models\BaseModel;
 use App\Models\Wiki\Artist;
 use App\Pivots\Wiki\ArtistMember;
 use App\Pivots\Wiki\ArtistResource as ArtistResourcePivot;
@@ -49,24 +50,10 @@ class ArtistResource extends BaseResource
      *
      * @param  Request  $request
      * @return array
-     *
-     * @noinspection PhpMissingParentCallCommonInspection
      */
     public function toArray($request): array
     {
-        $result = [];
-
-        if ($this->isAllowedField(BaseResource::ATTRIBUTE_ID)) {
-            $result[BaseResource::ATTRIBUTE_ID] = $this->getKey();
-        }
-
-        if ($this->isAllowedField(Artist::ATTRIBUTE_NAME)) {
-            $result[Artist::ATTRIBUTE_NAME] = $this->name;
-        }
-
-        if ($this->isAllowedField(Artist::ATTRIBUTE_SLUG)) {
-            $result[Artist::ATTRIBUTE_SLUG] = $this->slug;
-        }
+        $result = parent::toArray($request);
 
         if ($this->isAllowedField(ArtistSong::ATTRIBUTE_AS)) {
             $result[ArtistSong::ATTRIBUTE_AS] = $this->whenPivotLoaded(
@@ -83,18 +70,6 @@ class ArtistResource extends BaseResource
             );
         }
 
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_CREATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_CREATED_AT] = $this->created_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_UPDATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_UPDATED_AT] = $this->updated_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_DELETED_AT)) {
-            $result[BaseModel::ATTRIBUTE_DELETED_AT] = $this->deleted_at;
-        }
-
         $result[Artist::RELATION_SONGS] = new SongCollection($this->whenLoaded(Artist::RELATION_SONGS), $this->query);
         $result[Artist::RELATION_MEMBERS] = new ArtistCollection($this->whenLoaded(Artist::RELATION_MEMBERS), $this->query);
         $result[Artist::RELATION_GROUPS] = new ArtistCollection($this->whenLoaded(Artist::RELATION_GROUPS), $this->query);
@@ -102,5 +77,15 @@ class ArtistResource extends BaseResource
         $result[Artist::RELATION_IMAGES] = new ImageCollection($this->whenLoaded(Artist::RELATION_IMAGES), $this->query);
 
         return $result;
+    }
+
+    /**
+     * Get the resource schema.
+     *
+     * @return Schema
+     */
+    protected function schema(): Schema
+    {
+        return new ArtistSchema();
     }
 }

--- a/app/Http/Resources/Wiki/Resource/AudioResource.php
+++ b/app/Http/Resources/Wiki/Resource/AudioResource.php
@@ -4,19 +4,17 @@ declare(strict_types=1);
 
 namespace App\Http\Resources\Wiki\Resource;
 
-use App\Http\Api\Field\CountField;
 use App\Http\Api\Query\ReadQuery;
+use App\Http\Api\Schema\Schema;
+use App\Http\Api\Schema\Wiki\AudioSchema;
 use App\Http\Resources\BaseResource;
 use App\Http\Resources\Wiki\Collection\VideoCollection;
-use App\Models\BaseModel;
 use App\Models\Wiki\Audio;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\MissingValue;
 
 /**
  * Class AudioResource.
- *
- * @mixin Audio
  */
 class AudioResource extends BaseResource
 {
@@ -46,59 +44,23 @@ class AudioResource extends BaseResource
      *
      * @param  Request  $request
      * @return array
-     *
-     * @noinspection PhpMissingParentCallCommonInspection
      */
     public function toArray($request): array
     {
-        $result = [];
-
-        if ($this->isAllowedField(BaseResource::ATTRIBUTE_ID)) {
-            $result[BaseResource::ATTRIBUTE_ID] = $this->getKey();
-        }
-
-        if ($this->isAllowedField(Audio::ATTRIBUTE_BASENAME)) {
-            $result[Audio::ATTRIBUTE_BASENAME] = $this->basename;
-        }
-
-        if ($this->isAllowedField(Audio::ATTRIBUTE_FILENAME)) {
-            $result[Audio::ATTRIBUTE_FILENAME] = $this->filename;
-        }
-
-        if ($this->isAllowedField(Audio::ATTRIBUTE_PATH)) {
-            $result[Audio::ATTRIBUTE_PATH] = $this->path;
-        }
-
-        if ($this->isAllowedField(Audio::ATTRIBUTE_SIZE)) {
-            $result[Audio::ATTRIBUTE_SIZE] = $this->size;
-        }
-
-        if ($this->isAllowedField(Audio::ATTRIBUTE_MIMETYPE)) {
-            $result[Audio::ATTRIBUTE_MIMETYPE] = $this->mimetype;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_CREATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_CREATED_AT] = $this->created_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_UPDATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_UPDATED_AT] = $this->updated_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_DELETED_AT)) {
-            $result[BaseModel::ATTRIBUTE_DELETED_AT] = $this->deleted_at;
-        }
-
-        if ($this->isAllowedField(AudioResource::ATTRIBUTE_LINK)) {
-            $result[AudioResource::ATTRIBUTE_LINK] = route('audio.show', $this);
-        }
-
-        if ($this->isAllowedField(Audio::RELATION_VIEWS, false)) {
-            $result[Audio::RELATION_VIEWS] = $this->getAttribute(CountField::format(Audio::RELATION_VIEWS));
-        }
+        $result = parent::toArray($request);
 
         $result[Audio::RELATION_VIDEOS] = new VideoCollection($this->whenLoaded(Audio::RELATION_VIDEOS), $this->query);
 
         return $result;
+    }
+
+    /**
+     * Get the resource schema.
+     *
+     * @return Schema
+     */
+    protected function schema(): Schema
+    {
+        return new AudioSchema();
     }
 }

--- a/app/Http/Resources/Wiki/Resource/ExternalResourceResource.php
+++ b/app/Http/Resources/Wiki/Resource/ExternalResourceResource.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace App\Http\Resources\Wiki\Resource;
 
 use App\Http\Api\Query\ReadQuery;
+use App\Http\Api\Schema\Schema;
+use App\Http\Api\Schema\Wiki\ExternalResourceSchema;
 use App\Http\Resources\BaseResource;
 use App\Http\Resources\Wiki\Collection\AnimeCollection;
 use App\Http\Resources\Wiki\Collection\ArtistCollection;
 use App\Http\Resources\Wiki\Collection\StudioCollection;
-use App\Models\BaseModel;
 use App\Models\Wiki\ExternalResource;
 use App\Pivots\Wiki\AnimeResource as AnimeResourcePivot;
 use App\Pivots\Wiki\ArtistResource as ArtistResourcePivot;
@@ -48,28 +49,10 @@ class ExternalResourceResource extends BaseResource
      *
      * @param  Request  $request
      * @return array
-     *
-     * @noinspection PhpMissingParentCallCommonInspection
      */
     public function toArray($request): array
     {
-        $result = [];
-
-        if ($this->isAllowedField(BaseResource::ATTRIBUTE_ID)) {
-            $result[BaseResource::ATTRIBUTE_ID] = $this->getKey();
-        }
-
-        if ($this->isAllowedField(ExternalResource::ATTRIBUTE_LINK)) {
-            $result[ExternalResource::ATTRIBUTE_LINK] = $this->link;
-        }
-
-        if ($this->isAllowedField(ExternalResource::ATTRIBUTE_EXTERNAL_ID)) {
-            $result[ExternalResource::ATTRIBUTE_EXTERNAL_ID] = $this->external_id;
-        }
-
-        if ($this->isAllowedField(ExternalResource::ATTRIBUTE_SITE)) {
-            $result[ExternalResource::ATTRIBUTE_SITE] = $this->site?->description;
-        }
+        $result = parent::toArray($request);
 
         if ($this->isAllowedField(AnimeResourcePivot::ATTRIBUTE_AS)) {
             $result[AnimeResourcePivot::ATTRIBUTE_AS] = $this->whenPivotLoaded(
@@ -86,22 +69,20 @@ class ExternalResourceResource extends BaseResource
             );
         }
 
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_CREATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_CREATED_AT] = $this->created_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_UPDATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_UPDATED_AT] = $this->updated_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_DELETED_AT)) {
-            $result[BaseModel::ATTRIBUTE_DELETED_AT] = $this->deleted_at;
-        }
-
         $result[ExternalResource::RELATION_ARTISTS] = new ArtistCollection($this->whenLoaded(ExternalResource::RELATION_ARTISTS), $this->query);
         $result[ExternalResource::RELATION_ANIME] = new AnimeCollection($this->whenLoaded(ExternalResource::RELATION_ANIME), $this->query);
         $result[ExternalResource::RELATION_STUDIOS] = new StudioCollection($this->whenLoaded(ExternalResource::RELATION_STUDIOS), $this->query);
 
         return $result;
+    }
+
+    /**
+     * Get the resource schema.
+     *
+     * @return Schema
+     */
+    protected function schema(): Schema
+    {
+        return new ExternalResourceSchema();
     }
 }

--- a/app/Http/Resources/Wiki/Resource/ImageResource.php
+++ b/app/Http/Resources/Wiki/Resource/ImageResource.php
@@ -5,21 +5,18 @@ declare(strict_types=1);
 namespace App\Http\Resources\Wiki\Resource;
 
 use App\Http\Api\Query\ReadQuery;
+use App\Http\Api\Schema\Schema;
+use App\Http\Api\Schema\Wiki\ImageSchema;
 use App\Http\Resources\BaseResource;
 use App\Http\Resources\Wiki\Collection\AnimeCollection;
 use App\Http\Resources\Wiki\Collection\ArtistCollection;
 use App\Http\Resources\Wiki\Collection\StudioCollection;
-use App\Models\BaseModel;
 use App\Models\Wiki\Image;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\MissingValue;
-use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Facades\Storage;
 
 /**
  * Class ImageResource.
- *
- * @mixin Image
  */
 class ImageResource extends BaseResource
 {
@@ -49,45 +46,25 @@ class ImageResource extends BaseResource
      *
      * @param  Request  $request
      * @return array
-     *
-     * @noinspection PhpMissingParentCallCommonInspection
      */
     public function toArray($request): array
     {
-        $result = [];
-
-        if ($this->isAllowedField(BaseResource::ATTRIBUTE_ID)) {
-            $result[BaseResource::ATTRIBUTE_ID] = $this->getKey();
-        }
-
-        if ($this->isAllowedField(Image::ATTRIBUTE_PATH)) {
-            $result[Image::ATTRIBUTE_PATH] = $this->path;
-        }
-
-        if ($this->isAllowedField(Image::ATTRIBUTE_FACET)) {
-            $result[Image::ATTRIBUTE_FACET] = $this->facet?->description;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_CREATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_CREATED_AT] = $this->created_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_UPDATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_UPDATED_AT] = $this->updated_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_DELETED_AT)) {
-            $result[BaseModel::ATTRIBUTE_DELETED_AT] = $this->deleted_at;
-        }
-
-        if ($this->isAllowedField(ImageResource::ATTRIBUTE_LINK)) {
-            $result[ImageResource::ATTRIBUTE_LINK] = Storage::disk(Config::get('image.disk'))->url($this->path);
-        }
+        $result = parent::toArray($request);
 
         $result[Image::RELATION_ARTISTS] = new ArtistCollection($this->whenLoaded(Image::RELATION_ARTISTS), $this->query);
         $result[Image::RELATION_ANIME] = new AnimeCollection($this->whenLoaded(Image::RELATION_ANIME), $this->query);
         $result[Image::RELATION_STUDIOS] = new StudioCollection($this->whenLoaded(Image::RELATION_STUDIOS), $this->query);
 
         return $result;
+    }
+
+    /**
+     * Get the resource schema.
+     *
+     * @return Schema
+     */
+    protected function schema(): Schema
+    {
+        return new ImageSchema();
     }
 }

--- a/app/Http/Resources/Wiki/Resource/SeriesResource.php
+++ b/app/Http/Resources/Wiki/Resource/SeriesResource.php
@@ -5,17 +5,16 @@ declare(strict_types=1);
 namespace App\Http\Resources\Wiki\Resource;
 
 use App\Http\Api\Query\ReadQuery;
+use App\Http\Api\Schema\Schema;
+use App\Http\Api\Schema\Wiki\SeriesSchema;
 use App\Http\Resources\BaseResource;
 use App\Http\Resources\Wiki\Collection\AnimeCollection;
-use App\Models\BaseModel;
 use App\Models\Wiki\Series;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\MissingValue;
 
 /**
  * Class SeriesResource.
- *
- * @mixin Series
  */
 class SeriesResource extends BaseResource
 {
@@ -43,39 +42,23 @@ class SeriesResource extends BaseResource
      *
      * @param  Request  $request
      * @return array
-     *
-     * @noinspection PhpMissingParentCallCommonInspection
      */
     public function toArray($request): array
     {
-        $result = [];
-
-        if ($this->isAllowedField(BaseResource::ATTRIBUTE_ID)) {
-            $result[BaseResource::ATTRIBUTE_ID] = $this->getKey();
-        }
-
-        if ($this->isAllowedField(Series::ATTRIBUTE_NAME)) {
-            $result[Series::ATTRIBUTE_NAME] = $this->name;
-        }
-
-        if ($this->isAllowedField(Series::ATTRIBUTE_SLUG)) {
-            $result[Series::ATTRIBUTE_SLUG] = $this->slug;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_CREATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_CREATED_AT] = $this->created_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_UPDATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_UPDATED_AT] = $this->updated_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_DELETED_AT)) {
-            $result[BaseModel::ATTRIBUTE_DELETED_AT] = $this->deleted_at;
-        }
+        $result = parent::toArray($request);
 
         $result[Series::RELATION_ANIME] = new AnimeCollection($this->whenLoaded(Series::RELATION_ANIME), $this->query);
 
         return $result;
+    }
+
+    /**
+     * Get the resource schema.
+     *
+     * @return Schema
+     */
+    protected function schema(): Schema
+    {
+        return new SeriesSchema();
     }
 }

--- a/app/Http/Resources/Wiki/Resource/SongResource.php
+++ b/app/Http/Resources/Wiki/Resource/SongResource.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace App\Http\Resources\Wiki\Resource;
 
 use App\Http\Api\Query\ReadQuery;
+use App\Http\Api\Schema\Schema;
+use App\Http\Api\Schema\Wiki\SongSchema;
 use App\Http\Resources\BaseResource;
 use App\Http\Resources\Wiki\Anime\Collection\ThemeCollection;
 use App\Http\Resources\Wiki\Collection\ArtistCollection;
-use App\Models\BaseModel;
 use App\Models\Wiki\Song;
 use App\Pivots\Wiki\ArtistSong;
 use Illuminate\Http\Request;
@@ -45,40 +46,28 @@ class SongResource extends BaseResource
      *
      * @param  Request  $request
      * @return array
-     *
-     * @noinspection PhpMissingParentCallCommonInspection
      */
     public function toArray($request): array
     {
-        $result = [];
-
-        if ($this->isAllowedField(BaseResource::ATTRIBUTE_ID)) {
-            $result[BaseResource::ATTRIBUTE_ID] = $this->getKey();
-        }
-
-        if ($this->isAllowedField(Song::ATTRIBUTE_TITLE)) {
-            $result[Song::ATTRIBUTE_TITLE] = $this->title;
-        }
+        $result = parent::toArray($request);
 
         if ($this->isAllowedField(ArtistSong::ATTRIBUTE_AS)) {
             $result[ArtistSong::ATTRIBUTE_AS] = $this->whenPivotLoaded(ArtistSong::TABLE, fn () => $this->pivot->getAttribute(ArtistSong::ATTRIBUTE_AS));
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_CREATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_CREATED_AT] = $this->created_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_UPDATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_UPDATED_AT] = $this->updated_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_DELETED_AT)) {
-            $result[BaseModel::ATTRIBUTE_DELETED_AT] = $this->deleted_at;
         }
 
         $result[Song::RELATION_ANIMETHEMES] = new ThemeCollection($this->whenLoaded(Song::RELATION_ANIMETHEMES), $this->query);
         $result[Song::RELATION_ARTISTS] = new ArtistCollection($this->whenLoaded(Song::RELATION_ARTISTS), $this->query);
 
         return $result;
+    }
+
+    /**
+     * Get the resource schema.
+     *
+     * @return Schema
+     */
+    protected function schema(): Schema
+    {
+        return new SongSchema();
     }
 }

--- a/app/Http/Resources/Wiki/Resource/StudioResource.php
+++ b/app/Http/Resources/Wiki/Resource/StudioResource.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace App\Http\Resources\Wiki\Resource;
 
 use App\Http\Api\Query\ReadQuery;
+use App\Http\Api\Schema\Schema;
+use App\Http\Api\Schema\Wiki\StudioSchema;
 use App\Http\Resources\BaseResource;
 use App\Http\Resources\Wiki\Collection\AnimeCollection;
 use App\Http\Resources\Wiki\Collection\ExternalResourceCollection;
 use App\Http\Resources\Wiki\Collection\ImageCollection;
-use App\Models\BaseModel;
 use App\Models\Wiki\Studio;
 use App\Pivots\Wiki\StudioResource as StudioResourcePivot;
 use Illuminate\Http\Request;
@@ -46,36 +47,10 @@ class StudioResource extends BaseResource
      *
      * @param  Request  $request
      * @return array
-     *
-     * @noinspection PhpMissingParentCallCommonInspection
      */
     public function toArray($request): array
     {
-        $result = [];
-
-        if ($this->isAllowedField(BaseResource::ATTRIBUTE_ID)) {
-            $result[BaseResource::ATTRIBUTE_ID] = $this->getKey();
-        }
-
-        if ($this->isAllowedField(Studio::ATTRIBUTE_NAME)) {
-            $result[Studio::ATTRIBUTE_NAME] = $this->name;
-        }
-
-        if ($this->isAllowedField(Studio::ATTRIBUTE_SLUG)) {
-            $result[Studio::ATTRIBUTE_SLUG] = $this->slug;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_CREATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_CREATED_AT] = $this->created_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_UPDATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_UPDATED_AT] = $this->updated_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_DELETED_AT)) {
-            $result[BaseModel::ATTRIBUTE_DELETED_AT] = $this->deleted_at;
-        }
+        $result = parent::toArray($request);
 
         $result[Studio::RELATION_ANIME] = new AnimeCollection($this->whenLoaded(Studio::RELATION_ANIME), $this->query);
         $result[Studio::RELATION_RESOURCES] = new ExternalResourceCollection($this->whenLoaded(Studio::RELATION_RESOURCES), $this->query);
@@ -86,5 +61,15 @@ class StudioResource extends BaseResource
         }
 
         return $result;
+    }
+
+    /**
+     * Get the resource schema.
+     *
+     * @return Schema
+     */
+    protected function schema(): Schema
+    {
+        return new StudioSchema();
     }
 }

--- a/app/Http/Resources/Wiki/Resource/VideoResource.php
+++ b/app/Http/Resources/Wiki/Resource/VideoResource.php
@@ -4,20 +4,18 @@ declare(strict_types=1);
 
 namespace App\Http\Resources\Wiki\Resource;
 
-use App\Http\Api\Field\CountField;
 use App\Http\Api\Query\ReadQuery;
+use App\Http\Api\Schema\Schema;
+use App\Http\Api\Schema\Wiki\VideoSchema;
 use App\Http\Resources\BaseResource;
 use App\Http\Resources\Wiki\Anime\Theme\Collection\EntryCollection;
 use App\Http\Resources\Wiki\Video\Resource\ScriptResource;
-use App\Models\BaseModel;
 use App\Models\Wiki\Video;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\MissingValue;
 
 /**
  * Class VideoResource.
- *
- * @mixin Video
  */
 class VideoResource extends BaseResource
 {
@@ -47,93 +45,25 @@ class VideoResource extends BaseResource
      *
      * @param  Request  $request
      * @return array
-     *
-     * @noinspection PhpMissingParentCallCommonInspection
      */
     public function toArray($request): array
     {
-        $result = [];
-
-        if ($this->isAllowedField(BaseResource::ATTRIBUTE_ID)) {
-            $result[BaseResource::ATTRIBUTE_ID] = $this->getKey();
-        }
-
-        if ($this->isAllowedField(Video::ATTRIBUTE_BASENAME)) {
-            $result[Video::ATTRIBUTE_BASENAME] = $this->basename;
-        }
-
-        if ($this->isAllowedField(Video::ATTRIBUTE_FILENAME)) {
-            $result[Video::ATTRIBUTE_FILENAME] = $this->filename;
-        }
-
-        if ($this->isAllowedField(Video::ATTRIBUTE_PATH)) {
-            $result[Video::ATTRIBUTE_PATH] = $this->path;
-        }
-
-        if ($this->isAllowedField(Video::ATTRIBUTE_SIZE)) {
-            $result[Video::ATTRIBUTE_SIZE] = $this->size;
-        }
-
-        if ($this->isAllowedField(Video::ATTRIBUTE_MIMETYPE)) {
-            $result[Video::ATTRIBUTE_MIMETYPE] = $this->mimetype;
-        }
-
-        if ($this->isAllowedField(Video::ATTRIBUTE_RESOLUTION)) {
-            $result[Video::ATTRIBUTE_RESOLUTION] = $this->resolution;
-        }
-
-        if ($this->isAllowedField(Video::ATTRIBUTE_NC)) {
-            $result[Video::ATTRIBUTE_NC] = $this->nc;
-        }
-
-        if ($this->isAllowedField(Video::ATTRIBUTE_SUBBED)) {
-            $result[Video::ATTRIBUTE_SUBBED] = $this->subbed;
-        }
-
-        if ($this->isAllowedField(Video::ATTRIBUTE_LYRICS)) {
-            $result[Video::ATTRIBUTE_LYRICS] = $this->lyrics;
-        }
-
-        if ($this->isAllowedField(Video::ATTRIBUTE_UNCEN)) {
-            $result[Video::ATTRIBUTE_UNCEN] = $this->uncen;
-        }
-
-        if ($this->isAllowedField(Video::ATTRIBUTE_SOURCE)) {
-            $result[Video::ATTRIBUTE_SOURCE] = $this->source?->description;
-        }
-
-        if ($this->isAllowedField(Video::ATTRIBUTE_OVERLAP)) {
-            $result[Video::ATTRIBUTE_OVERLAP] = $this->overlap->description;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_CREATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_CREATED_AT] = $this->created_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_UPDATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_UPDATED_AT] = $this->updated_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_DELETED_AT)) {
-            $result[BaseModel::ATTRIBUTE_DELETED_AT] = $this->deleted_at;
-        }
-
-        if ($this->isAllowedField(Video::ATTRIBUTE_TAGS)) {
-            $result[Video::ATTRIBUTE_TAGS] = implode('', $this->tags);
-        }
-
-        if ($this->isAllowedField(VideoResource::ATTRIBUTE_LINK)) {
-            $result[VideoResource::ATTRIBUTE_LINK] = route('video.show', $this);
-        }
-
-        if ($this->isAllowedField(Video::RELATION_VIEWS, false)) {
-            $result[Video::RELATION_VIEWS] = $this->getAttribute(CountField::format(Video::RELATION_VIEWS));
-        }
+        $result = parent::toArray($request);
 
         $result[Video::RELATION_ANIMETHEMEENTRIES] = new EntryCollection($this->whenLoaded(Video::RELATION_ANIMETHEMEENTRIES), $this->query);
         $result[Video::RELATION_AUDIO] = new AudioResource($this->whenLoaded(Video::RELATION_AUDIO), $this->query);
         $result[Video::RELATION_SCRIPT] = new ScriptResource($this->whenLoaded(Video::RELATION_SCRIPT), $this->query);
 
         return $result;
+    }
+
+    /**
+     * Get the resource schema.
+     *
+     * @return Schema
+     */
+    protected function schema(): Schema
+    {
+        return new VideoSchema();
     }
 }

--- a/app/Http/Resources/Wiki/Video/Resource/ScriptResource.php
+++ b/app/Http/Resources/Wiki/Video/Resource/ScriptResource.php
@@ -5,17 +5,16 @@ declare(strict_types=1);
 namespace App\Http\Resources\Wiki\Video\Resource;
 
 use App\Http\Api\Query\ReadQuery;
+use App\Http\Api\Schema\Schema;
+use App\Http\Api\Schema\Wiki\Video\ScriptSchema;
 use App\Http\Resources\BaseResource;
 use App\Http\Resources\Wiki\Resource\VideoResource;
-use App\Models\BaseModel;
 use App\Models\Wiki\Video\VideoScript;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\MissingValue;
 
 /**
  * Class ScriptResource.
- *
- * @mixin VideoScript
  */
 class ScriptResource extends BaseResource
 {
@@ -45,39 +44,23 @@ class ScriptResource extends BaseResource
      *
      * @param  Request  $request
      * @return array
-     *
-     * @noinspection PhpMissingParentCallCommonInspection
      */
     public function toArray($request): array
     {
-        $result = [];
-
-        if ($this->isAllowedField(BaseResource::ATTRIBUTE_ID)) {
-            $result[BaseResource::ATTRIBUTE_ID] = $this->getKey();
-        }
-
-        if ($this->isAllowedField(VideoScript::ATTRIBUTE_PATH)) {
-            $result[VideoScript::ATTRIBUTE_PATH] = $this->path;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_CREATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_CREATED_AT] = $this->created_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_UPDATED_AT)) {
-            $result[BaseModel::ATTRIBUTE_UPDATED_AT] = $this->updated_at;
-        }
-
-        if ($this->isAllowedField(BaseModel::ATTRIBUTE_DELETED_AT)) {
-            $result[BaseModel::ATTRIBUTE_DELETED_AT] = $this->deleted_at;
-        }
-
-        if ($this->isAllowedField(ScriptResource::ATTRIBUTE_LINK)) {
-            $result[ScriptResource::ATTRIBUTE_LINK] = route('videoscript.show', $this);
-        }
+        $result = parent::toArray($request);
 
         $result[VideoScript::RELATION_VIDEO] = new VideoResource($this->whenLoaded(VideoScript::RELATION_VIDEO), $this->query);
 
         return $result;
+    }
+
+    /**
+     * Get the resource schema.
+     *
+     * @return Schema
+     */
+    protected function schema(): Schema
+    {
+        return new ScriptSchema();
     }
 }

--- a/tests/Feature/Http/Api/Admin/Announcement/AnnouncementShowTest.php
+++ b/tests/Feature/Http/Api/Admin/Announcement/AnnouncementShowTest.php
@@ -93,7 +93,7 @@ class AnnouncementShowTest extends TestCase
 
         $announcement = Announcement::factory()->create();
 
-        $response = $this->get(route('api.announcement.show', ['announcement' => $announcement]));
+        $response = $this->get(route('api.announcement.show', ['announcement' => $announcement] + $parameters));
 
         $response->assertJson(
             json_decode(

--- a/tests/Feature/Http/Api/Admin/Dump/DumpShowTest.php
+++ b/tests/Feature/Http/Api/Admin/Dump/DumpShowTest.php
@@ -93,7 +93,7 @@ class DumpShowTest extends TestCase
 
         $dump = Dump::factory()->create();
 
-        $response = $this->get(route('api.dump.show', ['dump' => $dump]));
+        $response = $this->get(route('api.dump.show', ['dump' => $dump] + $parameters));
 
         $response->assertJson(
             json_decode(

--- a/tests/Feature/Http/Api/Billing/Balance/BalanceShowTest.php
+++ b/tests/Feature/Http/Api/Billing/Balance/BalanceShowTest.php
@@ -93,7 +93,7 @@ class BalanceShowTest extends TestCase
 
         $balance = Balance::factory()->create();
 
-        $response = $this->get(route('api.balance.show', ['balance' => $balance]));
+        $response = $this->get(route('api.balance.show', ['balance' => $balance] + $parameters));
 
         $response->assertJson(
             json_decode(

--- a/tests/Feature/Http/Api/Billing/Transaction/TransactionShowTest.php
+++ b/tests/Feature/Http/Api/Billing/Transaction/TransactionShowTest.php
@@ -93,7 +93,7 @@ class TransactionShowTest extends TestCase
 
         $transaction = Transaction::factory()->create();
 
-        $response = $this->get(route('api.transaction.show', ['transaction' => $transaction]));
+        $response = $this->get(route('api.transaction.show', ['transaction' => $transaction] + $parameters));
 
         $response->assertJson(
             json_decode(

--- a/tests/Feature/Http/Api/Config/FlagsShowTest.php
+++ b/tests/Feature/Http/Api/Config/FlagsShowTest.php
@@ -71,7 +71,7 @@ class FlagsShowTest extends TestCase
             ],
         ];
 
-        $response = $this->get(route('api.config.flags.show'));
+        $response = $this->get(route('api.config.flags.show', $parameters));
 
         $response->assertJson(
             json_decode(

--- a/tests/Feature/Http/Api/Document/Page/PageShowTest.php
+++ b/tests/Feature/Http/Api/Document/Page/PageShowTest.php
@@ -93,7 +93,7 @@ class PageShowTest extends TestCase
 
         $page = Page::factory()->create();
 
-        $response = $this->get(route('api.page.show', ['page' => $page]));
+        $response = $this->get(route('api.page.show', ['page' => $page] + $parameters));
 
         $response->assertJson(
             json_decode(

--- a/tests/Feature/Http/Api/Wiki/Anime/YearShowTest.php
+++ b/tests/Feature/Http/Api/Wiki/Anime/YearShowTest.php
@@ -210,7 +210,7 @@ class YearShowTest extends TestCase
 
         $fallResources = new AnimeCollection($fallAnime->sortBy(Anime::ATTRIBUTE_NAME)->values(), new AnimeReadQuery($parameters));
 
-        $response = $this->get(route('api.animeyear.show', [Anime::ATTRIBUTE_YEAR => $year]));
+        $response = $this->get(route('api.animeyear.show', [Anime::ATTRIBUTE_YEAR => $year] + $parameters));
 
         $response->assertJson([
             Str::lower(AnimeSeason::getDescription(AnimeSeason::WINTER)) => json_decode(json_encode($winterResources->response()->getData()->anime), true),


### PR DESCRIPTION
Fields are "renderable" if they can be displayed to the user. These are distinguished from fields like foreign keys that may be used in select clauses but not necessarily displayed to the user.

This allows us to provide custom logic for the visibility of each field. For example, we want some fields to be displayed by default and some fields to be specified by the user in order explicitly.