### PR TITLE
feat: adding hashids support [incremental]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -171,6 +171,10 @@ FORTIFY_HOME=http://localhost
 FORTIFY_PATH=
 FORTIFY_URL=http://localhost
 
+# hashids
+HASHIDS_SALT_MAIN=
+HASHIDS_SALT_PLAYLISTS=
+
 # hashing
 BCRYPT_ROUNDS=10
 

--- a/app/Actions/Models/AssignHashidsAction.php
+++ b/app/Actions/Models/AssignHashidsAction.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Models;
+
+use App\Contracts\Models\HasHashids;
+use App\Models\BaseModel;
+use Vinkla\Hashids\Facades\Hashids;
+
+/**
+ * Class AssignHashidsAction.
+ */
+class AssignHashidsAction
+{
+    /**
+     * Assign Hashids to model.
+     *
+     * @param  HasHashids&BaseModel  $model
+     * @param  string|null  $connection
+     * @return void
+     */
+    public function assign(HasHashids&BaseModel $model, ?string $connection = null): void
+    {
+        $hashids = Hashids::connection($connection);
+
+        $model->setAttribute(HasHashids::ATTRIBUTE_HASHID, $hashids->encode($model->hashids()));
+
+        $model->save();
+    }
+}

--- a/app/Actions/Models/List/Playlist/InsertTrackAction.php
+++ b/app/Actions/Models/List/Playlist/InsertTrackAction.php
@@ -40,11 +40,7 @@ class InsertTrackAction
             $last?->next()?->associate($track)?->save();
             $track->previous()->associate($last);
 
