### PR TITLE
feat(api): adding crud endpoints for anime resource pivot type

### DIFF
--- a/app/Http/Api/Field/Pivot/Wiki/AnimeResource/AnimeResourceAnimeIdField.php
+++ b/app/Http/Api/Field/Pivot/Wiki/AnimeResource/AnimeResourceAnimeIdField.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Api\Field\Pivot\Wiki\AnimeResource;
+
+use App\Contracts\Http\Api\Field\CreatableField;
+use App\Contracts\Http\Api\Field\SelectableField;
+use App\Http\Api\Field\Field;
+use App\Http\Api\Query\Query;
+use App\Http\Api\Schema\Schema;
+use App\Models\Wiki\Anime;
+use App\Pivots\Wiki\AnimeResource;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+/**
+ * Class AnimeResourceAnimeIdField.
+ */
+class AnimeResourceAnimeIdField extends Field implements CreatableField, SelectableField
+{
+    /**
+     * Create a new field instance.
+     *
+     * @param  Schema  $schema
+     */
+    public function __construct(Schema $schema)
+    {
+        parent::__construct($schema, AnimeResource::ATTRIBUTE_ANIME);
+    }
+
+    /**
+     * Set the creation validation rules for the field.
+     *
+     * @param  Request  $request
+     * @return array
+     */
+    public function getCreationRules(Request $request): array
+    {
+        return [
+            'required',
+            'integer',
+            Rule::exists(Anime::TABLE, Anime::ATTRIBUTE_ID),
+        ];
+    }
+
+    /**
+     * Determine if the field should be included in the select clause of our query.
+     *
+     * @param  Query  $query
+     * @param  Schema  $schema
+     * @return bool
+     */
+    public function shouldSelect(Query $query, Schema $schema): bool
+    {
+        // Needed to match anime relation.
+        return true;
+    }
+}

--- a/app/Http/Api/Field/Pivot/Wiki/AnimeResource/AnimeResourceAsField.php
+++ b/app/Http/Api/Field/Pivot/Wiki/AnimeResource/AnimeResourceAsField.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Api\Field\Pivot\Wiki\AnimeResource;
+
+use App\Contracts\Http\Api\Field\CreatableField;
+use App\Contracts\Http\Api\Field\UpdatableField;
+use App\Http\Api\Field\StringField;
+use App\Http\Api\Schema\Schema;
+use App\Pivots\Wiki\AnimeResource;
+use Illuminate\Http\Request;
+
+/**
+ * Class AnimeResourceAsField.
+ */
+class AnimeResourceAsField extends StringField implements CreatableField, UpdatableField
+{
+    /**
+     * Create a new field instance.
+     *
+     * @param  Schema  $schema
+     */
+    public function __construct(Schema $schema)
+    {
+        parent::__construct($schema, AnimeResource::ATTRIBUTE_AS);
+    }
+
+    /**
+     * Set the creation validation rules for the field.
+     *
+     * @param  Request  $request
+     * @return array
+     */
+    public function getCreationRules(Request $request): array
+    {
+        return [
+            'nullable',
+            'string',
+            'max:192',
+        ];
+    }
+
+    /**
+     * Set the update validation rules for the field.
+     *
+     * @param  Request  $request
+     * @return array
+     */
+    public function getUpdateRules(Request $request): array
+    {
+        return [
+            'nullable',
+            'string',
+            'max:192',
+        ];
+    }
+}

--- a/app/Http/Api/Field/Pivot/Wiki/AnimeResource/AnimeResourceResourceIdField.php
+++ b/app/Http/Api/Field/Pivot/Wiki/AnimeResource/AnimeResourceResourceIdField.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Api\Field\Pivot\Wiki\AnimeResource;
+
+use App\Contracts\Http\Api\Field\CreatableField;
+use App\Contracts\Http\Api\Field\SelectableField;
+use App\Http\Api\Field\Field;
+use App\Http\Api\Query\Query;
+use App\Http\Api\Schema\Schema;
+use App\Models\Wiki\ExternalResource;
+use App\Pivots\Wiki\AnimeResource;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+/**
+ * Class AnimeResourceResourceIdField.
+ */
+class AnimeResourceResourceIdField extends Field implements CreatableField, SelectableField
+{
+    /**
+     * Create a new field instance.
+     *
+     * @param  Schema  $schema
+     */
+    public function __construct(Schema $schema)
+    {
+        parent::__construct($schema, AnimeResource::ATTRIBUTE_RESOURCE);
+    }
+
+    /**
+     * Set the creation validation rules for the field.
+     *
+     * @param  Request  $request
+     * @return array
+     */
+    public function getCreationRules(Request $request): array
+    {
+        return [
+            'required',
+            'integer',
+            Rule::exists(ExternalResource::TABLE, ExternalResource::ATTRIBUTE_ID),
+        ];
+    }
+
+    /**
+     * Determine if the field should be included in the select clause of our query.
+     *
+     * @param  Query  $query
+     * @param  Schema  $schema
+     * @return bool
+     */
+    public function shouldSelect(Query $query, Schema $schema): bool
+    {
+        // Needed to match resource relation.
+        return true;
+    }
+}

--- a/app/Http/Api/Schema/Pivot/Wiki/AnimeResourceSchema.php
+++ b/app/Http/Api/Schema/Pivot/Wiki/AnimeResourceSchema.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Api\Schema\Pivot\Wiki;
+
+use App\Http\Api\Field\Base\CreatedAtField;
+use App\Http\Api\Field\Base\UpdatedAtField;
+use App\Http\Api\Field\Field;
+use App\Http\Api\Field\Pivot\Wiki\AnimeResource\AnimeResourceAnimeIdField;
+use App\Http\Api\Field\Pivot\Wiki\AnimeResource\AnimeResourceAsField;
+use App\Http\Api\Field\Pivot\Wiki\AnimeResource\AnimeResourceResourceIdField;
+use App\Http\Api\Include\AllowedInclude;
+use App\Http\Api\Schema\EloquentSchema;
+use App\Http\Api\Schema\Wiki\AnimeSchema;
+use App\Http\Api\Schema\Wiki\ExternalResourceSchema;
+use App\Http\Resources\Pivot\Wiki\Resource\AnimeResourceResource;
+use App\Pivots\Wiki\AnimeResource;
+
+/**
+ * Class AnimeResourceSchema.
+ */
+class AnimeResourceSchema extends EloquentSchema
+{
+    /**
+     * The model this schema represents.
+     *
+     * @return string
+     */
+    public function model(): string
+    {
+        return AnimeResource::class;
+    }
+
+    /**
+     * Get the type of the resource.
+     *
+     * @return string
+     */
+    public function type(): string
+    {
+        return AnimeResourceResource::$wrap;
+    }
+
+    /**
+     * Get the allowed includes.
+     *
+     * @return AllowedInclude[]
+     */
+    public function allowedIncludes(): array
+    {
+        return [
+            new AllowedInclude(new AnimeSchema(), AnimeResource::RELATION_ANIME),
+            new AllowedInclude(new ExternalResourceSchema(), AnimeResource::RELATION_RESOURCE),
+        ];
+    }
+
+    /**
+     * Get the direct fields of the resource.
+     *
+     * @return Field[]
+     *
+     * @noinspection PhpMissingParentCallCommonInspection
+     */
+    public function fields(): array
+    {
+        return [
+            new CreatedAtField($this),
+            new UpdatedAtField($this),
+            new AnimeResourceAnimeIdField($this),
+            new AnimeResourceResourceIdField($this),
+            new AnimeResourceAsField($this),
+        ];
+    }
+}

