### PR TITLE
test: fix value boundary in billing factories & backfill anime studios needs unique value from external api

### DIFF
--- a/database/factories/Billing/BalanceFactory.php
+++ b/database/factories/Billing/BalanceFactory.php
@@ -34,11 +34,11 @@ class BalanceFactory extends Factory
     public function definition(): array
     {
         return [
-            Balance::ATTRIBUTE_BALANCE => fake()->randomFloat(2),
+            Balance::ATTRIBUTE_BALANCE => fake()->randomFloat(nbMaxDecimals: 2, max: 999999.99),
             Balance::ATTRIBUTE_FREQUENCY => BalanceFrequency::getRandomValue(),
             Balance::ATTRIBUTE_DATE => fake()->date(),
             Balance::ATTRIBUTE_SERVICE => Service::getRandomValue(),
-            Balance::ATTRIBUTE_USAGE => fake()->randomFloat(2),
+            Balance::ATTRIBUTE_USAGE => fake()->randomFloat(nbMaxDecimals: 2, max: 999999.99),
         ];
     }
 }

--- a/database/factories/Billing/TransactionFactory.php
+++ b/database/factories/Billing/TransactionFactory.php
@@ -33,7 +33,7 @@ class TransactionFactory extends Factory
     public function definition(): array
     {
         return [
-            Transaction::ATTRIBUTE_AMOUNT => fake()->randomFloat(2),
+            Transaction::ATTRIBUTE_AMOUNT => fake()->randomFloat(nbMaxDecimals: 2, max: 999999.99),
             Transaction::ATTRIBUTE_DATE => fake()->date(),
             Transaction::ATTRIBUTE_DESCRIPTION => fake()->sentence(),
             Transaction::ATTRIBUTE_EXTERNAL_ID => fake()->uuid(),

--- a/tests/Feature/Actions/Models/Wiki/Anime/Studio/BackfillAnimeStudiosTest.php
+++ b/tests/Feature/Actions/Models/Wiki/Anime/Studio/BackfillAnimeStudiosTest.php
@@ -118,7 +118,7 @@ class BackfillAnimeStudiosTest extends TestCase
 
         $studios = Collection::times(
             $studioCount,
-            fn (int $time) => ['id' => $time, 'name' => $this->faker->word()]
+            fn (int $time) => ['id' => $time, 'name' => $this->faker->unique()->word()]
         );
 
         Http::fake([
@@ -190,7 +190,7 @@ class BackfillAnimeStudiosTest extends TestCase
 
         $studios = Collection::times(
             $studioCount,
-            fn (int $time) => ['id' => $time, 'name' => $this->faker->word()]
+            fn (int $time) => ['id' => $time, 'name' => $this->faker->unique()->word()]
         );
 
         Http::fake([
@@ -271,7 +271,7 @@ class BackfillAnimeStudiosTest extends TestCase
             fn () => [
                 'role' => 'STUDIO',
                 'company' => [
-                    'name' => $this->faker->word(),
+                    'name' => $this->faker->unique()->word(),
                 ],
             ],
         );
@@ -319,7 +319,7 @@ class BackfillAnimeStudiosTest extends TestCase
 
         $studios = Collection::times(
             $studioCount,
-            fn (int $time) => ['id' => $time, 'name' => $this->faker->word()]
+            fn (int $time) => ['id' => $time, 'name' => $this->faker->unique()->word()]
         );
 
         Http::fake([
@@ -372,7 +372,7 @@ class BackfillAnimeStudiosTest extends TestCase
 
         $studios = Collection::times(
             $studioCount,
-            fn (int $time) => ['id' => $time, 'name' => $this->faker->word()]
+            fn (int $time) => ['id' => $time, 'name' => $this->faker->unique()->word()]
         );
 
         Http::fake([


### PR DESCRIPTION
I didn't have much time today so I just fixed some brittle tests