-            $track->next()->disassociate();
-
-            if ($track->isDirty()) {
-                $track->save();
-            }
+            $track->next()->disassociate()->save();
 
             DB::commit();
         } catch (Exception $e) {

--- a/app/Actions/Models/List/Playlist/RemoveTrackAction.php
+++ b/app/Actions/Models/List/Playlist/RemoveTrackAction.php
@@ -38,9 +38,7 @@ class RemoveTrackAction
             if ($playlist->last()->is($track)) {
                 $playlist->last()->associate($previous);
             }
-            if ($playlist->isDirty()) {
-                $playlist->save();
-            }
+            $playlist->save();
 
             $previous?->next()?->associate($next)?->save();
             $next?->previous()?->associate($previous)?->save();

--- a/app/Contracts/Events/AssignHashidsEvent.php
+++ b/app/Contracts/Events/AssignHashidsEvent.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Contracts\Events;
+
+use App\Contracts\Models\HasHashids;
+use App\Models\BaseModel;
+
+/**
+ * Interface AssignHashidsEvent.
+ */
+interface AssignHashidsEvent
+{
+    /**
+     * Get the model that has fired this event.
+     *
+     * @return HasHashids&BaseModel
+     */
+    public function getModel(): HasHashids&BaseModel;
+
+    /**
+     * Get the Hashids connection.
+     *
+     * @return string|null
+     */
+    public function getHashidsConnection(): ?string;
+}

--- a/app/Contracts/Models/HasHashids.php
+++ b/app/Contracts/Models/HasHashids.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Contracts\Models;
+
+/**
+ * Interface HasHashids.
+ *
+ * @property string $hashid
+ */
+interface HasHashids
+{
+    final public const ATTRIBUTE_HASHID = 'hashid';
+
+    /**
+     * Get the numbers used to encode the model's hashids.
+     *
+     * @return array<int, int>
+     */
+    public function hashids(): array;
+}

--- a/app/Events/List/Playlist/PlaylistCreated.php
+++ b/app/Events/List/Playlist/PlaylistCreated.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Events\List\Playlist;
 
+use App\Contracts\Events\AssignHashidsEvent;
 use App\Events\Base\Admin\AdminCreatedEvent;
 use App\Models\List\Playlist;
 
@@ -12,7 +13,7 @@ use App\Models\List\Playlist;
  *
  * @extends AdminCreatedEvent<Playlist>
  */
-class PlaylistCreated extends AdminCreatedEvent
+class PlaylistCreated extends AdminCreatedEvent implements AssignHashidsEvent
 {
     /**
      * Create a new event instance.
@@ -42,5 +43,15 @@ class PlaylistCreated extends AdminCreatedEvent
     protected function getDiscordMessageDescription(): string
     {
         return "Playlist '**{$this->getModel()->getName()}**' has been created.";
+    }
+
+    /**
+     * Get the Hashids connection.
+     *
+     * @return string|null
+     */
+    public function getHashidsConnection(): ?string
+    {
+        return 'playlists';
     }
 }

--- a/app/Events/List/Playlist/Track/TrackCreated.php
+++ b/app/Events/List/Playlist/Track/TrackCreated.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Events\List\Playlist\Track;
 
+use App\Contracts\Events\AssignHashidsEvent;
 use App\Events\Base\Admin\AdminCreatedEvent;
 use App\Models\List\Playlist;
 use App\Models\List\Playlist\PlaylistTrack;
@@ -13,7 +14,7 @@ use App\Models\List\Playlist\PlaylistTrack;
  *
  * @extends AdminCreatedEvent<PlaylistTrack>
  */
-class TrackCreated extends AdminCreatedEvent
+class TrackCreated extends AdminCreatedEvent implements AssignHashidsEvent
 {
     /**
      * The playlist the track belongs to.
@@ -51,5 +52,15 @@ class TrackCreated extends AdminCreatedEvent
     protected function getDiscordMessageDescription(): string
     {
         return "Track '**{$this->getModel()->getName()}**' has been created for Playlist '**{$this->playlist->getName()}**'.";
+    }
+
+    /**
+     * Get the Hashids connection.
+     *
+     * @return string|null
+     */
+    public function getHashidsConnection(): ?string
+    {
+        return 'playlists';
     }
 }

--- a/app/Http/Api/Field/List/Playlist/PlaylistHashidsField.php
+++ b/app/Http/Api/Field/List/Playlist/PlaylistHashidsField.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Api\Field\List\Playlist;
+
+use App\Contracts\Models\HasHashids;
+use App\Http\Api\Field\Field;
+use App\Http\Api\Schema\Schema;
+
+/**
+ * Class PlaylistHashidsField.
+ *
+ * TODO extend StringField
+ */
+class PlaylistHashidsField extends Field
+{
+    /**
+     * Create a new field instance.
+     *
+     * @param  Schema  $schema
+     */
+    public function __construct(Schema $schema)
+    {
+        parent::__construct($schema, HasHashids::ATTRIBUTE_HASHID);
+    }
+}

--- a/app/Http/Api/Field/List/Playlist/Track/TrackHashidsField.php
+++ b/app/Http/Api/Field/List/Playlist/Track/TrackHashidsField.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Api\Field\List\Playlist\Track;
+
+use App\Contracts\Models\HasHashids;
+use App\Http\Api\Field\Field;
+use App\Http\Api\Schema\Schema;
+
+/**
+ * Class TrackHashidsField.
+ *
+ * TODO extend StringField
+ */
+class TrackHashidsField extends Field
+{
+    /**
+     * Create a new field instance.
+     *
+     * @param  Schema  $schema
+     */
+    public function __construct(Schema $schema)
+    {
+        parent::__construct($schema, HasHashids::ATTRIBUTE_HASHID);
+    }
+}

--- a/app/Http/Api/Schema/List/Playlist/ForwardBackwardSchema.php
+++ b/app/Http/Api/Schema/List/Playlist/ForwardBackwardSchema.php
@@ -6,6 +6,7 @@ namespace App\Http\Api\Schema\List\Playlist;
 
 use App\Http\Api\Field\Base\IdField;
 use App\Http\Api\Field\Field;
+use App\Http\Api\Field\List\Playlist\Track\TrackHashidsField;
 use App\Http\Api\Field\List\Playlist\Track\TrackVideoIdField;
 use App\Http\Api\Include\AllowedInclude;
 use App\Http\Api\Schema\EloquentSchema;
@@ -66,8 +67,9 @@ class ForwardBackwardSchema extends EloquentSchema
         return array_merge(
             parent::fields(),
             [
-                new IdField($this, PlaylistTrack::ATTRIBUTE_ID),
+                new IdField($this, PlaylistTrack::ATTRIBUTE_ID), // TODO custom id field to prevent rendering
                 new TrackVideoIdField($this),
+                new TrackHashidsField($this),
             ],
         );
     }

--- a/app/Http/Api/Schema/List/Playlist/TrackSchema.php
+++ b/app/Http/Api/Schema/List/Playlist/TrackSchema.php
@@ -6,6 +6,7 @@ namespace App\Http\Api\Schema\List\Playlist;
 
 use App\Http\Api\Field\Base\IdField;
 use App\Http\Api\Field\Field;
+use App\Http\Api\Field\List\Playlist\Track\TrackHashidsField;
 use App\Http\Api\Field\List\Playlist\Track\TrackNextIdField;
 use App\Http\Api\Field\List\Playlist\Track\TrackPlaylistIdField;
 use App\Http\Api\Field\List\Playlist\Track\TrackPreviousIdField;
@@ -73,11 +74,12 @@ class TrackSchema extends EloquentSchema
         return array_merge(
             parent::fields(),
             [
-                new IdField($this, PlaylistTrack::ATTRIBUTE_ID),
+                new IdField($this, PlaylistTrack::ATTRIBUTE_ID), // TODO custom id field to prevent rendering
                 new TrackNextIdField($this),
                 new TrackPlaylistIdField($this),
                 new TrackPreviousIdField($this),
                 new TrackVideoIdField($this),
+                new TrackHashidsField($this),
             ],
         );
     }