--- a/app/Http/Controllers/Api/Pivot/Wiki/AnimeResourceController.php
+++ b/app/Http/Controllers/Api/Pivot/Wiki/AnimeResourceController.php
@@ -32,7 +32,7 @@ class AnimeResourceController extends PivotController
      */
     public function __construct()
     {
-        parent::__construct(Anime::class, 'resource', ExternalResource::class, 'resource');
+        parent::__construct(Anime::class, 'anime', ExternalResource::class, 'resource');
     }
 
     /**

--- a/app/Http/Controllers/Api/Pivot/Wiki/AnimeResourceController.php
+++ b/app/Http/Controllers/Api/Pivot/Wiki/AnimeResourceController.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\Pivot\Wiki;
+
+use App\Actions\Http\Api\DestroyAction;
+use App\Actions\Http\Api\IndexAction;
+use App\Actions\Http\Api\ShowAction;
+use App\Actions\Http\Api\StoreAction;
+use App\Actions\Http\Api\UpdateAction;
+use App\Http\Api\Query\Query;
+use App\Http\Controllers\Api\Pivot\PivotController;
+use App\Http\Requests\Api\IndexRequest;
+use App\Http\Requests\Api\ShowRequest;
+use App\Http\Requests\Api\StoreRequest;
+use App\Http\Requests\Api\UpdateRequest;
+use App\Http\Resources\Pivot\Wiki\Collection\AnimeResourceCollection;
+use App\Http\Resources\Pivot\Wiki\Resource\AnimeResourceResource;
+use App\Models\Wiki\Anime;
+use App\Models\Wiki\ExternalResource;
+use App\Pivots\Wiki\AnimeResource;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * Class AnimeResourceController.
+ */
+class AnimeResourceController extends PivotController
+{
+    /**
+     * Create a new controller instance.
+     */
+    public function __construct()
+    {
+        parent::__construct(Anime::class, 'resource', ExternalResource::class, 'resource');
+    }
+
+    /**
+     * Display a listing of the resource.
+     *
+     * @param  IndexRequest  $request
+     * @param  IndexAction  $action
+     * @return JsonResponse
+     */
+    public function index(IndexRequest $request, IndexAction $action): JsonResponse
+    {
+        $query = new Query($request->validated());
+
+        $resources = $action->index(AnimeResource::query(), $query, $request->schema());
+
+        $collection = new AnimeResourceCollection($resources, $query);
+
+        return $collection->toResponse($request);
+    }
+
+    /**
+     * Store a newly created resource.
+     *
+     * @param  StoreRequest  $request
+     * @param  StoreAction  $action
+     * @return JsonResponse
+     */
+    public function store(StoreRequest $request, StoreAction $action): JsonResponse
+    {
+        $animeResource = $action->store(AnimeResource::query(), $request->validated());
+
+        $resource = new AnimeResourceResource($animeResource, new Query());
+
+        return $resource->toResponse($request);
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  ShowRequest  $request
+     * @param  Anime  $anime
+     * @param  ExternalResource  $resource
+     * @param  ShowAction  $action
+     * @return JsonResponse
+     */
+    public function show(ShowRequest $request, Anime $anime, ExternalResource $resource, ShowAction $action): JsonResponse
+    {
+        $animeResource = AnimeResource::query()
+            ->where(AnimeResource::ATTRIBUTE_ANIME, $anime->getKey())
+            ->where(AnimeResource::ATTRIBUTE_RESOURCE, $resource->getKey())
+            ->firstOrFail();
+
+        $query = new Query($request->validated());
+
+        $show = $action->show($animeResource, $query, $request->schema());
+
+        $apiResource = new AnimeResourceResource($show, $query);
+
+        return $apiResource->toResponse($request);
+    }
+
+    /**
+     * Update the specified resource.
+     *
+     * @param  UpdateRequest  $request
+     * @param  Anime  $anime
+     * @param  ExternalResource  $resource
+     * @param  UpdateAction  $action
+     * @return JsonResponse
+     */
+    public function update(UpdateRequest $request, Anime $anime, ExternalResource $resource, UpdateAction $action): JsonResponse
+    {
+        $animeResource = AnimeResource::query()
+            ->where(AnimeResource::ATTRIBUTE_ANIME, $anime->getKey())
+            ->where(AnimeResource::ATTRIBUTE_RESOURCE, $resource->getKey())
+            ->firstOrFail();
+
+        $query = new Query($request->validated());
+
+        $updated = $action->update($animeResource, $request->validated());
+
+        $apiResource = new AnimeResourceResource($updated, $query);
+
+        return $apiResource->toResponse($request);
+    }
+
+    /**
+     * Remove the specified resource.
+     *
+     * @param  Anime  $anime
+     * @param  ExternalResource  $resource
+     * @param  DestroyAction  $action
+     * @return JsonResponse
+     */
+    public function destroy(Anime $anime, ExternalResource $resource, DestroyAction $action): JsonResponse
+    {
+        $animeResource = AnimeResource::query()
+            ->where(AnimeResource::ATTRIBUTE_ANIME, $anime->getKey())
+            ->where(AnimeResource::ATTRIBUTE_RESOURCE, $resource->getKey())
+            ->firstOrFail();
+
+        $action->destroy($animeResource);
+
+        return new JsonResponse([
+            'message' => "Resource '**{$resource->getName()}**' has been detached from Anime '**{$anime->getName()}**'.",
+        ]);
+    }
+}

--- a/app/Http/Resources/Pivot/Wiki/Collection/AnimeResourceCollection.php
+++ b/app/Http/Resources/Pivot/Wiki/Collection/AnimeResourceCollection.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Pivot\Wiki\Collection;
+
+use App\Http\Resources\BaseCollection;
+use App\Http\Resources\Pivot\Wiki\Resource\AnimeResourceResource;
+use App\Pivots\Wiki\AnimeResource;
+use Illuminate\Http\Request;
+
+/**
+ * Class AnimeResourceCollection.
+ */
+class AnimeResourceCollection extends BaseCollection
+{
+    /**
+     * The "data" wrapper that should be applied.
+     *
+     * @var string|null
+     */
+    public static $wrap = 'animeresources';
+
+    /**
+     * Transform the resource into a JSON array.
+     *
+     * @param  Request  $request
+     * @return array
+     *
+     * @noinspection PhpMissingParentCallCommonInspection
+     */
+    public function toArray($request): array
+    {
+        return $this->collection->map(fn (AnimeResource $animeResource) => new AnimeResourceResource($animeResource, $this->query))->all();
+    }
+}

--- a/app/Http/Resources/Pivot/Wiki/Resource/AnimeResourceResource.php
+++ b/app/Http/Resources/Pivot/Wiki/Resource/AnimeResourceResource.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Pivot\Wiki\Resource;
+
+use App\Http\Api\Schema\Pivot\Wiki\AnimeResourceSchema;
+use App\Http\Api\Schema\Schema;
+use App\Http\Resources\BaseResource;
+use App\Http\Resources\Wiki\Resource\AnimeResource;
+use App\Http\Resources\Wiki\Resource\ExternalResourceResource;
+use App\Pivots\Wiki\AnimeResource as AnimeResourcePivot;
+use Illuminate\Http\Request;
+
+/**
+ * Class AnimeResourceResource.
+ */
+class AnimeResourceResource extends BaseResource
+{
+    /**
+     * The "data" wrapper that should be applied.
+     *
+     * @var string|null
+     */
+    public static $wrap = 'animeresource';
+
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  Request  $request
+     * @return array
+     */
+    public function toArray($request): array
+    {
+        $result = parent::toArray($request);
+
+        $result[AnimeResourcePivot::RELATION_ANIME] = new AnimeResource($this->whenLoaded(AnimeResourcePivot::RELATION_ANIME), $this->query);
+        $result[AnimeResourcePivot::RELATION_RESOURCE] = new ExternalResourceResource($this->whenLoaded(AnimeResourcePivot::RELATION_RESOURCE), $this->query);
+
+        return $result;
+    }
+
+    /**
+     * Get the resource schema.
+     *
+     * @return Schema
+     */
+    protected function schema(): Schema
+    {
+        return new AnimeResourceSchema();
+    }
+}

--- a/app/Pivots/Wiki/AnimeResource.php
+++ b/app/Pivots/Wiki/AnimeResource.php
@@ -17,8 +17,10 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * Class AnimeResource.
  *
  * @property Anime $anime
+ * @property int $anime_id
  * @property string $as
  * @property ExternalResource $resource
+ * @property int $resource_id
  *
  * @method static AnimeResourceFactory factory(...$parameters)
  */
@@ -30,13 +32,18 @@ class AnimeResource extends BasePivot
     final public const ATTRIBUTE_AS = 'as';
     final public const ATTRIBUTE_RESOURCE = 'resource_id';
 
+    final public const RELATION_ANIME = 'anime';
+    final public const RELATION_RESOURCE = 'resource';
+
     /**
      * The attributes that are mass assignable.
      *
      * @var string[]
      */
     protected $fillable = [
+        AnimeResource::ATTRIBUTE_ANIME,
         AnimeResource::ATTRIBUTE_AS,
+        AnimeResource::ATTRIBUTE_RESOURCE,
     ];
 
     /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -17,6 +17,7 @@ use App\Http\Controllers\Api\List\Playlist\ForwardController;
 use App\Http\Controllers\Api\List\Playlist\TrackController;
 use App\Http\Controllers\Api\List\PlaylistController;
 use App\Http\Controllers\Api\Pivot\Wiki\AnimeImageController;
+use App\Http\Controllers\Api\Pivot\Wiki\AnimeResourceController;
 use App\Http\Controllers\Api\Wiki\Anime\SynonymController;
 use App\Http\Controllers\Api\Wiki\Anime\Theme\EntryController;
 use App\Http\Controllers\Api\Wiki\Anime\ThemeController;
@@ -167,6 +168,23 @@ if (! function_exists('apiPivotResource')) {
     }
 }
 
