### PR TITLE
feat(api): add track store insert operations for doubly-linked list

### DIFF
--- a/app/Actions/Http/Api/List/Playlist/Track/StoreTrackAction.php
+++ b/app/Actions/Http/Api/List/Playlist/Track/StoreTrackAction.php
@@ -5,10 +5,14 @@ declare(strict_types=1);
 namespace App\Actions\Http\Api\List\Playlist\Track;
 
 use App\Actions\Http\Api\StoreAction;
+use App\Actions\Models\List\Playlist\InsertTrackAction;
+use App\Actions\Models\List\Playlist\InsertTrackAfterAction;
+use App\Actions\Models\List\Playlist\InsertTrackBeforeAction;
 use App\Models\List\Playlist;
 use App\Models\List\Playlist\PlaylistTrack;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 
 /**
  * Class StoreTrackAction.
@@ -25,19 +29,46 @@ class StoreTrackAction
      */
     public function store(Playlist $playlist, Builder $builder, array $parameters): Model
     {
-        $trackParameters = array_merge(
-            $parameters,
-            [PlaylistTrack::ATTRIBUTE_PLAYLIST => $playlist->getKey()]
-        );
+        $trackParameters = $parameters;
+
+        $previousId = Arr::pull($trackParameters, PlaylistTrack::ATTRIBUTE_PREVIOUS);
+        $nextId = Arr::pull($trackParameters, PlaylistTrack::ATTRIBUTE_NEXT);
+
+        $trackParameters = $trackParameters + [PlaylistTrack::ATTRIBUTE_PLAYLIST => $playlist->getKey()];
 
         $storeAction = new StoreAction();
 
+        /** @var PlaylistTrack $track */
         $track = $storeAction->store($builder, $trackParameters);
 
-        if ($playlist->tracks()->count() === 1 && $playlist->first()->doesntExist()) {
-            $playlist->first()->associate($track)->save();
+        if (! empty($nextId) && empty($previousId)) {
+            /** @var PlaylistTrack $next */
+            $next = PlaylistTrack::query()
+                ->with(PlaylistTrack::RELATION_PREVIOUS)
+                ->findOrFail($nextId);
+
+            $insertAction = new InsertTrackBeforeAction();
+
+            $insertAction->insertBefore($playlist, $track, $next);
         }
 
-        return $track;
+        if (! empty($previousId) && empty($nextId)) {
+            /** @var PlaylistTrack $previous */
+            $previous = PlaylistTrack::query()
+                ->with(PlaylistTrack::RELATION_NEXT)
+                ->findOrFail($previousId);
+
+            $insertAction = new InsertTrackAfterAction();
+
+            $insertAction->insertAfter($playlist, $track, $previous);
+        }
+
+        if (empty($nextId) && empty($previousId)) {
+            $insertAction = new InsertTrackAction();
+
+            $insertAction->insert($playlist, $track);
+        }
+
+        return $storeAction->cleanup($track);
     }
 }