--- a/app/Http/Api/Schema/List/PlaylistSchema.php
+++ b/app/Http/Api/Schema/List/PlaylistSchema.php
@@ -8,6 +8,7 @@ use App\Contracts\Http\Api\Schema\SearchableSchema;
 use App\Http\Api\Field\Base\IdField;
 use App\Http\Api\Field\Field;
 use App\Http\Api\Field\List\Playlist\PlaylistFirstIdField;
+use App\Http\Api\Field\List\Playlist\PlaylistHashidsField;
 use App\Http\Api\Field\List\Playlist\PlaylistLastIdField;
 use App\Http\Api\Field\List\Playlist\PlaylistNameField;
 use App\Http\Api\Field\List\Playlist\PlaylistTrackCountField;
@@ -74,7 +75,7 @@ class PlaylistSchema extends EloquentSchema implements SearchableSchema
         return array_merge(
             parent::fields(),
             [
-                new IdField($this, Playlist::ATTRIBUTE_ID),
+                new IdField($this, Playlist::ATTRIBUTE_ID), // TODO custom id field to prevent rendering
                 new PlaylistFirstIdField($this),
                 new PlaylistLastIdField($this),
                 new PlaylistNameField($this),
@@ -83,6 +84,7 @@ class PlaylistSchema extends EloquentSchema implements SearchableSchema
                 new PlaylistViewCountField($this),
                 new PlaylistTrackExistsField($this),
                 new PlaylistTrackCountField($this),
+                new PlaylistHashidsField($this),
             ],
         );
     }

--- a/app/Listeners/AssignHashids.php
+++ b/app/Listeners/AssignHashids.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use App\Actions\Models\AssignHashidsAction;
+use App\Contracts\Events\AssignHashidsEvent;
+
+/**
+ * Class AssignHashids.
+ */
+class AssignHashids
+{
+    /**
+     * Handle the event.
+     *
+     * @param  AssignHashidsEvent  $event
+     * @return void
+     */
+    public function handle(AssignHashidsEvent $event): void
+    {
+        $action = new AssignHashidsAction();
+
+        $action->assign($event->getModel(), $event->getHashidsConnection());
+    }
+}

--- a/app/Models/List/Playlist.php
+++ b/app/Models/List/Playlist.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models\List;
 
+use App\Contracts\Models\HasHashids;
 use App\Enums\Models\List\PlaylistVisibility;
 use App\Events\List\Playlist\PlaylistCreated;
 use App\Events\List\Playlist\PlaylistDeleted;
@@ -36,12 +37,12 @@ use Laravel\Nova\Actions\Actionable;
  * @property Collection<int, PlaylistTrack> $tracks
  * @property string $name
  * @property User|null $user
- * @property int $user_id
+ * @property int|null $user_id
  * @property PlaylistVisibility $visibility
  *
  * @method static PlaylistFactory factory(...$parameters)
  */
