### PR TITLE
feat(api): add track restore operations for doubly-linked list

### DIFF
--- a/app/Actions/Http/Api/List/Playlist/Track/RestoreTrackAction.php
+++ b/app/Actions/Http/Api/List/Playlist/Track/RestoreTrackAction.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Http\Api\List\Playlist\Track;
+
+use App\Actions\Http\Api\RestoreAction;
+use App\Actions\Models\List\Playlist\InsertTrackAction;
+use App\Models\List\Playlist;
+use App\Models\List\Playlist\PlaylistTrack;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Class RestoreTrackAction.
+ */
+class RestoreTrackAction
+{
+    /**
+     * Store playlist track.
+     *
+     * @param  Playlist  $playlist
+     * @param  PlaylistTrack  $track
+     * @return Model
+     */
+    public function restore(Playlist $playlist, PlaylistTrack $track): Model
+    {
+        $restoreAction = new RestoreAction();
+
+        $restoreAction->restore($track);
+
+        $insertAction = new InsertTrackAction();
+
+        $insertAction->insert($playlist, $track);
+
+        return $restoreAction->cleanup($track);
+    }
+}

--- a/app/Actions/Http/Api/RestoreAction.php
+++ b/app/Actions/Http/Api/RestoreAction.php
@@ -21,6 +21,17 @@ class RestoreAction
     {
         $model->restore();
 
+        return $this->cleanup($model);
+    }
+
+    /**
+     * Perform model cleanup for presentation.
+     *
+     * @param  BaseModel  $model
+     * @return BaseModel
+     */
+    public function cleanup(BaseModel $model): BaseModel
+    {
         // Scout will load relations to refresh related search indices.
         $model->unsetRelations();
 

--- a/app/Http/Controllers/Api/List/Playlist/TrackController.php
+++ b/app/Http/Controllers/Api/List/Playlist/TrackController.php
@@ -7,8 +7,8 @@ namespace App\Http\Controllers\Api\List\Playlist;
 use App\Actions\Http\Api\IndexAction;
 use App\Actions\Http\Api\List\Playlist\Track\DestroyTrackAction;
 use App\Actions\Http\Api\List\Playlist\Track\ForceDeleteTrackAction;
+use App\Actions\Http\Api\List\Playlist\Track\RestoreTrackAction;
 use App\Actions\Http\Api\List\Playlist\Track\StoreTrackAction;
-use App\Actions\Http\Api\RestoreAction;
 use App\Actions\Http\Api\ShowAction;
 use App\Actions\Http\Api\UpdateAction;
 use App\Http\Api\Query\Query;
@@ -141,14 +141,12 @@ class TrackController extends BaseController
      * @param  Request  $request
      * @param  Playlist  $playlist
      * @param  PlaylistTrack  $track
-     * @param  RestoreAction  $action
+     * @param  RestoreTrackAction  $action
      * @return JsonResponse
-     *
-     * @noinspection PhpUnusedParameterInspection
      */
-    public function restore(Request $request, Playlist $playlist, PlaylistTrack $track, RestoreAction $action): JsonResponse
+    public function restore(Request $request, Playlist $playlist, PlaylistTrack $track, RestoreTrackAction $action): JsonResponse
     {
-        $restored = $action->restore($track);
+        $restored = $action->restore($playlist, $track);
 
         $resource = new TrackResource($restored, new Query());
 


### PR DESCRIPTION
Inserts restored track to the end of the list.