--- a/app/Actions/Http/Api/StoreAction.php
+++ b/app/Actions/Http/Api/StoreAction.php
@@ -23,6 +23,17 @@ class StoreAction
     {
         $model = $builder->create($parameters);
 
+        return $this->cleanup($model);
+    }
+
+    /**
+     * Perform model cleanup for presentation.
+     *
+     * @param  Model  $model
+     * @return Model
+     */
+    public function cleanup(Model $model): Model
+    {
         // Scout will load relations to refresh related search indices.
         $model->unsetRelations();
 

--- a/app/Actions/Models/List/Playlist/InsertTrackAction.php
+++ b/app/Actions/Models/List/Playlist/InsertTrackAction.php
@@ -13,7 +13,7 @@ use App\Models\List\Playlist\PlaylistTrack;
 class InsertTrackAction
 {
     /**
-     * Insert new track before next track.
+     * Append track to playlist.
      *
      * @param  Playlist  $playlist
      * @param  PlaylistTrack  $track

--- a/app/Actions/Models/List/Playlist/InsertTrackAction.php
+++ b/app/Actions/Models/List/Playlist/InsertTrackAction.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Models\List\Playlist;
+
+use App\Models\List\Playlist;
+use App\Models\List\Playlist\PlaylistTrack;
+
+/**
+ * Class InsertTrackAction.
+ */
+class InsertTrackAction
+{
+    /**
+     * Insert new track before next track.
+     *
+     * @param  Playlist  $playlist
+     * @param  PlaylistTrack  $track
+     * @return void
+     */
+    public function insert(Playlist $playlist, PlaylistTrack $track): void
+    {
+        if ($playlist->first()->doesntExist()) {
+            $playlist->first()->associate($track);
+        }
+
+        $last = $playlist->last;
+
+        if ($last !== null) {
+            $last->next()->associate($track)->save();
+            $track->previous()->associate($last)->save();
+        }
+
+        $playlist->last()->associate($track)->save();
+    }
+}

--- a/app/Actions/Models/List/Playlist/InsertTrackAfterAction.php
+++ b/app/Actions/Models/List/Playlist/InsertTrackAfterAction.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Models\List\Playlist;
+
+use App\Models\List\Playlist;
+use App\Models\List\Playlist\PlaylistTrack;
+
+/**
+ * Class InsertTrackAfterAction.
+ */
+class InsertTrackAfterAction
+{
+    /**
+     * Insert new track before next track.
+     *
+     * @param  Playlist  $playlist
+     * @param  PlaylistTrack  $track
+     * @param  PlaylistTrack  $previous
+     * @return void
+     */
+    public function insertAfter(Playlist $playlist, PlaylistTrack $track, PlaylistTrack $previous): void
+    {
+        $next = $previous->next;
+
+        if ($next === null) {
+            $playlist->last()->associate($track)->save();
+        } else {
+            $next->previous()->associate($track)->save();
+            $track->next()->associate($next);
+        }
+
+        $previous->next()->associate($track)->save();
+        $track->previous()->associate($previous)->save();
+    }
+}

--- a/app/Actions/Models/List/Playlist/InsertTrackAfterAction.php
+++ b/app/Actions/Models/List/Playlist/InsertTrackAfterAction.php
@@ -13,7 +13,7 @@ use App\Models\List\Playlist\PlaylistTrack;
 class InsertTrackAfterAction
 {
     /**
-     * Insert new track before next track.
+     * Insert track after previous track.
      *
      * @param  Playlist  $playlist
      * @param  PlaylistTrack  $track

--- a/app/Actions/Models/List/Playlist/InsertTrackBeforeAction.php
+++ b/app/Actions/Models/List/Playlist/InsertTrackBeforeAction.php
@@ -13,7 +13,7 @@ use App\Models\List\Playlist\PlaylistTrack;
 class InsertTrackBeforeAction
 {
     /**
-     * Insert new track before next track.
+     * Insert track before next track.
      *
      * @param  Playlist  $playlist
      * @param  PlaylistTrack  $track

--- a/app/Actions/Models/List/Playlist/InsertTrackBeforeAction.php
+++ b/app/Actions/Models/List/Playlist/InsertTrackBeforeAction.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Models\List\Playlist;
+
+use App\Models\List\Playlist;
+use App\Models\List\Playlist\PlaylistTrack;
+
+/**
+ * Class InsertTrackBeforeAction.
+ */
+class InsertTrackBeforeAction
+{
+    /**
+     * Insert new track before next track.
+     *
+     * @param  Playlist  $playlist
+     * @param  PlaylistTrack  $track
+     * @param  PlaylistTrack  $next
+     * @return void
+     */
+    public function insertBefore(Playlist $playlist, PlaylistTrack $track, PlaylistTrack $next): void
+    {
+        $previous = $next->previous;
+
+        if ($previous === null) {
+            $playlist->first()->associate($track)->save();
+        } else {
+            $previous->next()->associate($track)->save();
+            $track->previous()->associate($previous);
+        }
+
+        $next->previous()->associate($track)->save();
+        $track->next()->associate($next)->save();
+    }
+}

--- a/app/Http/Api/Field/List/Playlist/Track/TrackNextIdField.php
+++ b/app/Http/Api/Field/List/Playlist/Track/TrackNextIdField.php
@@ -13,6 +13,7 @@ use App\Http\Api\Schema\Schema;
 use App\Models\List\Playlist;
 use App\Models\List\Playlist\PlaylistTrack;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 
 /**
@@ -45,6 +46,7 @@ class TrackNextIdField extends Field implements CreatableField, SelectableField,
             'sometimes',
             'required',
             'integer',
+            Str::of('prohibits:')->append(PlaylistTrack::ATTRIBUTE_PREVIOUS)->__toString(),
             Rule::exists(PlaylistTrack::TABLE, PlaylistTrack::ATTRIBUTE_ID)
                 ->where(PlaylistTrack::ATTRIBUTE_PLAYLIST, $playlist?->getKey()),
         ];
@@ -74,12 +76,17 @@ class TrackNextIdField extends Field implements CreatableField, SelectableField,
         /** @var Playlist|null $playlist */
         $playlist = $request->route('playlist');
 
+        /** @var PlaylistTrack $track */
+        $track = $request->route('track');
+
         return [
             'sometimes',
             'required',
             'integer',
+            Str::of('prohibits:')->append(PlaylistTrack::ATTRIBUTE_PREVIOUS)->__toString(),
             Rule::exists(PlaylistTrack::TABLE, PlaylistTrack::ATTRIBUTE_ID)
-                ->where(PlaylistTrack::ATTRIBUTE_PLAYLIST, $playlist?->getKey()),
+                ->where(PlaylistTrack::ATTRIBUTE_PLAYLIST, $playlist?->getKey())
+                ->whereNot(PlaylistTrack::ATTRIBUTE_ID, $track->getKey()),
         ];
     }
 }

--- a/app/Http/Api/Field/List/Playlist/Track/TrackPreviousIdField.php
+++ b/app/Http/Api/Field/List/Playlist/Track/TrackPreviousIdField.php
@@ -13,6 +13,7 @@ use App\Http\Api\Schema\Schema;
 use App\Models\List\Playlist;
 use App\Models\List\Playlist\PlaylistTrack;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 
 /**
@@ -45,6 +46,7 @@ class TrackPreviousIdField extends Field implements CreatableField, SelectableFi
             'sometimes',
             'required',
             'integer',
+            Str::of('prohibits:')->append(PlaylistTrack::ATTRIBUTE_NEXT)->__toString(),
             Rule::exists(PlaylistTrack::TABLE, PlaylistTrack::ATTRIBUTE_ID)
                 ->where(PlaylistTrack::ATTRIBUTE_PLAYLIST, $playlist?->getKey()),
         ];
@@ -74,12 +76,17 @@ class TrackPreviousIdField extends Field implements CreatableField, SelectableFi
         /** @var Playlist|null $playlist */
         $playlist = $request->route('playlist');
 
+        /** @var PlaylistTrack $track */
+        $track = $request->route('track');
+
         return [
             'sometimes',
             'required',
             'integer',
+            Str::of('prohibits:')->append(PlaylistTrack::ATTRIBUTE_NEXT)->__toString(),
             Rule::exists(PlaylistTrack::TABLE, PlaylistTrack::ATTRIBUTE_ID)
-                ->where(PlaylistTrack::ATTRIBUTE_PLAYLIST, $playlist?->getKey()),
+                ->where(PlaylistTrack::ATTRIBUTE_PLAYLIST, $playlist?->getKey())
+                ->whereNot(PlaylistTrack::ATTRIBUTE_ID, $track->getKey()),
         ];
     }
 }