-class Playlist extends BaseModel implements Viewable
+class Playlist extends BaseModel implements HasHashids, Viewable
 {
     use Actionable;
     use Searchable;
@@ -49,8 +50,8 @@ class Playlist extends BaseModel implements Viewable
 
     final public const TABLE = 'playlists';
 
-    final public const ATTRIBUTE_ID = 'playlist_id';
     final public const ATTRIBUTE_FIRST = 'first_id';
+    final public const ATTRIBUTE_ID = 'playlist_id';
     final public const ATTRIBUTE_LAST = 'last_id';
     final public const ATTRIBUTE_NAME = 'name';
     final public const ATTRIBUTE_USER = 'user_id';
@@ -105,6 +106,18 @@ class Playlist extends BaseModel implements Viewable
     protected $primaryKey = Playlist::ATTRIBUTE_ID;
 
     /**
+     * Get the route key for the model.
+     *
+     * @return string
+     *
+     * @noinspection PhpMissingParentCallCommonInspection
+     */
+    public function getRouteKeyName(): string
+    {
+        return Playlist::ATTRIBUTE_ID; //TODO change to Hashids
+    }
+
+    /**
      * The attributes that should be cast.
      *
      * @var array<string, string>
@@ -112,6 +125,19 @@ class Playlist extends BaseModel implements Viewable
     protected $casts = [
         Playlist::ATTRIBUTE_VISIBILITY => PlaylistVisibility::class,
     ];
+
+    /**
+     * Get the numbers used to encode the model's hashids.
+     *
+     * @return array
+     */
+    public function hashids(): array
+    {
+        return array_filter([
+            $this->user_id,
+            $this->playlist_id,
+        ]);
+    }
 
     /**
      * Get name.

--- a/app/Models/List/Playlist/PlaylistTrack.php
+++ b/app/Models/List/Playlist/PlaylistTrack.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models\List\Playlist;
 
+use App\Contracts\Models\HasHashids;
 use App\Events\List\Playlist\Track\TrackCreated;
 use App\Events\List\Playlist\Track\TrackDeleted;
 use App\Events\List\Playlist\Track\TrackRestored;
@@ -31,7 +32,7 @@ use Staudenmeir\LaravelAdjacencyList\Eloquent\HasRecursiveRelationships;
  *
  * @method static PlaylistTrackFactory factory(...$parameters)
  */
-class PlaylistTrack extends BaseModel
+class PlaylistTrack extends BaseModel implements HasHashids
 {
     use Actionable;
     use HasRecursiveRelationships;
@@ -91,6 +92,31 @@ class PlaylistTrack extends BaseModel
      * @var string
      */
     protected $primaryKey = PlaylistTrack::ATTRIBUTE_ID;
+
+    /**
+     * Get the route key for the model.
+     *
+     * @return string
+     *
+     * @noinspection PhpMissingParentCallCommonInspection
+     */
+    public function getRouteKeyName(): string
+    {
+        return PlaylistTrack::ATTRIBUTE_ID; //TODO change to hashids
+    }
+
+    /**
+     * Get the numbers used to encode the model's hashids.
+     *
+     * @return array
+     */
+    public function hashids(): array
+    {
+        return [
+            $this->playlist_id,
+            $this->track_id,
+        ];
+    }
 
     /**
      * Get name.

--- a/app/Nova/Actions/Models/AssignHashidsAction.php
+++ b/app/Nova/Actions/Models/AssignHashidsAction.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Nova\Actions\Models;
+
+use App\Actions\Models\AssignHashidsAction as AssignHashids;
+use App\Contracts\Models\HasHashids;
+use App\Models\BaseModel;
+use Exception;
+use Illuminate\Support\Collection;
+use Laravel\Nova\Actions\Action;
+use Laravel\Nova\Fields\ActionFields;
+
+/**
+ * Class AssignHashidsAction.
+ */
+class AssignHashidsAction extends Action
+{
+    /**
+     * Create a new action instance.
+     *
+     * @param  string|null  $connection
+     */
+    public function __construct(protected readonly ?string $connection = null)
+    {
+    }
+
+    /**
+     * Get the displayable name of the action.
+     *
+     * @return string
+     *
+     * @noinspection PhpMissingParentCallCommonInspection
+     */
+    public function name(): string
+    {
+        return __('nova.actions.models.assign_hashids.name');
+    }
+
+    /**
+     * Perform the action on the given models.
+     *
+     * @param  ActionFields  $fields
+     * @param  Collection<int, HasHashids&BaseModel>  $models
+     * @return Collection
+     *
+     * @noinspection PhpUnusedParameterInspection
+     */
+    public function handle(ActionFields $fields, Collection $models): Collection
+    {
+        $action = new AssignHashids();
+
+        foreach ($models as $model) {
+            try {
+                $action->assign($model, $this->connection);
+            } catch (Exception $e) {
+                $this->markAsFailed($model, $e);
+            }
+        }
+
+        return $models;
+    }
+}

--- a/app/Nova/Resources/List/Playlist.php
+++ b/app/Nova/Resources/List/Playlist.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Nova\Resources\List;
 
+use App\Contracts\Models\HasHashids;
 use App\Enums\Models\List\PlaylistVisibility;
 use App\Models\List\Playlist as PlaylistModel;
+use App\Nova\Actions\Models\AssignHashidsAction;
 use App\Nova\Resources\Auth\User;
 use App\Nova\Resources\BaseResource;
 use App\Nova\Resources\List\Playlist\Track;
@@ -196,6 +198,15 @@ class Playlist extends BaseResource
                 ->filterable()
                 ->showWhenPeeking(),
 
+            Text::make(__('nova.fields.playlist.hashid.name'), HasHashids::ATTRIBUTE_HASHID)
+                ->readonly()
+                ->sortable()
+                ->copyable()
+                ->help(__('nova.fields.playlist.hashid.help'))
+                ->showOnPreview()
+                ->filterable()
+                ->showWhenPeeking(),
+
             BelongsTo::make(__('nova.fields.playlist.first.name'), PlaylistModel::RELATION_FIRST, Track::class)
                 ->hideFromIndex()
                 ->sortable()
@@ -230,5 +241,27 @@ class Playlist extends BaseResource
             Panel::make(__('nova.fields.base.timestamps'), $this->timestamps())
                 ->collapsable(),
         ];
+    }
+
+    /**
+     * Get the actions available for the resource.
+     *
+     * @param  NovaRequest  $request
+     * @return array
+     */
+    public function actions(NovaRequest $request): array
+    {
+        return array_merge(
+            parent::actions($request),
+            [
+                (new AssignHashidsAction('playlists'))
+                    ->confirmButtonText(__('nova.actions.models.assign_hashids.confirmButtonText'))
+                    ->cancelButtonText(__('nova.actions.base.cancelButtonText'))
+                    ->showOnIndex()
+                    ->showOnDetail()
+                    ->showInline()
+                    ->canSeeWhen('update', $this),
+            ]
+        );
     }
 }