+if (! function_exists('apiEditablePivotResource')) {
+    /**
+     * API pivot resource route registration.
+     *
+     * @param  string  $name
+     * @param  string  $related
+     * @param  string  $foreign
+     * @param  string  $controller
+     * @return void
+     */
+    function apiEditablePivotResource(string $name, string $related, string $foreign, string $controller): void
+    {
+        apiPivotResource($name, $related, $foreign, $controller);
+        Route::match(['put', 'patch'], apiPivotResourceUri($name, $related, $foreign), [$controller, 'update'])->name("$name.update");
+    }
+}
+
 if (! function_exists('apiPivotResourceUri')) {
     /**
      * Uri for ability.
@@ -217,6 +235,7 @@ Route::get('playlist/{playlist}/backward', [BackwardController::class, 'index'])
 
 // Pivot Routes
 apiPivotResource('animeimage', 'anime', 'image', AnimeImageController::class);
+apiEditablePivotResource('animeresource', 'anime', 'resource', AnimeResourceController::class);
 
 // Wiki Routes
 apiResource('anime', AnimeController::class);

--- a/routes/api.php
+++ b/routes/api.php
@@ -170,7 +170,7 @@ if (! function_exists('apiPivotResource')) {
 
 if (! function_exists('apiEditablePivotResource')) {
     /**
-     * API pivot resource route registration.
+     * API pivot resource route registration with update action.
      *
      * @param  string  $name
      * @param  string  $related

--- a/tests/Feature/Http/Api/Pivot/Wiki/AnimeResource/AnimeResourceDestroyTest.php
+++ b/tests/Feature/Http/Api/Pivot/Wiki/AnimeResource/AnimeResourceDestroyTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Http\Api\Pivot\Wiki\AnimeResource;
+
+use App\Models\Auth\User;
+use App\Models\Wiki\Anime;
+use App\Models\Wiki\ExternalResource;
+use App\Pivots\Wiki\AnimeResource;
+use Illuminate\Foundation\Testing\WithoutEvents;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+/**
+ * Class AnimeResourceDestroyTest.
+ */
+class AnimeResourceDestroyTest extends TestCase
+{
+    use WithoutEvents;
+
+    /**
+     * The Anime Resource Destroy Endpoint shall be protected by sanctum.
+     *
+     * @return void
+     */
+    public function testProtected(): void
+    {
+        $animeResource = AnimeResource::factory()
+            ->for(Anime::factory())
+            ->for(ExternalResource::factory(), AnimeResource::RELATION_RESOURCE)
+            ->createOne();
+
+        $response = $this->delete(route('api.animeresource.destroy', ['anime' => $animeResource->anime, 'resource' => $animeResource->resource]));
+
+        $response->assertUnauthorized();
+    }
+
+    /**
+     * The Anime Resource Destroy Endpoint shall forbid users without the delete anime & delete resource permissions.
+     *
+     * @return void
+     */
+    public function testForbidden(): void
+    {
+        $animeResource = AnimeResource::factory()
+            ->for(Anime::factory())
+            ->for(ExternalResource::factory(), AnimeResource::RELATION_RESOURCE)
+            ->createOne();
+
+        $user = User::factory()->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->delete(route('api.animeresource.destroy', ['anime' => $animeResource->anime, 'resource' => $animeResource->resource]));
+
+        $response->assertForbidden();
+    }
+
+    /**
+     * The Anime Resource Destroy Endpoint shall return an error if the anime resource does not exist.
+     *
+     * @return void
+     */
+    public function testNotFound(): void
+    {
+        $anime = Anime::factory()->createOne();
+        $resource = ExternalResource::factory()->createOne();
+
+        $user = User::factory()->withPermissions(['delete anime', 'delete external resource'])->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->delete(route('api.animeresource.destroy', ['anime' => $anime, 'resource' => $resource]));
+
+        $response->assertNotFound();
+    }
+
+    /**
+     * The Anime Resource Destroy Endpoint shall delete the anime resource.
+     *
+     * @return void
+     */
+    public function testDeleted(): void
+    {
+        $animeResource = AnimeResource::factory()
+            ->for(Anime::factory())
+            ->for(ExternalResource::factory(), AnimeResource::RELATION_RESOURCE)
+            ->createOne();
+
+        $user = User::factory()->withPermissions(['delete anime', 'delete external resource'])->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->delete(route('api.animeresource.destroy', ['anime' => $animeResource->anime, 'resource' => $animeResource->resource]));
+
+        $response->assertOk();
+        static::assertModelMissing($animeResource);
+    }
+}

--- a/tests/Feature/Http/Api/Pivot/Wiki/AnimeResource/AnimeResourceIndexTest.php
+++ b/tests/Feature/Http/Api/Pivot/Wiki/AnimeResource/AnimeResourceIndexTest.php
@@ -1,0 +1,468 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Http\Api\Pivot\Wiki\AnimeResource;
+
+use App\Concerns\Actions\Http\Api\SortsModels;
+use App\Contracts\Http\Api\Field\SortableField;
+use App\Enums\Http\Api\Sort\Direction;
+use App\Enums\Models\Wiki\AnimeSeason;
+use App\Enums\Models\Wiki\ResourceSite;
+use App\Http\Api\Criteria\Paging\Criteria;
+use App\Http\Api\Criteria\Paging\OffsetCriteria;
+use App\Http\Api\Field\Field;
+use App\Http\Api\Include\AllowedInclude;
+use App\Http\Api\Parser\FieldParser;
+use App\Http\Api\Parser\FilterParser;
+use App\Http\Api\Parser\IncludeParser;
+use App\Http\Api\Parser\PagingParser;
+use App\Http\Api\Parser\SortParser;
+use App\Http\Api\Query\Query;
+use App\Http\Api\Schema\Pivot\Wiki\AnimeResourceSchema;
+use App\Http\Resources\Pivot\Wiki\Collection\AnimeResourceCollection;
+use App\Http\Resources\Pivot\Wiki\Resource\AnimeResourceResource;
+use App\Models\Wiki\Anime;
+use App\Models\Wiki\ExternalResource;
+use App\Pivots\BasePivot;
+use App\Pivots\Wiki\AnimeResource;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\WithoutEvents;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+use Tests\TestCase;
+
+/**
+ * Class AnimeResourceIndexTest.
+ */
+class AnimeResourceIndexTest extends TestCase
+{
+    use SortsModels;
+    use WithFaker;
+    use WithoutEvents;
+
+    /**
+     * By default, the Anime Resource Index Endpoint shall return a collection of Anime Resource Resources.
+     *
+     * @return void
+     */
+    public function testDefault(): void
+    {
+        Collection::times($this->faker->randomDigitNotNull(), function () {
+            AnimeResource::factory()
+                ->for(Anime::factory())
+                ->for(ExternalResource::factory(), AnimeResource::RELATION_RESOURCE)
+                ->create();
+        });
+
+        $animeResources = AnimeResource::all();
+
+        $response = $this->get(route('api.animeresource.index'));
+
+        $response->assertJson(
+            json_decode(
+                json_encode(
+                    (new AnimeResourceCollection($animeResources, new Query()))
+                        ->response()
+                        ->getData()
+                ),
+                true
+            )
+        );
+    }
+
+    /**
+     * The Theme Index Endpoint shall be paginated.
+     *
+     * @return void
+     */
+    public function testPaginated(): void
+    {
+        Collection::times($this->faker->randomDigitNotNull(), function () {
+            AnimeResource::factory()
+                ->for(Anime::factory())
+                ->for(ExternalResource::factory(), AnimeResource::RELATION_RESOURCE)
+                ->create();
+        });
+
+        $response = $this->get(route('api.animeresource.index'));
+
+        $response->assertJsonStructure([
+            AnimeResourceCollection::$wrap,
+            'links',
+            'meta',
+        ]);
+    }
+
+    /**
+     * The Anime Resource Index Endpoint shall allow inclusion of related resources.
+     *
+     * @return void
+     */
+    public function testAllowedIncludePaths(): void
+    {
+        $schema = new AnimeResourceSchema();
+
+        $allowedIncludes = collect($schema->allowedIncludes());
+
+        $selectedIncludes = $allowedIncludes->random($this->faker->numberBetween(1, $allowedIncludes->count()));
+
+        $includedPaths = $selectedIncludes->map(fn (AllowedInclude $include) => $include->path());
+
+        $parameters = [
+            IncludeParser::param() => $includedPaths->join(','),
+        ];
+
+        Collection::times($this->faker->randomDigitNotNull(), function () {
+            AnimeResource::factory()
+                ->for(Anime::factory())
+                ->for(ExternalResource::factory(), AnimeResource::RELATION_RESOURCE)
+                ->create();
+        });
+
+        $response = $this->get(route('api.animeresource.index', $parameters));
+
+        $animeResources = AnimeResource::with($includedPaths->all())->get();
+
+        $response->assertJson(
+            json_decode(
+                json_encode(
+                    (new AnimeResourceCollection($animeResources, new Query($parameters)))
+                        ->response()
+                        ->getData()
+                ),
+                true
+            )
+        );
+    }
+
+    /**
+     * The Anime Resource Index Endpoint shall implement sparse fieldsets.
+     *
+     * @return void
+     */
+    public function testSparseFieldsets(): void
+    {
+        $schema = new AnimeResourceSchema();
+
+        $fields = collect($schema->fields());
+
+        $includedFields = $fields->random($this->faker->numberBetween(1, $fields->count()));
+
+        $parameters = [
+            FieldParser::param() => [
+                AnimeResourceResource::$wrap => $includedFields->map(fn (Field $field) => $field->getKey())->join(','),
+            ],
+        ];
+
+        Collection::times($this->faker->randomDigitNotNull(), function () {
+            AnimeResource::factory()
+                ->for(Anime::factory())
+                ->for(ExternalResource::factory(), AnimeResource::RELATION_RESOURCE)
+                ->create();
+        });
+
+        $response = $this->get(route('api.animeresource.index', $parameters));
+
+        $animeResources = AnimeResource::all();
+
+        $response->assertJson(
+            json_decode(
+                json_encode(
+                    (new AnimeResourceCollection($animeResources, new Query($parameters)))
+                        ->response()
+                        ->getData()
+                ),
+                true
+            )
+        );
+    }
+
+    /**
+     * The Anime Resource Index Endpoint shall support sorting resources.
+     *
+     * @return void
+     */
+    public function testSorts(): void
+    {
+        $schema = new AnimeResourceSchema();
+
+        $sort = collect($schema->fields())
+            ->filter(fn (Field $field) => $field instanceof SortableField)
+            ->map(fn (SortableField $field) => $field->getSort())
+            ->random();
+
+        $parameters = [
+            SortParser::param() => $sort->format(Direction::getRandomInstance()),
+        ];
+
+        $query = new Query($parameters);
+
+        Collection::times($this->faker->randomDigitNotNull(), function () {
+            AnimeResource::factory()
+                ->for(Anime::factory())
+                ->for(ExternalResource::factory(), AnimeResource::RELATION_RESOURCE)
+                ->create();
+        });
+
+        $response = $this->get(route('api.animeresource.index', $parameters));
+
+        $animeResources = $this->sort(AnimeResource::query(), $query, $schema)->get();
+
+        $response->assertJson(
+            json_decode(
+                json_encode(
+                    (new AnimeResourceCollection($animeResources, $query))
+                        ->response()
+                        ->getData()
+                ),
+                true
+            )
+        );
+    }
+
+    /**
+     * The Anime Resource Index Endpoint shall support filtering by created_at.
+     *
+     * @return void
+     */
+    public function testCreatedAtFilter(): void
+    {
+        $createdFilter = $this->faker->date();
+        $excludedDate = $this->faker->date();
+
+        $parameters = [
+            FilterParser::param() => [
+                BasePivot::ATTRIBUTE_CREATED_AT => $createdFilter,
+            ],
+            PagingParser::param() => [
+                OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
+            ],
+        ];
+
+        Carbon::withTestNow($createdFilter, function () {
+            Collection::times($this->faker->randomDigitNotNull(), function () {
+                AnimeResource::factory()
+                    ->for(Anime::factory())
+                    ->for(ExternalResource::factory(), AnimeResource::RELATION_RESOURCE)
+                    ->create();
+            });
+        });
+
+        Carbon::withTestNow($excludedDate, function () {
+            Collection::times($this->faker->randomDigitNotNull(), function () {
+                AnimeResource::factory()
+                    ->for(Anime::factory())
+                    ->for(ExternalResource::factory(), AnimeResource::RELATION_RESOURCE)
+                    ->create();
+            });
+        });
+
+        $animeResources = AnimeResource::query()->where(BasePivot::ATTRIBUTE_CREATED_AT, $createdFilter)->get();
+
+        $response = $this->get(route('api.animeresource.index', $parameters));
+
+        $response->assertJson(
+            json_decode(
+                json_encode(
+                    (new AnimeResourceCollection($animeResources, new Query($parameters)))
+                        ->response()
+                        ->getData()
+                ),
+                true
+            )
+        );
+    }
+
+    /**
+     * The Anime Resource Index Endpoint shall support filtering by updated_at.
+     *
+     * @return void
+     */
+    public function testUpdatedAtFilter(): void
+    {
+        $updatedFilter = $this->faker->date();
+        $excludedDate = $this->faker->date();
+
+        $parameters = [
+            FilterParser::param() => [
+                BasePivot::ATTRIBUTE_UPDATED_AT => $updatedFilter,
+            ],
+            PagingParser::param() => [
+                OffsetCriteria::SIZE_PARAM => Criteria::MAX_RESULTS,
+            ],
+        ];
+
+        Carbon::withTestNow($updatedFilter, function () {
+            Collection::times($this->faker->randomDigitNotNull(), function () {
+                AnimeResource::factory()
+                    ->for(Anime::factory())
+                    ->for(ExternalResource::factory(), AnimeResource::RELATION_RESOURCE)
+                    ->create();
+            });
+        });
+
+        Carbon::withTestNow($excludedDate, function () {
+            Collection::times($this->faker->randomDigitNotNull(), function () {
+                AnimeResource::factory()
+                    ->for(Anime::factory())
+                    ->for(ExternalResource::factory(), AnimeResource::RELATION_RESOURCE)
+                    ->create();
+            });
+        });
+
+        $animeResources = AnimeResource::query()->where(BasePivot::ATTRIBUTE_UPDATED_AT, $updatedFilter)->get();
+
+        $response = $this->get(route('api.animeresource.index', $parameters));
+
+        $response->assertJson(
+            json_decode(
+                json_encode(
+                    (new AnimeResourceCollection($animeResources, new Query($parameters)))
+                        ->response()
+                        ->getData()
+                ),
+                true
+            )
+        );
+    }
+
+    /**
+     * The Anime Resource Index Endpoint shall support constrained eager loading of resources by site.
+     *
+     * @return void
+     */
+    public function testResourcesBySite(): void
+    {
+        $siteFilter = ResourceSite::getRandomInstance();
+
+        $parameters = [
+            FilterParser::param() => [
+                ExternalResource::ATTRIBUTE_SITE => $siteFilter->description,
+            ],
+            IncludeParser::param() => AnimeResource::RELATION_RESOURCE,
+        ];
+
+        Collection::times($this->faker->randomDigitNotNull(), function () {
+            AnimeResource::factory()
+                ->for(Anime::factory())
+                ->for(ExternalResource::factory(), AnimeResource::RELATION_RESOURCE)
+                ->create();
+        });
+
+        $response = $this->get(route('api.animeresource.index', $parameters));
+
+        $animeResources = AnimeResource::with([
+            AnimeResource::RELATION_RESOURCE => function (BelongsTo $query) use ($siteFilter) {
+                $query->where(ExternalResource::ATTRIBUTE_SITE, $siteFilter->value);
+            },
+        ])
+            ->get();
+
+        $response->assertJson(
+            json_decode(
+                json_encode(
+                    (new AnimeResourceCollection($animeResources, new Query($parameters)))
+                        ->response()
+                        ->getData()
+                ),
+                true
+            )
+        );
+    }
+
+    /**
+     * The Anime Resource Show Endpoint shall support constrained eager loading of anime by season.
+     *
+     * @return void
+     */
+    public function testAnimeBySeason(): void
+    {
+        $seasonFilter = AnimeSeason::getRandomInstance();
+
+        $parameters = [
+            FilterParser::param() => [
+                Anime::ATTRIBUTE_SEASON => $seasonFilter->description,
+            ],
+            IncludeParser::param() => AnimeResource::RELATION_ANIME,
+        ];
+
+        Collection::times($this->faker->randomDigitNotNull(), function () {
+            AnimeResource::factory()
+                ->for(Anime::factory())
+                ->for(ExternalResource::factory(), AnimeResource::RELATION_RESOURCE)
+                ->create();
+        });
+
+        $response = $this->get(route('api.animeresource.index', $parameters));
+
+        $animeResources = AnimeResource::with([
+            AnimeResource::RELATION_ANIME => function (BelongsTo $query) use ($seasonFilter) {
+                $query->where(Anime::ATTRIBUTE_SEASON, $seasonFilter->value);
+            },
+        ])
+            ->get();
+
+        $response->assertJson(
+            json_decode(
+                json_encode(
+                    (new AnimeResourceCollection($animeResources, new Query($parameters)))
+                        ->response()
+                        ->getData()
+                ),
+                true
+            )
+        );
+    }
+
+    /**
+     * The Anime Resource Show Endpoint shall support constrained eager loading of anime by year.
+     *
+     * @return void
+     */
+    public function testAnimeByYear(): void
+    {
+        $yearFilter = intval($this->faker->year());
+        $excludedYear = $yearFilter + 1;
+
+        $parameters = [
+            FilterParser::param() => [
+                Anime::ATTRIBUTE_YEAR => $yearFilter,
+            ],
+            IncludeParser::param() => AnimeResource::RELATION_ANIME,
+        ];
+
+        Collection::times($this->faker->randomDigitNotNull(), function () use ($yearFilter, $excludedYear) {
+            AnimeResource::factory()
+                ->for(
+                    Anime::factory()
+                        ->state([
+                            Anime::ATTRIBUTE_YEAR => $this->faker->boolean() ? $yearFilter : $excludedYear,
+                        ])
+                )
+                ->for(ExternalResource::factory(), AnimeResource::RELATION_RESOURCE)
+                ->create();
+        });
+
+        $response = $this->get(route('api.animeresource.index', $parameters));
+
+        $animeResources = AnimeResource::with([
+            AnimeResource::RELATION_ANIME => function (BelongsTo $query) use ($yearFilter) {
+                $query->where(Anime::ATTRIBUTE_YEAR, $yearFilter);
+            },
+        ])
+            ->get();
+
+        $response->assertJson(
+            json_decode(
+                json_encode(
+                    (new AnimeResourceCollection($animeResources, new Query($parameters)))
+                        ->response()
+                        ->getData()
+                ),
+                true
+            )
+        );
+    }
+}

--- a/tests/Feature/Http/Api/Pivot/Wiki/AnimeResource/AnimeResourceShowTest.php
+++ b/tests/Feature/Http/Api/Pivot/Wiki/AnimeResource/AnimeResourceShowTest.php
@@ -1,0 +1,284 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Http\Api\Pivot\Wiki\AnimeResource;
+
+use App\Enums\Models\Wiki\AnimeSeason;
+use App\Enums\Models\Wiki\ResourceSite;
+use App\Http\Api\Field\Field;
+use App\Http\Api\Include\AllowedInclude;
+use App\Http\Api\Parser\FieldParser;
+use App\Http\Api\Parser\FilterParser;
+use App\Http\Api\Parser\IncludeParser;
+use App\Http\Api\Query\Query;
+use App\Http\Api\Schema\Pivot\Wiki\AnimeResourceSchema;
+use App\Http\Resources\Pivot\Wiki\Resource\AnimeResourceResource;
+use App\Models\Wiki\Anime;
+use App\Models\Wiki\ExternalResource;
+use App\Pivots\Wiki\AnimeResource;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\WithoutEvents;
+use Tests\TestCase;
+
+/**
+ * Class AnimeResourceShowTest.
+ */
+class AnimeResourceShowTest extends TestCase
+{
+    use WithFaker;
+    use WithoutEvents;
+
+    /**
+     * The Anime Resource Show Endpoint shall return an error if the anime resource does not exist.
+     *
+     * @return void
+     */
+    public function testNotFound(): void
+    {
+        $anime = Anime::factory()->createOne();
+        $resource = ExternalResource::factory()->createOne();
+
+        $response = $this->get(route('api.animeresource.show', ['anime' => $anime, 'resource' => $resource]));
+
+        $response->assertNotFound();
+    }
+
+    /**
+     * By default, the Anime Resource Show Endpoint shall return an Anime Resource Resource.
+     *
+     * @return void
+     */
+    public function testDefault(): void
+    {
+        $animeResource = AnimeResource::factory()
+            ->for(Anime::factory())
+            ->for(ExternalResource::factory(), AnimeResource::RELATION_RESOURCE)
+            ->createOne();
+
+        $response = $this->get(route('api.animeresource.show', ['anime' => $animeResource->anime, 'resource' => $animeResource->resource]));
+
+        $animeResource->unsetRelations();
+
+        $response->assertJson(
+            json_decode(
+                json_encode(
+                    (new AnimeResourceResource($animeResource, new Query()))
+                        ->response()
+                        ->getData()
+                ),
+                true
+            )
+        );
+    }
+
+    /**
+     * The Anime Resource Show Endpoint shall allow inclusion of related resources.
+     *
+     * @return void
+     */
+    public function testAllowedIncludePaths(): void
+    {
+        $schema = new AnimeResourceSchema();
+
+        $allowedIncludes = collect($schema->allowedIncludes());
+
+        $selectedIncludes = $allowedIncludes->random($this->faker->numberBetween(1, $allowedIncludes->count()));
+
+        $includedPaths = $selectedIncludes->map(fn (AllowedInclude $include) => $include->path());
+
+        $parameters = [
+            IncludeParser::param() => $includedPaths->join(','),
+        ];
+
+        $animeResource = AnimeResource::factory()
+            ->for(Anime::factory())
+            ->for(ExternalResource::factory(), AnimeResource::RELATION_RESOURCE)
+            ->createOne();
+
+        $response = $this->get(route('api.animeresource.show', ['anime' => $animeResource->anime, 'resource' => $animeResource->resource] + $parameters));
+
+        $animeResource->unsetRelations()->load($includedPaths->all());
+
+        $response->assertJson(
+            json_decode(
+                json_encode(
+                    (new AnimeResourceResource($animeResource, new Query($parameters)))
+                        ->response()
+                        ->getData()
+                ),
+                true
+            )
+        );
+    }
+
+    /**
+     * The Anime Resource Show Endpoint shall implement sparse fieldsets.
+     *
+     * @return void
+     */
+    public function testSparseFieldsets(): void
+    {
+        $schema = new AnimeResourceSchema();
+
+        $fields = collect($schema->fields());
+
+        $includedFields = $fields->random($this->faker->numberBetween(1, $fields->count()));
+
+        $parameters = [
+            FieldParser::param() => [
+                AnimeResourceResource::$wrap => $includedFields->map(fn (Field $field) => $field->getKey())->join(','),
+            ],
+        ];
+
+        $animeResource = AnimeResource::factory()
+            ->for(Anime::factory())
+            ->for(ExternalResource::factory(), AnimeResource::RELATION_RESOURCE)
+            ->createOne();
+
+        $response = $this->get(route('api.animeresource.show', ['anime' => $animeResource->anime, 'resource' => $animeResource->resource] + $parameters));
+
+        $animeResource->unsetRelations();
+
+        $response->assertJson(
+            json_decode(
+                json_encode(
+                    (new AnimeResourceResource($animeResource, new Query($parameters)))
+                        ->response()
+                        ->getData()
+                ),
+                true
+            )
+        );
+    }
+
+    /**
+     * The Anime Resource Show Endpoint shall support constrained eager loading of resources by site.
+     *
+     * @return void
+     */
+    public function testResourcesBySite(): void
+    {
+        $siteFilter = ResourceSite::getRandomInstance();
+
+        $parameters = [
+            FilterParser::param() => [
+                ExternalResource::ATTRIBUTE_SITE => $siteFilter->description,
+            ],
+            IncludeParser::param() => AnimeResource::RELATION_RESOURCE,
+        ];
+
+        $animeResource = AnimeResource::factory()
+            ->for(Anime::factory())
+            ->for(ExternalResource::factory(), AnimeResource::RELATION_RESOURCE)
+            ->createOne();
+
+        $response = $this->get(route('api.animeresource.show', ['anime' => $animeResource->anime, 'resource' => $animeResource->resource] + $parameters));
+
+        $animeResource->unsetRelations()->load([
+            AnimeResource::RELATION_RESOURCE => function (BelongsTo $query) use ($siteFilter) {
+                $query->where(ExternalResource::ATTRIBUTE_SITE, $siteFilter->value);
+            },
+        ]);
+
+        $response->assertJson(
+            json_decode(
+                json_encode(
+                    (new AnimeResourceResource($animeResource, new Query($parameters)))
+                        ->response()
+                        ->getData()
+                ),
+                true
+            )
+        );
+    }
+
+    /**
+     * The Anime Resource Show Endpoint shall support constrained eager loading of anime by season.
+     *
+     * @return void
+     */
+    public function testAnimeBySeason(): void
+    {
+        $seasonFilter = AnimeSeason::getRandomInstance();
+
+        $parameters = [
+            FilterParser::param() => [
+                Anime::ATTRIBUTE_SEASON => $seasonFilter->description,
+            ],
+            IncludeParser::param() => AnimeResource::RELATION_ANIME,
+        ];
+
+        $animeResource = AnimeResource::factory()
+            ->for(Anime::factory())
+            ->for(ExternalResource::factory(), AnimeResource::RELATION_RESOURCE)
+            ->createOne();
+
+        $response = $this->get(route('api.animeresource.show', ['anime' => $animeResource->anime, 'resource' => $animeResource->resource] + $parameters));
+
+        $animeResource->unsetRelations()->load([
+            AnimeResource::RELATION_ANIME => function (BelongsTo $query) use ($seasonFilter) {
+                $query->where(Anime::ATTRIBUTE_SEASON, $seasonFilter->value);
+            },
+        ]);
+
+        $response->assertJson(
+            json_decode(
+                json_encode(
+                    (new AnimeResourceResource($animeResource, new Query($parameters)))
+                        ->response()
+                        ->getData()
+                ),
+                true
+            )
+        );
+    }
+
+    /**
+     * The Anime Resource Show Endpoint shall support constrained eager loading of anime by year.
+     *
+     * @return void
+     */
+    public function testAnimeByYear(): void
+    {
+        $yearFilter = intval($this->faker->year());
+        $excludedYear = $yearFilter + 1;
+
+        $parameters = [
+            FilterParser::param() => [
+                Anime::ATTRIBUTE_YEAR => $yearFilter,
+            ],
+            IncludeParser::param() => AnimeResource::RELATION_ANIME,
+        ];
+
+        $animeResource = AnimeResource::factory()
+            ->for(
+                Anime::factory()
+                    ->state([
+                        Anime::ATTRIBUTE_YEAR => $this->faker->boolean() ? $yearFilter : $excludedYear,
+                    ])
+            )
+            ->for(ExternalResource::factory(), AnimeResource::RELATION_RESOURCE)
+            ->createOne();
+
+        $response = $this->get(route('api.animeresource.show', ['anime' => $animeResource->anime, 'resource' => $animeResource->resource] + $parameters));
+
+        $animeResource->unsetRelations()->load([
+            AnimeResource::RELATION_ANIME => function (BelongsTo $query) use ($yearFilter) {
+                $query->where(Anime::ATTRIBUTE_YEAR, $yearFilter);
+            },
+        ]);
+
+        $response->assertJson(
+            json_decode(
+                json_encode(
+                    (new AnimeResourceResource($animeResource, new Query($parameters)))
+                        ->response()
+                        ->getData()
+                ),
+                true
+            )
+        );
+    }
+}

--- a/tests/Feature/Http/Api/Pivot/Wiki/AnimeResource/AnimeResourceStoreTest.php
+++ b/tests/Feature/Http/Api/Pivot/Wiki/AnimeResource/AnimeResourceStoreTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Http\Api\Pivot\Wiki\AnimeResource;
+
+use App\Models\Auth\User;
+use App\Models\Wiki\Anime;
+use App\Models\Wiki\ExternalResource;
+use App\Pivots\Wiki\AnimeResource;
+use Illuminate\Foundation\Testing\WithoutEvents;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+/**
+ * Class AnimeResourceStoreTest.
+ */
+class AnimeResourceStoreTest extends TestCase
+{
+    use WithoutEvents;
+
+    /**
+     * The Anime Resource Store Destroy Endpoint shall be protected by sanctum.
+     *
+     * @return void
+     */
+    public function testProtected(): void
+    {
+        $animeResource = AnimeResource::factory()
+            ->for(Anime::factory())
+            ->for(ExternalResource::factory(), AnimeResource::RELATION_RESOURCE)
+            ->makeOne();
+
+        $response = $this->post(route('api.animeresource.store', $animeResource->toArray()));
+
+        $response->assertUnauthorized();
+    }
+
+    /**
+     * The Anime Resource Store Endpoint shall forbid users without the create anime & create resource permissions.
+     *
+     * @return void
+     */
+    public function testForbidden(): void
+    {
+        $animeResource = AnimeResource::factory()
+            ->for(Anime::factory())
+            ->for(ExternalResource::factory(), AnimeResource::RELATION_RESOURCE)
+            ->makeOne();
+
+        $user = User::factory()->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->post(route('api.animeresource.store', $animeResource->toArray()));
+
+        $response->assertForbidden();
+    }
+
+    /**
+     * The Anime Resource Store Endpoint shall require anime and resource fields.
+     *
+     * @return void
+     */
+    public function testRequiredFields(): void
+    {
+        $user = User::factory()->withPermissions(['create anime', 'create external resource'])->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->post(route('api.animeresource.store'));
+
+        $response->assertJsonValidationErrors([
+            AnimeResource::ATTRIBUTE_ANIME,
+            AnimeResource::ATTRIBUTE_RESOURCE,
+        ]);
+    }
+
+    /**
+     * The Anime Resource Store Endpoint shall create an anime resource.
+     *
+     * @return void
+     */
+    public function testCreate(): void
+    {
+        $parameters = array_merge(
+            AnimeResource::factory()->raw(),
+            [AnimeResource::ATTRIBUTE_ANIME => Anime::factory()->createOne()->getKey()],
+            [AnimeResource::ATTRIBUTE_RESOURCE => ExternalResource::factory()->createOne()->getKey()],
+        );
+
+        $user = User::factory()->withPermissions(['create anime', 'create external resource'])->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->post(route('api.animeresource.store', $parameters));
+
+        $response->assertCreated();
+        static::assertDatabaseCount(AnimeResource::TABLE, 1);
+    }
+}

--- a/tests/Feature/Http/Api/Pivot/Wiki/AnimeResource/AnimeResourceUpdateTest.php
+++ b/tests/Feature/Http/Api/Pivot/Wiki/AnimeResource/AnimeResourceUpdateTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Http\Api\Pivot\Wiki\AnimeResource;
+
+use App\Models\Auth\User;
+use App\Models\Wiki\Anime;
+use App\Models\Wiki\ExternalResource;
+use App\Pivots\Wiki\AnimeResource;
+use Illuminate\Foundation\Testing\WithoutEvents;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+/**
+ * Class AnimeResourceUpdateTest.
+ */
+class AnimeResourceUpdateTest extends TestCase
+{
+    use WithoutEvents;
+
+    /**
+     * The Anime Resource Update Destroy Endpoint shall be protected by sanctum.
+     *
+     * @return void
+     */
+    public function testProtected(): void
+    {
+        $animeResource = AnimeResource::factory()
+            ->for(Anime::factory())
+            ->for(ExternalResource::factory(), AnimeResource::RELATION_RESOURCE)
+            ->createOne();
+
+        $parameters = AnimeResource::factory()->raw();
+
+        $response = $this->put(route('api.animeresource.update', ['anime' => $animeResource->anime, 'resource' => $animeResource->resource] + $parameters));
+
+        $response->assertUnauthorized();
+    }
+
+    /**
+     * The Anime Resource Update Endpoint shall forbid users without the update anime & update resource permissions.
+     *
+     * @return void
+     */
+    public function testForbidden(): void
+    {
+        $animeResource = AnimeResource::factory()
+            ->for(Anime::factory())
+            ->for(ExternalResource::factory(), AnimeResource::RELATION_RESOURCE)
+            ->createOne();
+
+        $parameters = AnimeResource::factory()->raw();
+
+        $user = User::factory()->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->put(route('api.animeresource.update', ['anime' => $animeResource->anime, 'resource' => $animeResource->resource] + $parameters));
+
+        $response->assertForbidden();
+    }
+
+    /**
+     * The Anime Resource Update Endpoint shall update an anime resource.
+     *
+     * @return void
+     */
+    public function testUpdate(): void
+    {
+        $animeResource = AnimeResource::factory()
+            ->for(Anime::factory())
+            ->for(ExternalResource::factory(), AnimeResource::RELATION_RESOURCE)
+            ->createOne();
+
+        $parameters = AnimeResource::factory()->raw();
+
+        $user = User::factory()->withPermissions(['update anime', 'update external resource'])->createOne();
+
+        Sanctum::actingAs($user);
+
+        $response = $this->put(route('api.animeresource.update', ['anime' => $animeResource->anime, 'resource' => $animeResource->resource] + $parameters));
+
+        $response->assertOk();
+    }
+}


### PR DESCRIPTION
* Testing new DX for adding new API endpoints, evaluating remaining pain points.
* We might need pivot resources configured to address some pain points in the transformation layer.
* There was a request for these actions in the API layer.

With this and AnimeImage being configured, there is a blueprint for pivots with and without pivot fields, so the rest can be backfilled fairly easily.