--- a/tests/Feature/Actions/Models/List/Playlist/InsertTrackAfterTest.php
+++ b/tests/Feature/Actions/Models/List/Playlist/InsertTrackAfterTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Actions\Models\List\Playlist;
+
+use App\Actions\Models\List\Playlist\InsertTrackAfterAction;
+use App\Models\List\Playlist;
+use App\Models\List\Playlist\PlaylistTrack;
+use App\Models\Wiki\Video;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\WithoutEvents;
+use Tests\TestCase;
+
+/**
+ * Class InsertTrackAfterTest.
+ */
+class InsertTrackAfterTest extends TestCase
+{
+    use WithFaker;
+    use WithoutEvents;
+
+    /**
+     * The Insert Track After Action shall set the track as the playlist's last track if inserting after the last track.
+     *
+     * @return void
+     */
+    public function testLastTrack(): void
+    {
+        $playlist = Playlist::factory()
+            ->tracks($this->faker->numberBetween(2, 9))
+            ->createOne();
+
+        $last = $playlist->last;
+
+        $track = PlaylistTrack::factory()
+            ->for($playlist)
+            ->for(Video::factory())
+            ->createOne();
+
+        $action = new InsertTrackAfterAction();
+
+        $action->insertAfter($playlist, $track, $last);
+
+        static::assertTrue($playlist->last()->is($track));
+
+        static::assertTrue($last->next()->is($track));
+
+        static::assertTrue($track->previous()->is($last));
+        static::assertTrue($track->next()->doesntExist());
+    }
+
+    /**
+     * The Insert Track After Action shall set the track as the first track's next track if inserting after it.
+     *
+     * @return void
+     */
+    public function testFirstTrack(): void
+    {
+        $playlist = Playlist::factory()
+            ->tracks($this->faker->numberBetween(2, 9))
+            ->createOne();
+
+        $first = $playlist->first;
+
+        $next = $first->next;
+
+        $track = PlaylistTrack::factory()
+            ->for($playlist)
+            ->for(Video::factory())
+            ->createOne();
+
+        $action = new InsertTrackAfterAction();
+
+        $action->insertAfter($playlist, $track, $first);
+
+        static::assertTrue($playlist->first()->is($first));
+
+        static::assertTrue($first->next()->is($track));
+
+        static::assertTrue($track->previous()->is($first));
+        static::assertTrue($track->next()->is($next));
+    }
+}