--- a/app/Nova/Resources/List/Playlist/Track.php
+++ b/app/Nova/Resources/List/Playlist/Track.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Nova\Resources\List\Playlist;
 
+use App\Contracts\Models\HasHashids;
 use App\Models\List\Playlist\PlaylistTrack;
 use App\Models\Wiki\Video as VideoModel;
+use App\Nova\Actions\Models\AssignHashidsAction;
 use App\Nova\Resources\BaseResource;
 use App\Nova\Resources\List\Playlist;
 use App\Nova\Resources\Wiki\Video;
@@ -13,6 +15,7 @@ use Exception;
 use Illuminate\Database\Eloquent\Builder;
 use Laravel\Nova\Fields\BelongsTo;
 use Laravel\Nova\Fields\ID;
+use Laravel\Nova\Fields\Text;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Panel;
 use Laravel\Nova\Query\Search\SearchableRelation;
@@ -192,6 +195,15 @@ class Track extends BaseResource
                 ->showOnPreview()
                 ->showWhenPeeking(),
 
+            Text::make(__('nova.fields.playlist_track.hashid.name'), HasHashids::ATTRIBUTE_HASHID)
+                ->readonly()
+                ->sortable()
+                ->copyable()
+                ->help(__('nova.fields.playlist_track.hashid.help'))
+                ->showOnPreview()
+                ->filterable()
+                ->showWhenPeeking(),
+
             BelongsTo::make(__('nova.fields.playlist_track.previous.name'), PlaylistTrack::RELATION_PREVIOUS, Track::class)
                 ->hideFromIndex()
                 ->sortable()
@@ -213,5 +225,27 @@ class Track extends BaseResource
             Panel::make(__('nova.fields.base.timestamps'), $this->timestamps())
                 ->collapsable(),
         ];
+    }
+
+    /**
+     * Get the actions available for the resource.
+     *
+     * @param  NovaRequest  $request
+     * @return array
+     */
+    public function actions(NovaRequest $request): array
+    {
+        return array_merge(
+            parent::actions($request),
+            [
+                (new AssignHashidsAction('playlists'))
+                    ->confirmButtonText(__('nova.actions.models.assign_hashids.confirmButtonText'))
+                    ->cancelButtonText(__('nova.actions.base.cancelButtonText'))
+                    ->showOnIndex()
+                    ->showOnDetail()
+                    ->showInline()
+                    ->canSeeWhen('update', $this),
+            ]
+        );
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,8 @@
         "staudenmeir/belongs-to-through": "^2.12",
         "staudenmeir/laravel-adjacency-list": "^1.12",
         "symfony/http-client": "^6.0",
-        "symfony/mailgun-mailer": "^6.0"
+        "symfony/mailgun-mailer": "^6.0",
+        "vinkla/hashids": "^10.0"
     },
     "require-dev": {
         "brianium/paratest": "^6.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e3bbf30e62ddad243e652db24175650c",
+    "content-hash": "15e53114c57c5fd614525b42427b8c4e",
     "packages": [
         {
             "name": "akaunting/laravel-setting",
@@ -2180,6 +2180,76 @@
             "time": "2022-02-20T15:07:15+00:00"
         },
         {
+            "name": "graham-campbell/manager",
+            "version": "v4.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/GrahamCampbell/Laravel-Manager.git",
+                "reference": "b4cafa6491b9c92ecf7ce17521580050a27b8308"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/GrahamCampbell/Laravel-Manager/zipball/b4cafa6491b9c92ecf7ce17521580050a27b8308",
+                "reference": "b4cafa6491b9c92ecf7ce17521580050a27b8308",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^5.5 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
+                "illuminate/support": "^5.5 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
+                "php": "^7.1.3 || ^8.0"
+            },
+            "require-dev": {
+                "graham-campbell/analyzer": "^2.4 || ^3.0",
+                "graham-campbell/testbench-core": "^3.4",
+                "mockery/mockery": "^1.3.1",
+                "phpunit/phpunit": "^6.5.14 || ^7.5.20 || ^8.5.8 || ^9.3.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "GrahamCampbell\\Manager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                }
+            ],
+            "description": "Manager Provides Some Manager Functionality For Laravel",
+            "keywords": [
+                "Graham Campbell",
+                "GrahamCampbell",
+                "Laravel Manager",
+                "Laravel-Manager",
+                "connector",
+                "framework",
+                "interface",
+                "laravel",
+                "manager"
+            ],
+            "support": {
+                "issues": "https://github.com/GrahamCampbell/Laravel-Manager/issues",
+                "source": "https://github.com/GrahamCampbell/Laravel-Manager/tree/v4.7.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/graham-campbell/manager",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-01-24T01:59:19+00:00"
+        },
+        {
             "name": "graham-campbell/result-type",
             "version": "v1.1.1",
             "source": {
@@ -2655,6 +2725,76 @@
                 }
             ],
             "time": "2021-10-07T12:57:01+00:00"
+        },
+        {
+            "name": "hashids/hashids",
+            "version": "4.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vinkla/hashids.git",
+                "reference": "8cab111f78e0bd9c76953b082919fc9e251761be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vinkla/hashids/zipball/8cab111f78e0bd9c76953b082919fc9e251761be",
+                "reference": "8cab111f78e0bd9c76953b082919fc9e251761be",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.0 || ^9.4",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "suggest": {
+                "ext-bcmath": "Required to use BC Math arbitrary precision mathematics (*).",
+                "ext-gmp": "Required to use GNU multiple precision mathematics (*)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Hashids\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ivan Akimov",
+                    "email": "ivan@barreleye.com"
+                },
+                {
+                    "name": "Vincent Klaiber",
+                    "email": "hello@doubledip.se"
+                }
+            ],
+            "description": "Generate short, unique, non-sequential ids (like YouTube and Bitly) from numbers",
+            "homepage": "https://hashids.org/php",
+            "keywords": [
+                "bitly",
+                "decode",
+                "encode",
+                "hash",
+                "hashid",
+                "hashids",
+                "ids",
+                "obfuscate",
+                "youtube"
+            ],
+            "support": {
+                "issues": "https://github.com/vinkla/hashids/issues",
+                "source": "https://github.com/vinkla/hashids/tree/4.1.0"
+            },
+            "time": "2020-11-26T19:24:33+00:00"
         },
         {
             "name": "inertiajs/inertia-laravel",
@@ -9677,6 +9817,74 @@
                 "source": "https://github.com/tijsverkoyen/CssToInlineStyles/tree/2.2.6"
             },
             "time": "2023-01-03T09:29:04+00:00"
+        },
+        {
+            "name": "vinkla/hashids",
+            "version": "10.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vinkla/laravel-hashids.git",
+                "reference": "9dbcfc1b20ecc25e73bba6e8c724d1648fa15fdd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vinkla/laravel-hashids/zipball/9dbcfc1b20ecc25e73bba6e8c724d1648fa15fdd",
+                "reference": "9dbcfc1b20ecc25e73bba6e8c724d1648fa15fdd",
+                "shasum": ""
+            },
+            "require": {
+                "graham-campbell/manager": "^4.7",
+                "hashids/hashids": "^4.1",
+                "illuminate/contracts": "^9.0",
+                "illuminate/support": "^9.0",
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "graham-campbell/analyzer": "^3.0",
+                "graham-campbell/testbench": "^5.7",
+                "mockery/mockery": "^1.3",
+                "phpunit/phpunit": "^9.3",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "10.0-dev"
+                },
+                "laravel": {
+                    "aliases": {
+                        "Hashids": "Vinkla\\Hashids\\Facades\\Hashids"
+                    },
+                    "providers": [
+                        "Vinkla\\Hashids\\HashidsServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Vinkla\\Hashids\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Vincent Klaiber",
+                    "email": "hello@doubledip.se"
+                }
+            ],
+            "description": "A Hashids bridge for Laravel",
+            "keywords": [
+                "hashids",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/vinkla/laravel-hashids/issues",
+                "source": "https://github.com/vinkla/laravel-hashids/tree/10.0.1"
+            },
+            "time": "2022-04-10T18:38:38+00:00"
         },
         {
             "name": "vlucas/phpdotenv",

--- a/config/hashids.php
+++ b/config/hashids.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Copyright (c) Vincent Klaiber.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @see https://github.com/vinkla/laravel-hashids
+ */
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Connection Name
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify which of the connections below you wish to use as
+    | your default connection for all work. Of course, you may use many
+    | connections at once using the manager class.
+    |
+    */
+
+    'default' => 'main',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Hashids Connections
+    |--------------------------------------------------------------------------
+    |
+    | Here are each of the connections setup for your application. Example
+    | configuration has been included, but you may add as many connections as
+    | you would like.
+    |
+    */
+
+    'connections' => [
+        'main' => [
+            'salt' => env('HASHIDS_SALT_MAIN'),
+        ],
+        'playlists' => [
+            'salt' => env('HASHIDS_SALT_PLAYLISTS'),
+        ],
+    ],
+];