--- a/tests/Feature/Actions/Models/List/Playlist/InsertTrackBeforeTest.php
+++ b/tests/Feature/Actions/Models/List/Playlist/InsertTrackBeforeTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Actions\Models\List\Playlist;
+
+use App\Actions\Models\List\Playlist\InsertTrackBeforeAction;
+use App\Models\List\Playlist;
+use App\Models\List\Playlist\PlaylistTrack;
+use App\Models\Wiki\Video;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\WithoutEvents;
+use Tests\TestCase;
+
+/**
+ * Class InsertTrackBeforeTest.
+ */
+class InsertTrackBeforeTest extends TestCase
+{
+    use WithFaker;
+    use WithoutEvents;
+
+    /**
+     * The Insert Track Before Action shall set the track as the playlist's first track if inserting before the first track.
+     *
+     * @return void
+     */
+    public function testFirstTrack(): void
+    {
+        $playlist = Playlist::factory()
+            ->tracks($this->faker->numberBetween(2, 9))
+            ->createOne();
+
+        $first = $playlist->first;
+
+        $track = PlaylistTrack::factory()
+            ->for($playlist)
+            ->for(Video::factory())
+            ->createOne();
+
+        $action = new InsertTrackBeforeAction();
+
+        $action->insertBefore($playlist, $track, $first);
+
+        static::assertTrue($playlist->first()->is($track));
+
+        static::assertTrue($first->previous()->is($track));
+
+        static::assertTrue($track->next()->is($first));
+        static::assertTrue($track->previous()->doesntExist());
+    }
+
+    /**
+     * The Insert Track Before Action shall set the track as the last track's previous track if inserting before it.
+     *
+     * @return void
+     */
+    public function testLastTrack(): void
+    {
+        $playlist = Playlist::factory()
+            ->tracks($this->faker->numberBetween(2, 9))
+            ->createOne();
+
+        $last = $playlist->last;
+
+        $previous = $last->previous;
+
+        $track = PlaylistTrack::factory()
+            ->for($playlist)
+            ->for(Video::factory())
+            ->createOne();
+
+        $action = new InsertTrackBeforeAction();
+
+        $action->insertBefore($playlist, $track, $last);
+
+        static::assertTrue($playlist->last()->is($last));
+
+        static::assertTrue($last->previous()->is($track));
+
+        static::assertTrue($track->previous()->is($previous));
+        static::assertTrue($track->next()->is($last));
+    }
+}