--- a/database/migrations/2022_09_29_203332_create_playlists_table.php
+++ b/database/migrations/2022_09_29_203332_create_playlists_table.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Contracts\Models\HasHashids;
 use App\Models\Auth\User;
 use App\Models\BaseModel;
 use App\Models\List\Playlist;
@@ -23,6 +24,7 @@ return new class extends Migration
                 $table->id(Playlist::ATTRIBUTE_ID);
                 $table->timestamps(6);
                 $table->softDeletes(BaseModel::ATTRIBUTE_DELETED_AT, 6);
+                $table->string(HasHashids::ATTRIBUTE_HASHID)->nullable();
                 $table->string(Playlist::ATTRIBUTE_NAME);
                 $table->integer(Playlist::ATTRIBUTE_VISIBILITY);
 

--- a/database/migrations/2022_09_29_204718_create_playlist_tracks_table.php
+++ b/database/migrations/2022_09_29_204718_create_playlist_tracks_table.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Contracts\Models\HasHashids;
 use App\Models\BaseModel;
 use App\Models\List\Playlist;
 use App\Models\List\Playlist\PlaylistTrack;
@@ -24,6 +25,7 @@ return new class extends Migration
                 $table->id(PlaylistTrack::ATTRIBUTE_ID);
                 $table->timestamps(6);
                 $table->softDeletes(BaseModel::ATTRIBUTE_DELETED_AT, 6);
+                $table->string(HasHashids::ATTRIBUTE_HASHID)->nullable();
 
                 $table->unsignedBigInteger(PlaylistTrack::ATTRIBUTE_PLAYLIST);
                 $table->foreign(PlaylistTrack::ATTRIBUTE_PLAYLIST)->references(Playlist::ATTRIBUTE_ID)->on(Playlist::TABLE)->cascadeOnDelete();

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -28,5 +28,6 @@ class DatabaseSeeder extends Seeder
         $this->call(RoleSeeder::class);
         $this->call(VideoSeeder::class);
         $this->call(AudioSeeder::class);
+        $this->call(HashidsSeeder::class);
     }
 }

--- a/database/seeders/HashidsSeeder.php
+++ b/database/seeders/HashidsSeeder.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use Database\Seeders\List\Playlist\PlaylistHashidsSeeder;
+use Database\Seeders\List\Playlist\Track\TrackHashidsSeeder;
+use Illuminate\Database\Seeder;
+
+/**
+ * Class HashidsSeeder.
+ */
+class HashidsSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run(): void
+    {
+        $this->call(PlaylistHashidsSeeder::class);
+        $this->call(TrackHashidsSeeder::class);
+    }
+}

--- a/database/seeders/List/Playlist/PlaylistHashidsSeeder.php
+++ b/database/seeders/List/Playlist/PlaylistHashidsSeeder.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\List\Playlist;
+
+use App\Actions\Models\AssignHashidsAction;
+use App\Models\List\Playlist;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Collection;
+
+/**
+ * Class PlaylistHashidsSeeder.
+ */
+class PlaylistHashidsSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run(): void
+    {
+        Playlist::query()
+            ->chunkById(100, fn (Collection $playlists) => $playlists->each(function (Playlist $playlist) {
+                $action = new AssignHashidsAction();
+
+                $action->assign($playlist, 'playlists');
+            }));
+    }
+}

--- a/database/seeders/List/Playlist/Track/TrackHashidsSeeder.php
+++ b/database/seeders/List/Playlist/Track/TrackHashidsSeeder.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders\List\Playlist\Track;
+
+use App\Actions\Models\AssignHashidsAction;
+use App\Models\List\Playlist\PlaylistTrack;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Collection;
+
+/**
+ * Class TrackHashidsSeeder.
+ */
+class TrackHashidsSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run(): void
+    {
+        PlaylistTrack::query()
+            ->chunkById(100, fn (Collection $tracks) => $tracks->each(function (PlaylistTrack $track) {
+                $action = new AssignHashidsAction();
+
+                $action->assign($track, 'playlists');
+            }));
+    }
+}