--- a/tests/Feature/Actions/Models/List/Playlist/InsertTrackTest.php
+++ b/tests/Feature/Actions/Models/List/Playlist/InsertTrackTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Actions\Models\List\Playlist;
+
+use App\Actions\Models\List\Playlist\InsertTrackAction;
+use App\Models\List\Playlist;
+use App\Models\List\Playlist\PlaylistTrack;
+use App\Models\Wiki\Video;
+use Illuminate\Foundation\Testing\WithoutEvents;
+use Tests\TestCase;
+
+/**
+ * Class InsertTrackTest.
+ */
+class InsertTrackTest extends TestCase
+{
+    use WithoutEvents;
+
+    /**
+     * The Insert Track Action shall set the first inserted track as first and last.
+     *
+     * @return void
+     */
+    public function testFirstTrack(): void
+    {
+        $playlist = Playlist::factory()->createOne();
+
+        $track = PlaylistTrack::factory()
+            ->for($playlist)
+            ->for(Video::factory())
+            ->createOne();
+
+        $action = new InsertTrackAction();
+
+        $action->insert($playlist, $track);
+
+        static::assertTrue($playlist->first()->is($track));
+        static::assertTrue($playlist->last()->is($track));
+    }
+
+    /**
+     * The Insert Track Action shall set the second track as the first's next track and the playlist's last track.
+     *
+     * @return void
+     */
+    public function testSecondTrack(): void
+    {
+        $playlist = Playlist::factory()->createOne();
+
+        $first = PlaylistTrack::factory()
+            ->for($playlist)
+            ->for(Video::factory())
+            ->createOne();
+
+        $second = PlaylistTrack::factory()
+            ->for($playlist)
+            ->for(Video::factory())
+            ->createOne();
+
+        $action = new InsertTrackAction();
+
+        $action->insert($playlist, $first);
+        $action->insert($playlist, $second);
+
+        static::assertTrue($playlist->first()->is($first));
+        static::assertTrue($playlist->last()->is($second));
+
+        static::assertTrue($first->previous()->doesntExist());
+        static::assertTrue($first->next()->is($second));
+
+        static::assertTrue($second->previous()->is($first));
+        static::assertTrue($second->next()->doesntExist());
+    }
+
+    /**
+     * The Insert Track Action shall set the third track as the second's next track and the playlist's last track.
+     *
+     * @return void
+     */
+    public function testThirdTrack(): void
+    {
+        $playlist = Playlist::factory()->createOne();
+
+        $first = PlaylistTrack::factory()
+            ->for($playlist)
+            ->for(Video::factory())
+            ->createOne();
+
+        $second = PlaylistTrack::factory()
+            ->for($playlist)
+            ->for(Video::factory())
+            ->createOne();
+
+        $third = PlaylistTrack::factory()
+            ->for($playlist)
+            ->for(Video::factory())
+            ->createOne();
+
+        $action = new InsertTrackAction();
+
+        $action->insert($playlist, $first);
+        $action->insert($playlist, $second);
+        $action->insert($playlist, $third);
+
+        static::assertTrue($playlist->first()->is($first));
+        static::assertTrue($playlist->last()->is($third));
+
+        static::assertTrue($first->previous()->doesntExist());
+        static::assertTrue($first->next()->is($second));
+
+        static::assertTrue($second->previous()->is($first));
+        static::assertTrue($second->next()->is($third));
+
+        static::assertTrue($third->previous()->is($second));
+        static::assertTrue($third->next()->doesntExist());
+    }
+}

--- a/tests/Feature/Http/Api/List/Playlist/Track/TrackUpdateTest.php
+++ b/tests/Feature/Http/Api/List/Playlist/Track/TrackUpdateTest.php
@@ -269,20 +269,10 @@ class TrackUpdateTest extends TestCase
             ->for($playlist)
             ->createOne();
 
-        $previous = PlaylistTrack::factory()
-            ->for($playlist)
-            ->createOne();
-
-        $next = PlaylistTrack::factory()
-            ->for($playlist)
-            ->createOne();
-
         $parameters = array_merge(
             PlaylistTrack::factory()->raw(),
             [
                 PlaylistTrack::ATTRIBUTE_VIDEO => Video::factory()->createOne()->getKey(),
-                PlaylistTrack::ATTRIBUTE_PREVIOUS => $previous->getKey(),
-                PlaylistTrack::ATTRIBUTE_NEXT => $next->getKey(),
             ],
         );
 


### PR DESCRIPTION
Adds doubly-linked list insert operations on track store action.

* By default, we append the new track to the end of the list.
* If `previous_id` is provided in the request, we will insert the new track **AFTER** the previous track.
* If `next_id` is provided in the request, we will insert the new track **BEFORE** the next track.

These parameters prohibit one another since it may make no sense to insert before and after the provided tracks.

Also added additional validation to anticipate update action where we check that we aren't trying to move a track before or after itself.