--- a/lang/en/nova.php
+++ b/lang/en/nova.php
@@ -156,6 +156,10 @@ return [
             ],
         ],
         'models' => [
+            'assign_hashids' => [
+                'name' => 'Assign Hashids',
+                'confirmButtonText' => 'Assign',
+            ],
             'wiki' => [
                 'attach_resource' => [
                     'confirmButtonText' => 'Attach',
@@ -518,6 +522,10 @@ return [
             'name' => 'Name',
         ],
         'playlist_track' => [
+            'hashid' => [
+                'help' => 'The short, unique, non-sequential id derived from model identifiers.',
+                'name' => 'Hashid',
+            ],
             'next' => [
                 'help' => 'The next Track in the Playlist',
                 'name' => 'Next Track',
@@ -531,6 +539,10 @@ return [
             'first' => [
                 'help' => 'The first Track of the Playlist',
                 'name' => 'First Track',
+            ],
+            'hashid' => [
+                'help' => 'The short, unique, non-sequential id derived from model identifiers.',
+                'name' => 'Hashid',
             ],
             'last' => [
                 'help' => 'The last Track of the Playlist',

--- a/tests/Feature/Events/List/Playlist/TrackTest.php
+++ b/tests/Feature/Events/List/Playlist/TrackTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Events\List\Playlist;
 
+use App\Contracts\Models\HasHashids;
 use App\Events\List\Playlist\Track\TrackCreated;
 use App\Events\List\Playlist\Track\TrackDeleted;
 use App\Events\List\Playlist\Track\TrackRestored;
@@ -139,5 +140,21 @@ class TrackTest extends TestCase
 
             return ! empty(Arr::get($message->embed, 'fields'));
         });
+    }
+
+    /**
+     * The Track Created event shall assign hashids to the track.
+     *
+     * @return void
+     */
+    public function testPlaylistCreatedAssignsNullableUserHashids(): void
+    {
+        Event::fakeExcept(TrackCreated::class);
+
+        PlaylistTrack::factory()
+            ->for(Playlist::factory())
+            ->createOne();
+
+        static::assertDatabaseMissing(PlaylistTrack::class, [HasHashids::ATTRIBUTE_HASHID => null]);
     }
 }

--- a/tests/Unit/Events/AssignHashidsTest.php
+++ b/tests/Unit/Events/AssignHashidsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Events;
+
+use App\Contracts\Events\AssignHashidsEvent;
+use App\Listeners\AssignHashids;
+use Illuminate\Support\Facades\Event;
+use Tests\TestCase;
+
+/**
+ * Class AssignHashidsTest.
+ */
+class AssignHashidsTest extends TestCase
+{
+    /**
+     * AssignHashids shall listen to AssignHashidsEvent.
+     *
+     * @return void
+     */
+    public function testListening(): void
+    {
+        $fake = Event::fake();
+
+        $fake->assertListening(AssignHashidsEvent::class, AssignHashids::class);
+    }
+}

--- a/tests/Unit/Models/List/Playlist/TrackTest.php
+++ b/tests/Unit/Models/List/Playlist/TrackTest.php
@@ -30,6 +30,23 @@ class TrackTest extends TestCase
     }
 
     /**
+     * Playlists shall include playlist and track ids for hashids encoding.
+     *
+     * @return void
+     */
+    public function testHashids(): void
+    {
+        $playlist = Playlist::factory()->createOne();
+
+        $track = PlaylistTrack::factory()
+            ->for($playlist)
+            ->createOne();
+
+        static::assertEmpty(array_diff([$playlist->playlist_id, $track->track_id], $track->hashids()));
+        static::assertEmpty(array_diff($track->hashids(), [$playlist->playlist_id, $track->track_id]));
+    }
+
+    /**
      * Playlist Tracks shall belong to a Playlist.
      *
      * @return void

--- a/tests/Unit/Models/List/PlaylistTest.php
+++ b/tests/Unit/Models/List/PlaylistTest.php
@@ -91,6 +91,36 @@ class PlaylistTest extends TestCase
     }
 
     /**
+     * Playlists shall filter null user_id values from hashids.
+     *
+     * @return void
+     */
+    public function testHashidsNullableUser(): void
+    {
+        $playlist = Playlist::factory()->createOne();
+
+        static::assertEmpty(array_diff([$playlist->playlist_id], $playlist->hashids()));
+        static::assertEmpty(array_diff($playlist->hashids(), [$playlist->playlist_id]));
+    }
+
+    /**
+     * Playlists shall include nonnull user_id values from hashids.
+     *
+     * @return void
+     */
+    public function testHashidsNonNullUser(): void
+    {
+        $user = User::factory()->createOne();
+
+        $playlist = Playlist::factory()
+            ->for($user)
+            ->createOne();
+
+        static::assertEmpty(array_diff([$user->id, $playlist->playlist_id], $playlist->hashids()));
+        static::assertEmpty(array_diff($playlist->hashids(), [$user->id, $playlist->playlist_id]));
+    }
+
+    /**
      * Playlists shall have a one-to-many polymorphic relationship to View.
      *
      * @return void


### PR DESCRIPTION
Initial support for hashids, intended for models where we might want to obscure enumeration without introducing the ugliness of UUIDs.

Supports multiple configurable salts and utilities to repopulate encoded values if, for some reason, we need to perform rotation.

Some switches need to be flipped to fully support this, but it will need to be coordinated with Mani.