### PR TITLE
chore: address deprecations to validation rules in Laravel 10

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,4 +1,4 @@
-version: 8.1
+version: 8.2
 preset: laravel
 finder:
   not-name:

--- a/app/Actions/Storage/Base/DeleteResults.php
+++ b/app/Actions/Storage/Base/DeleteResults.php
@@ -15,7 +15,7 @@ use Illuminate\Support\Facades\Log;
 /**
  * Class DeleteResults.
  */
-class DeleteResults implements StorageResults
+readonly class DeleteResults implements StorageResults
 {
     /**
      * Create a new action result instance.
@@ -23,7 +23,7 @@ class DeleteResults implements StorageResults
      * @param  BaseModel  $model
      * @param  array<string, bool>  $deletions
      */
-    public function __construct(protected readonly BaseModel $model, protected readonly array $deletions = [])
+    public function __construct(protected BaseModel $model, protected array $deletions = [])
     {
     }
 

--- a/app/Actions/Storage/Base/MoveResults.php
+++ b/app/Actions/Storage/Base/MoveResults.php
@@ -15,7 +15,7 @@ use Illuminate\Support\Facades\Log;
 /**
  * Class MoveResults.
  */
-class MoveResults implements StorageResults
+readonly class MoveResults implements StorageResults
 {
     /**
      * Create a new action result instance.
@@ -26,10 +26,10 @@ class MoveResults implements StorageResults
      * @param  array<string, bool>  $moves
      */
     public function __construct(
-        protected readonly BaseModel $model,
-        protected readonly string $from,
-        protected readonly string $to,
-        protected readonly array $moves = []
+        protected BaseModel $model,
+        protected string $from,
+        protected string $to,
+        protected array $moves = []
     ) {
     }
 

--- a/app/Actions/Storage/Base/PruneResults.php
+++ b/app/Actions/Storage/Base/PruneResults.php
@@ -14,7 +14,7 @@ use Illuminate\Support\Facades\Log;
 /**
  * Class PruneResults.
  */
-class PruneResults implements StorageResults
+readonly class PruneResults implements StorageResults
 {
     /**
      * Create a new action result instance.
@@ -22,7 +22,7 @@ class PruneResults implements StorageResults
      * @param  string  $fs
      * @param  array<string, bool>  $prunings
      */
-    public function __construct(protected readonly string $fs, protected readonly array $prunings = [])
+    public function __construct(protected string $fs, protected array $prunings = [])
     {
     }
 

--- a/app/Actions/Storage/Base/UploadResults.php
+++ b/app/Actions/Storage/Base/UploadResults.php
@@ -14,14 +14,14 @@ use Illuminate\Support\Facades\Log;
 /**
  * Class UploadResults.
  */
-class UploadResults implements StorageResults
+readonly class UploadResults implements StorageResults
 {
     /**
      * Create a new action result instance.
      *
      * @param  array<string, string|false>  $uploads
      */
-    public function __construct(protected readonly array $uploads = [])
+    public function __construct(protected array $uploads = [])
     {
     }
 

--- a/app/Http/Api/Criteria/Field/Criteria.php
+++ b/app/Http/Api/Criteria/Field/Criteria.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Collection;
 /**
  * Class Criteria.
  */
-class Criteria
+readonly class Criteria
 {
     /**
      * Create a new criteria instance.
@@ -17,7 +17,7 @@ class Criteria
      * @param  string  $type
      * @param  Collection<int, string>  $fields
      */
-    public function __construct(protected readonly string $type, protected readonly Collection $fields)
+    public function __construct(protected string $type, protected Collection $fields)
     {
     }
 

--- a/app/Http/Api/Criteria/Filter/Expression.php
+++ b/app/Http/Api/Criteria/Filter/Expression.php
@@ -7,14 +7,14 @@ namespace App\Http\Api\Criteria\Filter;
 /**
  * Class Expression.
  */
-class Expression
+readonly class Expression
 {
     /**
      * Create a new expression.
      *
      * @param  mixed  $value
      */
-    public function __construct(protected readonly mixed $value)
+    public function __construct(protected mixed $value)
     {
     }
 

--- a/app/Http/Api/Criteria/Filter/Predicate.php
+++ b/app/Http/Api/Criteria/Filter/Predicate.php
@@ -9,7 +9,7 @@ use App\Enums\Http\Api\Filter\ComparisonOperator;
 /**
  * Class Predicate.
  */
-class Predicate
+readonly class Predicate
 {
     /**
      * Create a new predicate.
@@ -19,9 +19,9 @@ class Predicate
      * @param  Expression  $expression
      */
     public function __construct(
-        protected readonly string $column,
-        protected readonly ?ComparisonOperator $operator,
-        protected readonly Expression $expression
+        protected string $column,
+        protected ?ComparisonOperator $operator,
+        protected Expression $expression
     ) {
     }
 

--- a/app/Http/Api/Criteria/Search/Criteria.php
+++ b/app/Http/Api/Criteria/Search/Criteria.php
@@ -7,14 +7,14 @@ namespace App\Http\Api\Criteria\Search;
 /**
  * Class Criteria.
  */
-class Criteria
+readonly class Criteria
 {
     /**
      * Create a new criteria instance.
      *
      * @param  string  $term
      */
-    public function __construct(protected readonly string $term)
+    public function __construct(protected string $term)
     {
     }
 

--- a/app/Http/Api/Include/AllowedInclude.php
+++ b/app/Http/Api/Include/AllowedInclude.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Str;
 /**
  * Class AllowedInclude.
  */
-class AllowedInclude
+readonly class AllowedInclude
 {
     /**
      * Create a new AllowedIncludePath instance.
@@ -18,7 +18,7 @@ class AllowedInclude
      * @param  SchemaInterface  $schema
      * @param  string  $path
      */
-    final public function __construct(protected readonly SchemaInterface $schema, protected readonly string $path)
+    final public function __construct(protected SchemaInterface $schema, protected string $path)
     {
     }
 

--- a/app/Nova/Actions/Models/Wiki/Anime/AttachAnimeResourceAction.php
+++ b/app/Nova/Actions/Models/Wiki/Anime/AttachAnimeResourceAction.php
@@ -7,7 +7,7 @@ namespace App\Nova\Actions\Models\Wiki\Anime;
 use App\Models\Wiki\ExternalResource;
 use App\Nova\Actions\Models\Wiki\AttachResourceAction;
 use App\Rules\Wiki\Resource\AnimeResourceLinkFormatRule;
-use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 /**
@@ -29,9 +29,9 @@ class AttachAnimeResourceAction extends AttachResourceAction
     /**
      * Get the format validation rule.
      *
-     * @return Rule
+     * @return ValidationRule
      */
-    protected function getFormatRule(): Rule
+    protected function getFormatRule(): ValidationRule
     {
         return new AnimeResourceLinkFormatRule($this->site);
     }

--- a/app/Nova/Actions/Models/Wiki/Artist/AttachArtistResourceAction.php
+++ b/app/Nova/Actions/Models/Wiki/Artist/AttachArtistResourceAction.php
@@ -7,7 +7,7 @@ namespace App\Nova\Actions\Models\Wiki\Artist;
 use App\Models\Wiki\ExternalResource;
 use App\Nova\Actions\Models\Wiki\AttachResourceAction;
 use App\Rules\Wiki\Resource\ArtistResourceLinkFormatRule;
-use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 /**
@@ -29,9 +29,9 @@ class AttachArtistResourceAction extends AttachResourceAction
     /**
      * Get the format validation rule.
      *
-     * @return Rule
+     * @return ValidationRule
      */
-    protected function getFormatRule(): Rule
+    protected function getFormatRule(): ValidationRule
     {
         return new ArtistResourceLinkFormatRule($this->site);
     }

--- a/app/Nova/Actions/Models/Wiki/AttachResourceAction.php
+++ b/app/Nova/Actions/Models/Wiki/AttachResourceAction.php
@@ -6,7 +6,7 @@ namespace App\Nova\Actions\Models\Wiki;
 
 use App\Enums\Models\Wiki\ResourceSite;
 use App\Models\Wiki\ExternalResource;
-use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Collection;
 use Laravel\Nova\Actions\Action;
@@ -114,7 +114,7 @@ abstract class AttachResourceAction extends Action
     /**
      * Get the format validation rule.
      *
-     * @return Rule
+     * @return ValidationRule
      */
-    abstract protected function getFormatRule(): Rule;
+    abstract protected function getFormatRule(): ValidationRule;
 }

--- a/app/Nova/Actions/Models/Wiki/Studio/AttachStudioResourceAction.php
+++ b/app/Nova/Actions/Models/Wiki/Studio/AttachStudioResourceAction.php
@@ -7,7 +7,7 @@ namespace App\Nova\Actions\Models\Wiki\Studio;
 use App\Models\Wiki\ExternalResource;
 use App\Nova\Actions\Models\Wiki\AttachResourceAction;
 use App\Rules\Wiki\Resource\StudioResourceLinkFormatRule;
-use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 /**
@@ -29,9 +29,9 @@ class AttachStudioResourceAction extends AttachResourceAction
     /**
      * Get the format validation rule.
      *
-     * @return Rule
+     * @return ValidationRule
      */
-    protected function getFormatRule(): Rule
+    protected function getFormatRule(): ValidationRule
     {
         return new StudioResourceLinkFormatRule($this->site);
     }

--- a/app/Rules/Api/DelimitedRule.php
+++ b/app/Rules/Api/DelimitedRule.php
@@ -5,8 +5,7 @@ declare(strict_types=1);
 namespace App\Rules\Api;
 
 use Closure;
-use Illuminate\Contracts\Validation\InvokableRule;
-use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 use Illuminate\Translation\PotentiallyTranslatedString;
@@ -14,14 +13,14 @@ use Illuminate\Translation\PotentiallyTranslatedString;
 /**
  * Class DelimitedRule.
  */
-class DelimitedRule implements InvokableRule
+readonly class DelimitedRule implements ValidationRule
 {
     /**
      * Create a new rule instance.
      *
-     * @param  string|array|Rule  $rule
+     * @param  string|array|ValidationRule  $rule
      */
-    public function __construct(protected readonly string|array|Rule $rule)
+    public function __construct(protected string|array|ValidationRule $rule)
     {
     }
 
@@ -33,7 +32,7 @@ class DelimitedRule implements InvokableRule
      * @param  Closure(string): PotentiallyTranslatedString  $fail
      * @return void
      */
-    public function __invoke(string $attribute, mixed $value, Closure $fail): void
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         $key = Str::of($attribute)->explode('.')->last();
         $items = Str::of($value)->explode(',');

--- a/app/Rules/Api/DistinctIgnoringDirectionRule.php
+++ b/app/Rules/Api/DistinctIgnoringDirectionRule.php
@@ -4,22 +4,25 @@ declare(strict_types=1);
 
 namespace App\Rules\Api;
 
-use Illuminate\Contracts\Validation\Rule;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Str;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 /**
  * Class DistinctIgnoringDirectionRule.
  */
-class DistinctIgnoringDirectionRule implements Rule
+class DistinctIgnoringDirectionRule implements ValidationRule
 {
     /**
-     * Determine if the validation rule passes.
+     * Run the validation rule.
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @return bool
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
+     * @return void
      */
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         $values = Str::of($value)->explode(',');
 
@@ -31,16 +34,8 @@ class DistinctIgnoringDirectionRule implements Rule
             return $sort;
         });
 
-        return $duplicateValues->isEmpty();
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string
-     */
-    public function message(): string
-    {
-        return __('validation.distinct');
+        if ($duplicateValues->isNotEmpty()) {
+            $fail(__('validation.distinct'));
+        }
     }
 }

--- a/app/Rules/Api/EnumDescriptionRule.php
+++ b/app/Rules/Api/EnumDescriptionRule.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace App\Rules\Api;
 
 use App\Enums\BaseEnum;
-use Illuminate\Contracts\Validation\Rule;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 /**
  * Class EnumDescriptionRule.
  */
-class EnumDescriptionRule implements Rule
+readonly class EnumDescriptionRule implements ValidationRule
 {
     /**
      * Create a new rule instance.
@@ -18,29 +20,22 @@ class EnumDescriptionRule implements Rule
      * @param  class-string<BaseEnum>  $enumClass
      * @return void
      */
-    public function __construct(protected readonly string $enumClass)
+    public function __construct(protected string $enumClass)
     {
     }
 
     /**
-     * Determine if the validation rule passes.
+     * Run the validation rule.
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @return bool
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
+     * @return void
      */
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        return is_string($value) && $this->enumClass::fromDescription($value) !== null;
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string
-     */
-    public function message(): string
-    {
-        return __('validation.enum');
+        if (! is_string($value) || $this->enumClass::fromDescription($value) === null) {
+            $fail(__('validation.enum'));
+        }
     }
 }

--- a/app/Rules/Api/IsValidBoolean.php
+++ b/app/Rules/Api/IsValidBoolean.php
@@ -4,32 +4,27 @@ declare(strict_types=1);
 
 namespace App\Rules\Api;
 
-use Illuminate\Contracts\Validation\Rule;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 /**
  * Class IsValidBoolean.
  */
-class IsValidBoolean implements Rule
+class IsValidBoolean implements ValidationRule
 {
     /**
-     * Determine if the validation rule passes.
+     * Run the validation rule.
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @return bool
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
+     * @return void
      */
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        return filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) !== null;
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string
-     */
-    public function message(): string
-    {
-        return __('validation.boolean');
+        if (filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) === null) {
+            $fail(__('validation.boolean'));
+        }
     }
 }

--- a/app/Rules/Api/RandomSoleRule.php
+++ b/app/Rules/Api/RandomSoleRule.php
@@ -5,35 +5,30 @@ declare(strict_types=1);
 namespace App\Rules\Api;
 
 use App\Http\Api\Criteria\Sort\RandomCriteria;
-use Illuminate\Contracts\Validation\Rule;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Str;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 /**
  * Class RandomSoleRule.
  */
-class RandomSoleRule implements Rule
+class RandomSoleRule implements ValidationRule
 {
     /**
-     * Determine if the validation rule passes.
+     * Run the validation rule.
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @return bool
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
+     * @return void
      */
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         $values = Str::of($value)->explode(',');
 
-        return ! $values->contains(RandomCriteria::PARAM_VALUE) || $values->containsOneItem();
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string
-     */
-    public function message(): string
-    {
-        return __('validation.api.random_sole');
+        if ($values->contains(RandomCriteria::PARAM_VALUE) && ! $values->containsOneItem()) {
+            $fail(__('validation.api.random_sole'));
+        }
     }
 }

--- a/app/Rules/Billing/TransparencyDateRule.php
+++ b/app/Rules/Billing/TransparencyDateRule.php
@@ -5,14 +5,16 @@ declare(strict_types=1);
 namespace App\Rules\Billing;
 
 use App\Enums\Http\Api\Filter\AllowedDateFormat;
-use Illuminate\Contracts\Validation\Rule;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 /**
  * Class TransparencyDateRule.
  */
-class TransparencyDateRule implements Rule
+readonly class TransparencyDateRule implements ValidationRule
 {
     /**
      * Create a new rule instance.
@@ -20,31 +22,22 @@ class TransparencyDateRule implements Rule
      * @param  Collection<int, Carbon>  $validDates
      * @return void
      */
-    public function __construct(protected readonly Collection $validDates)
+    public function __construct(protected Collection $validDates)
     {
     }
 
     /**
-     * Determine if the validation rule passes.
+     * Run the validation rule.
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @return bool
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
+     * @return void
      */
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        return $this->validDates->contains(
-            fn (Carbon $validDate) => $validDate->format(AllowedDateFormat::YM) === $value
-        );
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string
-     */
-    public function message(): string
-    {
-        return __('The selected month is not valid.');
+        if (! $this->validDates->contains(fn (Carbon $validDate) => $validDate->format(AllowedDateFormat::YM) === $value)) {
+            $fail(__('The selected month is not valid.'));
+        }
     }
 }

--- a/app/Rules/ModerationRule.php
+++ b/app/Rules/ModerationRule.php
@@ -9,7 +9,7 @@ use App\Constants\Config\ValidationConstants;
 use App\Enums\Rules\ModerationService;
 use Closure;
 use Exception;
-use Illuminate\Contracts\Validation\InvokableRule;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
@@ -20,7 +20,7 @@ use RuntimeException;
 /**
  * Class ModerationRule.
  */
-class ModerationRule implements InvokableRule
+class ModerationRule implements ValidationRule
 {
     /**
      * Run the validation rule.
@@ -32,11 +32,11 @@ class ModerationRule implements InvokableRule
      *
      * @throws RuntimeException
      */
-    public function __invoke(string $attribute, mixed $value, Closure $fail): void
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         match (Config::get(ValidationConstants::MODERATION_SERVICE_QUALIFIED)) {
             ModerationService::NONE => null,
-            ModerationService::OPENAI => $this->invokeForOpenAI($attribute, $value, $fail),
+            ModerationService::OPENAI => $this->validateForOpenAI($attribute, $value, $fail),
             default => throw new RuntimeException('Invalid moderation service config value'),
         };
     }
@@ -49,7 +49,7 @@ class ModerationRule implements InvokableRule
      * @param  Closure(string): PotentiallyTranslatedString  $fail
      * @return void
      */
-    private function invokeForOpenAI(string $attribute, mixed $value, Closure $fail): void
+    private function validateForOpenAI(string $attribute, mixed $value, Closure $fail): void
     {
         try {
             $response = Http::acceptJson()

--- a/app/Rules/Storage/StorageDirectoryExistsRule.php
+++ b/app/Rules/Storage/StorageDirectoryExistsRule.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace App\Rules\Storage;
 
+use Closure;
 use Illuminate\Contracts\Filesystem\Filesystem;
-use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 /**
  * Class StorageDirectoryExistsRule.
  */
-class StorageDirectoryExistsRule implements Rule
+readonly class StorageDirectoryExistsRule implements ValidationRule
 {
     /**
      * Create a new rule instance.
@@ -18,29 +20,22 @@ class StorageDirectoryExistsRule implements Rule
      * @param  Filesystem  $fs
      * @return void
      */
-    public function __construct(protected readonly Filesystem $fs)
+    public function __construct(protected Filesystem $fs)
     {
     }
 
     /**
-     * Determine if the validation rule passes.
+     * Run the validation rule.
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @return bool
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
+     * @return void
      */
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        return $this->fs->directoryExists($value);
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string|array
-     */
-    public function message(): string|array
-    {
-        return __('validation.directory_exists');
+        if (! $this->fs->directoryExists($value)) {
+            $fail(__('validation.directory_exists'));
+        }
     }
 }

--- a/app/Rules/Storage/StorageFileDirectoryExistsRule.php
+++ b/app/Rules/Storage/StorageFileDirectoryExistsRule.php
@@ -4,14 +4,16 @@ declare(strict_types=1);
 
 namespace App\Rules\Storage;
 
+use Closure;
 use Illuminate\Contracts\Filesystem\Filesystem;
-use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Facades\File;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 /**
  * Class StorageFileDirectoryExistsRule.
  */
-class StorageFileDirectoryExistsRule implements Rule
+readonly class StorageFileDirectoryExistsRule implements ValidationRule
 {
     /**
      * Create a new rule instance.
@@ -19,29 +21,22 @@ class StorageFileDirectoryExistsRule implements Rule
      * @param  Filesystem  $fs
      * @return void
      */
-    public function __construct(protected readonly Filesystem $fs)
+    public function __construct(protected Filesystem $fs)
     {
     }
 
     /**
-     * Determine if the validation rule passes.
+     * Run the validation rule.
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @return bool
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
+     * @return void
      */
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        return $this->fs->directoryExists(File::dirname($value));
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string|array
-     */
-    public function message(): string|array
-    {
-        return __('validation.directory_exists');
+        if (! $this->fs->directoryExists(File::dirname($value))) {
+            $fail(__('validation.directory_exists'));
+        }
     }
 }

--- a/app/Rules/Wiki/Resource/AnimeResourceLinkFormatRule.php
+++ b/app/Rules/Wiki/Resource/AnimeResourceLinkFormatRule.php
@@ -5,31 +5,34 @@ declare(strict_types=1);
 namespace App\Rules\Wiki\Resource;
 
 use App\Enums\Models\Wiki\ResourceSite;
-use Illuminate\Contracts\Validation\Rule;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Str;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 /**
  * Class AnimeResourceLinkFormatRule.
  */
-class AnimeResourceLinkFormatRule implements Rule
+readonly class AnimeResourceLinkFormatRule implements ValidationRule
 {
     /**
      * Create a new rule instance.
      *
      * @param  ResourceSite  $site
      */
-    public function __construct(protected readonly ResourceSite $site)
+    public function __construct(protected ResourceSite $site)
     {
     }
 
     /**
-     * Determine if the validation rule passes.
+     * Run the validation rule.
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @return bool
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
+     * @return void
      */
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         $pattern = match ($this->site->value) {
             ResourceSite::TWITTER => '/^https:\/\/twitter\.com\/\w+$/',
@@ -42,16 +45,8 @@ class AnimeResourceLinkFormatRule implements Rule
             default => null,
         };
 
-        return $pattern === null || Str::match($pattern, $value) === $value;
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string|array
-     */
-    public function message(): string|array
-    {
-        return __('validation.regex');
+        if ($pattern !== null && Str::match($pattern, $value) !== $value) {
+            $fail(__('validation.regex'));
+        }
     }
 }

--- a/app/Rules/Wiki/Resource/ArtistResourceLinkFormatRule.php
+++ b/app/Rules/Wiki/Resource/ArtistResourceLinkFormatRule.php
@@ -5,31 +5,34 @@ declare(strict_types=1);
 namespace App\Rules\Wiki\Resource;
 
 use App\Enums\Models\Wiki\ResourceSite;
-use Illuminate\Contracts\Validation\Rule;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Str;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 /**
  * Class ArtistResourceLinkFormatRule.
  */
-class ArtistResourceLinkFormatRule implements Rule
+readonly class ArtistResourceLinkFormatRule implements ValidationRule
 {
     /**
      * Create a new rule instance.
      *
      * @param  ResourceSite  $site
      */
-    public function __construct(protected readonly ResourceSite $site)
+    public function __construct(protected ResourceSite $site)
     {
     }
 
     /**
-     * Determine if the validation rule passes.
+     * Run the validation rule.
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @return bool
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
+     * @return void
      */
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         $pattern = match ($this->site->value) {
             ResourceSite::TWITTER => '/^https:\/\/twitter\.com\/\w+$/',
@@ -42,16 +45,8 @@ class ArtistResourceLinkFormatRule implements Rule
             default => null,
         };
 
-        return $pattern === null || Str::match($pattern, $value) === $value;
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string|array
-     */
-    public function message(): string|array
-    {
-        return __('validation.regex');
+        if ($pattern !== null && Str::match($pattern, $value) !== $value) {
+            $fail(__('validation.regex'));
+        }
     }
 }

--- a/app/Rules/Wiki/Resource/ResourceSiteMatchesLinkRule.php
+++ b/app/Rules/Wiki/Resource/ResourceSiteMatchesLinkRule.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace App\Rules\Wiki\Resource;
 
 use App\Enums\Models\Wiki\ResourceSite;
-use Illuminate\Contracts\Validation\Rule;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 /**
  * Class ResourceSiteMatchesLinkRule.
  */
-class ResourceSiteMatchesLinkRule implements Rule
+readonly class ResourceSiteMatchesLinkRule implements ValidationRule
 {
     /**
      * Create a new rule instance.
@@ -18,31 +20,24 @@ class ResourceSiteMatchesLinkRule implements Rule
      * @param  string  $link
      * @return void
      */
-    public function __construct(protected readonly string $link)
+    public function __construct(protected string $link)
     {
     }
 
     /**
-     * Determine if the validation rule passes.
+     * Run the validation rule.
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @return bool
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
+     * @return void
      */
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         $domain = ResourceSite::getDomain($value);
 
-        return empty($domain) || $domain === parse_url($this->link, PHP_URL_HOST);
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string|array
-     */
-    public function message(): string|array
-    {
-        return __('validation.resource_link_site_mismatch');
+        if (! empty($domain) && $domain !== parse_url($this->link, PHP_URL_HOST)) {
+            $fail(__('validation.resource_link_site_mismatch'));
+        }
     }
 }

--- a/app/Rules/Wiki/Resource/StudioResourceLinkFormatRule.php
+++ b/app/Rules/Wiki/Resource/StudioResourceLinkFormatRule.php
@@ -5,31 +5,34 @@ declare(strict_types=1);
 namespace App\Rules\Wiki\Resource;
 
 use App\Enums\Models\Wiki\ResourceSite;
-use Illuminate\Contracts\Validation\Rule;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Str;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 /**
  * Class StudioResourceLinkFormatRule.
  */
-class StudioResourceLinkFormatRule implements Rule
+readonly class StudioResourceLinkFormatRule implements ValidationRule
 {
     /**
      * Create a new rule instance.
      *
      * @param  ResourceSite  $site
      */
-    public function __construct(protected readonly ResourceSite $site)
+    public function __construct(protected ResourceSite $site)
     {
     }
 
     /**
-     * Determine if the validation rule passes.
+     * Run the validation rule.
      *
      * @param  string  $attribute
      * @param  mixed  $value
-     * @return bool
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
+     * @return void
      */
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         $pattern = match ($this->site->value) {
             ResourceSite::TWITTER => '/^https:\/\/twitter\.com\/\w+$/',
@@ -42,16 +45,8 @@ class StudioResourceLinkFormatRule implements Rule
             default => null,
         };
 
-        return $pattern === null || Str::match($pattern, $value) === $value;
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string|array
-     */
-    public function message(): string|array
-    {
-        return __('validation.regex');
+        if ($pattern !== null && Str::match($pattern, $value) !== $value) {
+            $fail(__('validation.regex'));
+        }
     }
 }

--- a/app/Rules/Wiki/Submission/Audio/AudioChannelLayoutStreamRule.php
+++ b/app/Rules/Wiki/Submission/Audio/AudioChannelLayoutStreamRule.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace App\Rules\Wiki\Submission\Audio;
 
 use App\Rules\Wiki\Submission\SubmissionRule;
-use Illuminate\Http\UploadedFile;
+use Closure;
 use Illuminate\Support\Arr;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 /**
  * Class AudioChannelLayoutStreamRule.
@@ -14,29 +15,22 @@ use Illuminate\Support\Arr;
 class AudioChannelLayoutStreamRule extends SubmissionRule
 {
     /**
-     * Determine if the validation rule passes.
+     * Run the validation rule.
      *
      * @param  string  $attribute
-     * @param  UploadedFile  $value
-     * @return bool
+     * @param  mixed  $value
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
+     * @return void
      */
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         $audio = Arr::first(
             $this->streams(),
             fn (array $stream) => Arr::get($stream, 'codec_type') === 'audio'
         );
 
-        return Arr::get($audio, 'channel_layout') === 'stereo';
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string|array
-     */
-    public function message(): string|array
-    {
-        return __('validation.submission.audio_channel_layout');
+        if (Arr::get($audio, 'channel_layout') !== 'stereo') {
+            $fail(__('validation.submission.audio_channel_layout'));
+        }
     }
 }

--- a/app/Rules/Wiki/Submission/Audio/AudioChannelsStreamRule.php
+++ b/app/Rules/Wiki/Submission/Audio/AudioChannelsStreamRule.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace App\Rules\Wiki\Submission\Audio;
 
 use App\Rules\Wiki\Submission\SubmissionRule;
-use Illuminate\Http\UploadedFile;
+use Closure;
 use Illuminate\Support\Arr;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 /**
  * Class AudioChannelsStreamRule.
@@ -14,29 +15,22 @@ use Illuminate\Support\Arr;
 class AudioChannelsStreamRule extends SubmissionRule
 {
     /**
-     * Determine if the validation rule passes.
+     * Run the validation rule.
      *
      * @param  string  $attribute
-     * @param  UploadedFile  $value
-     * @return bool
+     * @param  mixed  $value
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
+     * @return void
      */
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         $audio = Arr::first(
             $this->streams(),
             fn (array $stream) => Arr::get($stream, 'codec_type') === 'audio'
         );
 
-        return Arr::get($audio, 'channels') === 2;
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string|array
-     */
-    public function message(): string|array
-    {
-        return __('validation.submission.audio_channels');
+        if (Arr::get($audio, 'channels') !== 2) {
+            $fail(__('validation.submission.audio_channels'));
+        }
     }
 }

--- a/app/Rules/Wiki/Submission/Audio/AudioCodecStreamRule.php
+++ b/app/Rules/Wiki/Submission/Audio/AudioCodecStreamRule.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace App\Rules\Wiki\Submission\Audio;
 
 use App\Rules\Wiki\Submission\SubmissionRule;
-use Illuminate\Http\UploadedFile;
+use Closure;
 use Illuminate\Support\Arr;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 /**
  * Class AudioCodecStreamRule.
@@ -14,29 +15,22 @@ use Illuminate\Support\Arr;
 class AudioCodecStreamRule extends SubmissionRule
 {
     /**
-     * Determine if the validation rule passes.
+     * Run the validation rule.
      *
      * @param  string  $attribute
-     * @param  UploadedFile  $value
-     * @return bool
+     * @param  mixed  $value
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
+     * @return void
      */
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         $audio = Arr::first(
             $this->streams(),
             fn (array $stream) => Arr::get($stream, 'codec_type') === 'audio'
         );
 
-        return Arr::get($audio, 'codec_name') === 'opus';
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string|array
-     */
-    public function message(): string|array
-    {
-        return __('validation.submission.audio_codec');
+        if (Arr::get($audio, 'codec_name') !== 'opus') {
+            $fail(__('validation.submission.audio_codec'));
+        }
     }
 }

--- a/app/Rules/Wiki/Submission/Audio/AudioIndexStreamRule.php
+++ b/app/Rules/Wiki/Submission/Audio/AudioIndexStreamRule.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace App\Rules\Wiki\Submission\Audio;
 
 use App\Rules\Wiki\Submission\SubmissionRule;
-use Illuminate\Http\UploadedFile;
+use Closure;
 use Illuminate\Support\Arr;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 /**
  * Class AudioIndexStreamRule.
@@ -23,29 +24,22 @@ class AudioIndexStreamRule extends SubmissionRule
     }
 
     /**
-     * Determine if the validation rule passes.
+     * Run the validation rule.
      *
      * @param  string  $attribute
-     * @param  UploadedFile  $value
-     * @return bool
+     * @param  mixed  $value
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
+     * @return void
      */
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         $stream = Arr::first(
             $this->streams(),
             fn (array $stream) => Arr::get($stream, 'codec_type') === 'audio' && Arr::get($stream, 'index') === $this->expected
         );
 
-        return $stream !== null;
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string|array
-     */
-    public function message(): string|array
-    {
-        return __('validation.submission.audio_index');
+        if ($stream === null) {
+            $fail(__('validation.submission.audio_index'));
+        }
     }
 }

--- a/app/Rules/Wiki/Submission/Audio/AudioLoudnessIntegratedTargetStreamRule.php
+++ b/app/Rules/Wiki/Submission/Audio/AudioLoudnessIntegratedTargetStreamRule.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace App\Rules\Wiki\Submission\Audio;
 
 use App\Rules\Wiki\Submission\SubmissionRule;
-use Illuminate\Http\UploadedFile;
+use Closure;
 use Illuminate\Support\Arr;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 /**
  * Class AudioLoudnessIntegratedTargetStreamRule.
@@ -14,28 +15,21 @@ use Illuminate\Support\Arr;
 class AudioLoudnessIntegratedTargetStreamRule extends SubmissionRule
 {
     /**
-     * Determine if the validation rule passes.
+     * Run the validation rule.
      *
      * @param  string  $attribute
-     * @param  UploadedFile  $value
-     * @return bool
+     * @param  mixed  $value
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
+     * @return void
      */
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         $loudness = $this->loudness();
 
         $target = floatval(Arr::get($loudness, 'input_i'));
 
-        return $target >= -17.0 && $target <= -14.0;
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string|array
-     */
-    public function message(): string|array
-    {
-        return __('validation.submission.audio_loudness_integrated_target');
+        if ($target < -17.0 || $target > -14.0) {
+            $fail(__('validation.submission.audio_loudness_integrated_target'));
+        }
     }
 }

--- a/app/Rules/Wiki/Submission/Audio/AudioLoudnessTruePeakStreamRule.php
+++ b/app/Rules/Wiki/Submission/Audio/AudioLoudnessTruePeakStreamRule.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace App\Rules\Wiki\Submission\Audio;
 
 use App\Rules\Wiki\Submission\SubmissionRule;
-use Illuminate\Http\UploadedFile;
+use Closure;
 use Illuminate\Support\Arr;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 /**
  * Class AudioLoudnessTruePeakStreamRule.
@@ -14,28 +15,21 @@ use Illuminate\Support\Arr;
 class AudioLoudnessTruePeakStreamRule extends SubmissionRule
 {
     /**
-     * Determine if the validation rule passes.
+     * Run the validation rule.
      *
      * @param  string  $attribute
-     * @param  UploadedFile  $value
-     * @return bool
+     * @param  mixed  $value
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
+     * @return void
      */
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         $loudness = $this->loudness();
 
         $peak = floatval(Arr::get($loudness, 'input_tp'));
 
-        return $peak <= 0.0;
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string|array
-     */
-    public function message(): string|array
-    {
-        return __('validation.submission.audio_loudness_true_peak');
+        if ($peak > 0.0) {
+            $fail(__('validation.submission.audio_loudness_true_peak'));
+        }
     }
 }

--- a/app/Rules/Wiki/Submission/Audio/AudioSampleRateStreamRule.php
+++ b/app/Rules/Wiki/Submission/Audio/AudioSampleRateStreamRule.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace App\Rules\Wiki\Submission\Audio;
 
 use App\Rules\Wiki\Submission\SubmissionRule;
-use Illuminate\Http\UploadedFile;
+use Closure;
 use Illuminate\Support\Arr;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 /**
  * Class AudioSampleRateStreamRule.
@@ -14,29 +15,22 @@ use Illuminate\Support\Arr;
 class AudioSampleRateStreamRule extends SubmissionRule
 {
     /**
-     * Determine if the validation rule passes.
+     * Run the validation rule.
      *
      * @param  string  $attribute
-     * @param  UploadedFile  $value
-     * @return bool
+     * @param  mixed  $value
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
+     * @return void
      */
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         $audio = Arr::first(
             $this->streams(),
             fn (array $stream) => Arr::get($stream, 'codec_type') === 'audio'
         );
 
-        return Arr::get($audio, 'sample_rate') === '48000';
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string|array
-     */
-    public function message(): string|array
-    {
-        return __('validation.submission.audio_sample_rate');
+        if (Arr::get($audio, 'sample_rate') !== '48000') {
+            $fail(__('validation.submission.audio_sample_rate'));
+        }
     }
 }

--- a/app/Rules/Wiki/Submission/Format/AudioBitrateRestrictionFormatRule.php
+++ b/app/Rules/Wiki/Submission/Format/AudioBitrateRestrictionFormatRule.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace App\Rules\Wiki\Submission\Format;
 
 use App\Rules\Wiki\Submission\SubmissionRule;
-use Illuminate\Http\UploadedFile;
+use Closure;
 use Illuminate\Support\Arr;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 /**
  * Class AudioBitrateRestrictionFormatRule.
@@ -14,28 +15,21 @@ use Illuminate\Support\Arr;
 class AudioBitrateRestrictionFormatRule extends SubmissionRule
 {
     /**
-     * Determine if the validation rule passes.
+     * Run the validation rule.
      *
      * @param  string  $attribute
-     * @param  UploadedFile  $value
-     * @return bool
+     * @param  mixed  $value
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
+     * @return void
      */
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         $format = $this->format();
 
         $bitrate = intval(Arr::get($format, 'bit_rate'));
 
-        return $bitrate > 128000 && $bitrate < 360000;
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string|array
-     */
-    public function message(): string|array
-    {
-        return __('validation.submission.format_bitrate_restriction');
+        if ($bitrate < 128000 || $bitrate > 360000) {
+            $fail(__('validation.submission.format_bitrate_restriction'));
+        }
     }
 }

--- a/app/Rules/Wiki/Submission/Format/EncoderNameFormatRule.php
+++ b/app/Rules/Wiki/Submission/Format/EncoderNameFormatRule.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace App\Rules\Wiki\Submission\Format;
 
 use App\Rules\Wiki\Submission\SubmissionRule;
-use Illuminate\Http\UploadedFile;
+use Closure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 /**
  * Class EncoderNameFormatRule.
@@ -15,28 +16,21 @@ use Illuminate\Support\Str;
 class EncoderNameFormatRule extends SubmissionRule
 {
     /**
-     * Determine if the validation rule passes.
+     * Run the validation rule.
      *
      * @param  string  $attribute
-     * @param  UploadedFile  $value
-     * @return bool
+     * @param  mixed  $value
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
+     * @return void
      */
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         $tags = $this->tags();
 
         $encoder = Arr::get($tags, 'encoder');
 
-        return Str::startsWith($encoder, 'Lavf');
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string|array
-     */
-    public function message(): string|array
-    {
-        return __('validation.submission.format_encoder_name');
+        if (! Str::startsWith($encoder, 'Lavf')) {
+            $fail(__('validation.submission.format_encoder_name'));
+        }
     }
 }

--- a/app/Rules/Wiki/Submission/Format/EncoderVersionFormatRule.php
+++ b/app/Rules/Wiki/Submission/Format/EncoderVersionFormatRule.php
@@ -6,8 +6,9 @@ namespace App\Rules\Wiki\Submission\Format;
 
 use App\Constants\FeatureConstants;
 use App\Rules\Wiki\Submission\SubmissionRule;
-use Illuminate\Http\UploadedFile;
+use Closure;
 use Illuminate\Support\Arr;
+use Illuminate\Translation\PotentiallyTranslatedString;
 use Laravel\Pennant\Feature;
 
 /**
@@ -16,28 +17,21 @@ use Laravel\Pennant\Feature;
 class EncoderVersionFormatRule extends SubmissionRule
 {
     /**
-     * Determine if the validation rule passes.
+     * Run the validation rule.
      *
      * @param  string  $attribute
-     * @param  UploadedFile  $value
-     * @return bool
+     * @param  mixed  $value
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
+     * @return void
      */
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         $tags = $this->tags();
 
         $encoder = Arr::get($tags, 'encoder');
 
-        return version_compare($encoder, Feature::for(null)->value(FeatureConstants::REQUIRED_ENCODER_VERSION), '>=');
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string|array
-     */
-    public function message(): string|array
-    {
-        return __('validation.submission.format_encoder_version');
+        if (version_compare($encoder, Feature::for(null)->value(FeatureConstants::REQUIRED_ENCODER_VERSION), '<')) {
+            $fail(__('validation.submission.format_encoder_version'));
+        }
     }
 }

--- a/app/Rules/Wiki/Submission/Format/ExtraneousChaptersFormatRule.php
+++ b/app/Rules/Wiki/Submission/Format/ExtraneousChaptersFormatRule.php
@@ -5,32 +5,26 @@ declare(strict_types=1);
 namespace App\Rules\Wiki\Submission\Format;
 
 use App\Rules\Wiki\Submission\SubmissionRule;
-use Illuminate\Http\UploadedFile;
+use Closure;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 /**
- * Class ExtraneousChaptersRule.
+ * Class ExtraneousChaptersFormatRule.
  */
 class ExtraneousChaptersFormatRule extends SubmissionRule
 {
     /**
-     * Determine if the validation rule passes.
+     * Run the validation rule.
      *
      * @param  string  $attribute
-     * @param  UploadedFile  $value
-     * @return bool
+     * @param  mixed  $value
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
+     * @return void
      */
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        return empty($this->chapters());
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string|array
-     */
-    public function message(): string|array
-    {
-        return __('validation.submission.format_extraneous_chapters');
+        if (! empty($this->chapters())) {
+            $fail(__('validation.submission.format_extraneous_chapters'));
+        }
     }
 }

--- a/app/Rules/Wiki/Submission/Format/ExtraneousMetadataFormatRule.php
+++ b/app/Rules/Wiki/Submission/Format/ExtraneousMetadataFormatRule.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace App\Rules\Wiki\Submission\Format;
 
 use App\Rules\Wiki\Submission\SubmissionRule;
-use Illuminate\Http\UploadedFile;
+use Closure;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 /**
  * Class ExtraneousMetadataFormatRule.
@@ -13,26 +14,19 @@ use Illuminate\Http\UploadedFile;
 class ExtraneousMetadataFormatRule extends SubmissionRule
 {
     /**
-     * Determine if the validation rule passes.
+     * Run the validation rule.
      *
      * @param  string  $attribute
-     * @param  UploadedFile  $value
-     * @return bool
+     * @param  mixed  $value
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
+     * @return void
      */
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         $tags = $this->tags();
 
-        return collect($tags)->keys()->diff(['encoder', 'duration'])->isEmpty();
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string|array
-     */
-    public function message(): string|array
-    {
-        return __('validation.submission.format_extraneous_metadata');
+        if (collect($tags)->keys()->diff(['encoder', 'duration'])->isNotEmpty()) {
+            $fail(__('validation.submission.format_extraneous_metadata'));
+        }
     }
 }

--- a/app/Rules/Wiki/Submission/Format/FormatNameFormatRule.php
+++ b/app/Rules/Wiki/Submission/Format/FormatNameFormatRule.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace App\Rules\Wiki\Submission\Format;
 
 use App\Rules\Wiki\Submission\SubmissionRule;
-use Illuminate\Http\UploadedFile;
+use Closure;
 use Illuminate\Support\Arr;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 /**
  * Class FormatNameFormatRule.
@@ -23,28 +24,21 @@ class FormatNameFormatRule extends SubmissionRule
     }
 
     /**
-     * Determine if the validation rule passes.
+     * Run the validation rule.
      *
      * @param  string  $attribute
-     * @param  UploadedFile  $value
-     * @return bool
+     * @param  mixed  $value
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
+     * @return void
      */
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         $format = $this->format();
 
         $formatName = Arr::get($format, 'format_name');
 
-        return $formatName === $this->expected;
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string|array
-     */
-    public function message(): string|array
-    {
-        return __('validation.submission.format_format_name');
+        if ($formatName !== $this->expected) {
+            $fail(__('validation.submission.format_format_name'));
+        }
     }
 }

--- a/app/Rules/Wiki/Submission/Format/TotalStreamsFormatRule.php
+++ b/app/Rules/Wiki/Submission/Format/TotalStreamsFormatRule.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace App\Rules\Wiki\Submission\Format;
 
 use App\Rules\Wiki\Submission\SubmissionRule;
-use Illuminate\Http\UploadedFile;
+use Closure;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 /**
  * Class TotalStreamsFormatRule.
@@ -22,26 +23,19 @@ class TotalStreamsFormatRule extends SubmissionRule
     }
 
     /**
-     * Determine if the validation rule passes.
+     * Run the validation rule.
      *
      * @param  string  $attribute
-     * @param  UploadedFile  $value
-     * @return bool
+     * @param  mixed  $value
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
+     * @return void
      */
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         $streams = $this->streams();
 
-        return count($streams) === $this->expected;
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string|array
-     */
-    public function message(): string|array
-    {
-        return __('validation.submission.format_total_streams');
+        if (count($streams) !== $this->expected) {
+            $fail(__('validation.submission.format_total_streams'));
+        }
     }
 }

--- a/app/Rules/Wiki/Submission/Format/VideoBitrateRestrictionFormatRule.php
+++ b/app/Rules/Wiki/Submission/Format/VideoBitrateRestrictionFormatRule.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace App\Rules\Wiki\Submission\Format;
 
 use App\Rules\Wiki\Submission\SubmissionRule;
-use Illuminate\Http\UploadedFile;
+use Closure;
 use Illuminate\Support\Arr;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 /**
  * Class VideoBitrateRestrictionFormatRule.
@@ -14,13 +15,14 @@ use Illuminate\Support\Arr;
 class VideoBitrateRestrictionFormatRule extends SubmissionRule
 {
     /**
-     * Determine if the validation rule passes.
+     * Run the validation rule.
      *
      * @param  string  $attribute
-     * @param  UploadedFile  $value
-     * @return bool
+     * @param  mixed  $value
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
+     * @return void
      */
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         $format = $this->format();
 
@@ -33,16 +35,8 @@ class VideoBitrateRestrictionFormatRule extends SubmissionRule
         $height = intval(Arr::get($video, 'height'));
 
         // Linear approximation of egregious bitrate by resolution
-        return $bitrate < $height * 7100 + 475000;
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string|array
-     */
-    public function message(): string|array
-    {
-        return __('validation.submission.format_bitrate_restriction');
+        if ($bitrate > $height * 7100 + 475000) {
+            $fail(__('validation.submission.format_bitrate_restriction'));
+        }
     }
 }

--- a/app/Rules/Wiki/Submission/SubmissionRule.php
+++ b/app/Rules/Wiki/Submission/SubmissionRule.php
@@ -31,7 +31,6 @@ abstract class SubmissionRule implements ValidationRule, ValidatorAwareRule
      */
     protected array $loudnessStats;
 
-
     /**
      * Set the current validator.
      *

--- a/app/Rules/Wiki/Submission/SubmissionRule.php
+++ b/app/Rules/Wiki/Submission/SubmissionRule.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace App\Rules\Wiki\Submission;
 
-use Illuminate\Contracts\Validation\DataAwareRule;
-use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Contracts\Validation\ValidatorAwareRule;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Arr;
@@ -16,27 +15,22 @@ use Illuminate\Validation\Validator;
 /**
  * Class SubmissionRule.
  */
-abstract class SubmissionRule implements DataAwareRule, Rule, ValidatorAwareRule
+abstract class SubmissionRule implements ValidationRule, ValidatorAwareRule
 {
     /**
-     * The data under validation.
+     * The stream, chapter and format data as inspected by ffprobe.
      *
      * @var array
      */
-    protected array $data = [];
+    protected array $ffprobeData;
 
     /**
-     * Set the data under validation.
+     * The loudness stats of the input file as parsed by the ffmpeg audio filter.
      *
-     * @param  array  $data
-     * @return $this
+     * @var array
      */
-    public function setData(array $data): self
-    {
-        $this->data = $data;
+    protected array $loudnessStats;
 
-        return $this;
-    }
 
     /**
      * Set the current validator.
@@ -51,13 +45,17 @@ abstract class SubmissionRule implements DataAwareRule, Rule, ValidatorAwareRule
 
         $ffprobeData = Arr::get($validator->getData(), 'ffprobeData');
         if ($ffprobeData === null && $file !== null) {
-            $validator->setValue('ffprobeData', $this->getFFprobeData($file));
+            $ffprobeData = $this->getFFprobeData($file);
+            $validator->setValue('ffprobeData', $ffprobeData);
         }
+        $this->ffprobeData = $ffprobeData;
 
         $loudnessStats = Arr::get($validator->getData(), 'loudnessStats');
         if ($loudnessStats === null && $file !== null) {
-            $validator->setValue('loudnessStats', $this->getLoudnessStats($file));
+            $loudnessStats = $this->getLoudnessStats($file);
+            $validator->setValue('loudnessStats', $loudnessStats);
         }
+        $this->loudnessStats = $loudnessStats;
 
         return $this;
     }
@@ -101,7 +99,7 @@ abstract class SubmissionRule implements DataAwareRule, Rule, ValidatorAwareRule
      */
     protected function streams(): array
     {
-        return Arr::get($this->data, 'ffprobeData.streams', []);
+        return Arr::get($this->ffprobeData, 'streams', []);
     }
 
     /**
@@ -111,7 +109,7 @@ abstract class SubmissionRule implements DataAwareRule, Rule, ValidatorAwareRule
      */
     protected function format(): array
     {
-        return Arr::get($this->data, 'ffprobeData.format', []);
+        return Arr::get($this->ffprobeData, 'format', []);
     }
 
     /**
@@ -121,7 +119,7 @@ abstract class SubmissionRule implements DataAwareRule, Rule, ValidatorAwareRule
      */
     protected function chapters(): array
     {
-        return Arr::get($this->data, 'ffprobeData.chapters', []);
+        return Arr::get($this->ffprobeData, 'chapters', []);
     }
 
     /**
@@ -131,7 +129,7 @@ abstract class SubmissionRule implements DataAwareRule, Rule, ValidatorAwareRule
      */
     protected function loudness(): array
     {
-        return Arr::get($this->data, 'loudnessStats', []);
+        return $this->loudnessStats;
     }
 
     /**

--- a/app/Rules/Wiki/Submission/Video/VideoCodecStreamRule.php
+++ b/app/Rules/Wiki/Submission/Video/VideoCodecStreamRule.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace App\Rules\Wiki\Submission\Video;
 
 use App\Rules\Wiki\Submission\SubmissionRule;
-use Illuminate\Http\UploadedFile;
+use Closure;
 use Illuminate\Support\Arr;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 /**
  * Class VideoCodecStreamRule.
@@ -14,29 +15,22 @@ use Illuminate\Support\Arr;
 class VideoCodecStreamRule extends SubmissionRule
 {
     /**
-     * Determine if the validation rule passes.
+     * Run the validation rule.
      *
      * @param  string  $attribute
-     * @param  UploadedFile  $value
-     * @return bool
+     * @param  mixed  $value
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
+     * @return void
      */
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         $video = Arr::first(
             $this->streams(),
             fn (array $stream) => Arr::get($stream, 'codec_type') === 'video'
         );
 
-        return Arr::get($video, 'codec_name') === 'vp9';
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string|array
-     */
-    public function message(): string|array
-    {
-        return __('validation.submission.video_codec');
+        if (Arr::get($video, 'codec_name') !== 'vp9') {
+            $fail(__('validation.submission.video_codec'));
+        }
     }
 }

--- a/app/Rules/Wiki/Submission/Video/VideoColorPrimariesStreamRule.php
+++ b/app/Rules/Wiki/Submission/Video/VideoColorPrimariesStreamRule.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace App\Rules\Wiki\Submission\Video;
 
 use App\Rules\Wiki\Submission\SubmissionRule;
-use Illuminate\Http\UploadedFile;
+use Closure;
 use Illuminate\Support\Arr;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 /**
  * Class VideoColorPrimariesStreamRule.
@@ -14,32 +15,22 @@ use Illuminate\Support\Arr;
 class VideoColorPrimariesStreamRule extends SubmissionRule
 {
     /**
-     * Determine if the validation rule passes.
+     * Run the validation rule.
      *
      * @param  string  $attribute
-     * @param  UploadedFile  $value
-     * @return bool
+     * @param  mixed  $value
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
+     * @return void
      */
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         $video = Arr::first(
             $this->streams(),
             fn (array $stream) => Arr::get($stream, 'codec_type') === 'video'
         );
 
-        return in_array(
-            Arr::get($video, 'color_primaries'),
-            ['bt709', 'smpte170m', 'bt470bg']
-        );
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string|array
-     */
-    public function message(): string|array
-    {
-        return __('validation.submission.video_color_primaries');
+        if (! in_array(Arr::get($video, 'color_primaries'), ['bt709', 'smpte170m', 'bt470bg'])) {
+            $fail(__('validation.submission.video_color_primaries'));
+        }
     }
 }

--- a/app/Rules/Wiki/Submission/Video/VideoColorSpaceStreamRule.php
+++ b/app/Rules/Wiki/Submission/Video/VideoColorSpaceStreamRule.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace App\Rules\Wiki\Submission\Video;
 
 use App\Rules\Wiki\Submission\SubmissionRule;
-use Illuminate\Http\UploadedFile;
+use Closure;
 use Illuminate\Support\Arr;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 /**
  * Class VideoColorSpaceStreamRule.
@@ -14,32 +15,22 @@ use Illuminate\Support\Arr;
 class VideoColorSpaceStreamRule extends SubmissionRule
 {
     /**
-     * Determine if the validation rule passes.
+     * Run the validation rule.
      *
      * @param  string  $attribute
-     * @param  UploadedFile  $value
-     * @return bool
+     * @param  mixed  $value
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
+     * @return void
      */
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         $video = Arr::first(
             $this->streams(),
             fn (array $stream) => Arr::get($stream, 'codec_type') === 'video'
         );
 
-        return in_array(
-            Arr::get($video, 'color_space'),
-            ['bt709', 'smpte170m', 'bt470bg']
-        );
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string|array
-     */
-    public function message(): string|array
-    {
-        return __('validation.submission.video_color_space');
+        if (! in_array(Arr::get($video, 'color_space'), ['bt709', 'smpte170m', 'bt470bg'])) {
+            $fail(__('validation.submission.video_color_space'));
+        }
     }
 }

--- a/app/Rules/Wiki/Submission/Video/VideoColorTransferStreamRule.php
+++ b/app/Rules/Wiki/Submission/Video/VideoColorTransferStreamRule.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace App\Rules\Wiki\Submission\Video;
 
 use App\Rules\Wiki\Submission\SubmissionRule;
-use Illuminate\Http\UploadedFile;
+use Closure;
 use Illuminate\Support\Arr;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 /**
  * Class VideoColorTransferStreamRule.
@@ -14,32 +15,22 @@ use Illuminate\Support\Arr;
 class VideoColorTransferStreamRule extends SubmissionRule
 {
     /**
-     * Determine if the validation rule passes.
+     * Run the validation rule.
      *
      * @param  string  $attribute
-     * @param  UploadedFile  $value
-     * @return bool
+     * @param  mixed  $value
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
+     * @return void
      */
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         $video = Arr::first(
             $this->streams(),
             fn (array $stream) => Arr::get($stream, 'codec_type') === 'video'
         );
 
-        return in_array(
-            Arr::get($video, 'color_transfer'),
-            ['bt709', 'smpte170m', 'bt470bg']
-        );
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string|array
-     */
-    public function message(): string|array
-    {
-        return __('validation.submission.video_color_transfer');
+        if (! in_array(Arr::get($video, 'color_transfer'), ['bt709', 'smpte170m', 'bt470bg'])) {
+            $fail(__('validation.submission.video_color_transfer'));
+        }
     }
 }

--- a/app/Rules/Wiki/Submission/Video/VideoIndexStreamRule.php
+++ b/app/Rules/Wiki/Submission/Video/VideoIndexStreamRule.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace App\Rules\Wiki\Submission\Video;
 
 use App\Rules\Wiki\Submission\SubmissionRule;
-use Illuminate\Http\UploadedFile;
+use Closure;
 use Illuminate\Support\Arr;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 /**
  * Class VideoIndexStreamRule.
@@ -14,29 +15,22 @@ use Illuminate\Support\Arr;
 class VideoIndexStreamRule extends SubmissionRule
 {
     /**
-     * Determine if the validation rule passes.
+     * Run the validation rule.
      *
      * @param  string  $attribute
-     * @param  UploadedFile  $value
-     * @return bool
+     * @param  mixed  $value
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
+     * @return void
      */
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         $stream = Arr::first(
             $this->streams(),
             fn (array $stream) => Arr::get($stream, 'codec_type') === 'video' && Arr::get($stream, 'index') === 0
         );
 
-        return $stream !== null;
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string|array
-     */
-    public function message(): string|array
-    {
-        return __('validation.submission.video_index');
+        if ($stream === null) {
+            $fail(__('validation.submission.video_index'));
+        }
     }
 }

--- a/app/Rules/Wiki/Submission/Video/VideoPixelFormatStreamRule.php
+++ b/app/Rules/Wiki/Submission/Video/VideoPixelFormatStreamRule.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace App\Rules\Wiki\Submission\Video;
 
 use App\Rules\Wiki\Submission\SubmissionRule;
-use Illuminate\Http\UploadedFile;
+use Closure;
 use Illuminate\Support\Arr;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 /**
  * Class VideoPixelFormatStreamRule.
@@ -14,29 +15,22 @@ use Illuminate\Support\Arr;
 class VideoPixelFormatStreamRule extends SubmissionRule
 {
     /**
-     * Determine if the validation rule passes.
+     * Run the validation rule.
      *
      * @param  string  $attribute
-     * @param  UploadedFile  $value
-     * @return bool
+     * @param  mixed  $value
+     * @param  Closure(string): PotentiallyTranslatedString  $fail
+     * @return void
      */
-    public function passes($attribute, $value): bool
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         $video = Arr::first(
             $this->streams(),
             fn (array $stream) => Arr::get($stream, 'codec_type') === 'video'
         );
 
-        return Arr::get($video, 'pix_fmt') === 'yuv420p';
-    }
-
-    /**
-     * Get the validation error message.
-     *
-     * @return string|array
-     */
-    public function message(): string|array
-    {
-        return __('validation.submission.video_pixel_format');
+        if (Arr::get($video, 'pix_fmt') !== 'yuv420p') {
+            $fail(__('validation.submission.video_pixel_format'));
+        }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1355,16 +1355,16 @@
         },
         {
             "name": "doctrine/dbal",
-            "version": "3.6.2",
+            "version": "3.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "b4bd1cfbd2b916951696d82e57d054394d84864c"
+                "reference": "9a747d29e7e6b39509b8f1847e37a23a0163ea6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/b4bd1cfbd2b916951696d82e57d054394d84864c",
-                "reference": "b4bd1cfbd2b916951696d82e57d054394d84864c",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/9a747d29e7e6b39509b8f1847e37a23a0163ea6a",
+                "reference": "9a747d29e7e6b39509b8f1847e37a23a0163ea6a",
                 "shasum": ""
             },
             "require": {
@@ -1377,12 +1377,12 @@
                 "psr/log": "^1|^2|^3"
             },
             "require-dev": {
-                "doctrine/coding-standard": "11.1.0",
+                "doctrine/coding-standard": "12.0.0",
                 "fig/log-test": "^1",
                 "jetbrains/phpstorm-stubs": "2022.3",
-                "phpstan/phpstan": "1.10.9",
+                "phpstan/phpstan": "1.10.14",
                 "phpstan/phpstan-strict-rules": "^1.5",
-                "phpunit/phpunit": "9.6.6",
+                "phpunit/phpunit": "9.6.7",
                 "psalm/plugin-phpunit": "0.18.4",
                 "squizlabs/php_codesniffer": "3.7.2",
                 "symfony/cache": "^5.4|^6.0",
@@ -1447,7 +1447,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/dbal/issues",
-                "source": "https://github.com/doctrine/dbal/tree/3.6.2"
+                "source": "https://github.com/doctrine/dbal/tree/3.6.3"
             },
             "funding": [
                 {
@@ -1463,29 +1463,33 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-14T07:25:38+00:00"
+            "time": "2023-06-01T05:46:46+00:00"
         },
         {
             "name": "doctrine/deprecations",
-            "version": "v1.1.0",
+            "version": "v1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "8cffffb2218e01f3b370bf763e00e81697725259"
+                "reference": "612a3ee5ab0d5dd97b7cf3874a6efe24325efac3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/8cffffb2218e01f3b370bf763e00e81697725259",
-                "reference": "8cffffb2218e01f3b370bf763e00e81697725259",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/612a3ee5ab0d5dd97b7cf3874a6efe24325efac3",
+                "reference": "612a3ee5ab0d5dd97b7cf3874a6efe24325efac3",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1|^8.0"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
                 "doctrine/coding-standard": "^9",
-                "phpunit/phpunit": "^7.5|^8.5|^9.5",
-                "psr/log": "^1|^2|^3"
+                "phpstan/phpstan": "1.4.10 || 1.10.15",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "psalm/plugin-phpunit": "0.18.4",
+                "psr/log": "^1 || ^2 || ^3",
+                "vimeo/psalm": "4.30.0 || 5.12.0"
             },
             "suggest": {
                 "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
@@ -1504,9 +1508,9 @@
             "homepage": "https://www.doctrine-project.org/",
             "support": {
                 "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/v1.1.0"
+                "source": "https://github.com/doctrine/deprecations/tree/v1.1.1"
             },
-            "time": "2023-05-29T18:55:17+00:00"
+            "time": "2023-06-03T09:27:29+00:00"
         },
         {
             "name": "doctrine/event-manager",
@@ -3065,16 +3069,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v10.13.0",
+            "version": "v10.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "7322723585103082758d74917db62980684845cb"
+                "reference": "c1569099594168870cb4bdabfbaa35e5d172310b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/7322723585103082758d74917db62980684845cb",
-                "reference": "7322723585103082758d74917db62980684845cb",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/c1569099594168870cb4bdabfbaa35e5d172310b",
+                "reference": "c1569099594168870cb4bdabfbaa35e5d172310b",
                 "shasum": ""
             },
             "require": {
@@ -3261,7 +3265,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2023-05-30T14:46:25+00:00"
+            "time": "2023-06-02T13:13:10+00:00"
         },
         {
             "name": "laravel/horizon",
@@ -3729,16 +3733,16 @@
         },
         {
             "name": "laravel/telescope",
-            "version": "v4.14.4",
+            "version": "v4.14.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/telescope.git",
-                "reference": "12cf59ce767e2984979a57c83891263be0e4c66a"
+                "reference": "9e30c9e1c7800814590d1418711101a190e0004b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/telescope/zipball/12cf59ce767e2984979a57c83891263be0e4c66a",
-                "reference": "12cf59ce767e2984979a57c83891263be0e4c66a",
+                "url": "https://api.github.com/repos/laravel/telescope/zipball/9e30c9e1c7800814590d1418711101a190e0004b",
+                "reference": "9e30c9e1c7800814590d1418711101a190e0004b",
                 "shasum": ""
             },
             "require": {
@@ -3794,9 +3798,9 @@
             ],
             "support": {
                 "issues": "https://github.com/laravel/telescope/issues",
-                "source": "https://github.com/laravel/telescope/tree/v4.14.4"
+                "source": "https://github.com/laravel/telescope/tree/v4.14.5"
             },
-            "time": "2023-05-29T15:04:52+00:00"
+            "time": "2023-06-02T17:38:04+00:00"
         },
         {
             "name": "laravel/tinker",
@@ -5422,16 +5426,16 @@
         },
         {
             "name": "propaganistas/laravel-disposable-email",
-            "version": "2.2.7",
+            "version": "2.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Propaganistas/Laravel-Disposable-Email.git",
-                "reference": "82e270cc8fa6fb7c800557dd1a030fa6eaadfc06"
+                "reference": "eb53ee1a8b261c7cfe2bf018a32e1b3cbf06da70"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Propaganistas/Laravel-Disposable-Email/zipball/82e270cc8fa6fb7c800557dd1a030fa6eaadfc06",
-                "reference": "82e270cc8fa6fb7c800557dd1a030fa6eaadfc06",
+                "url": "https://api.github.com/repos/Propaganistas/Laravel-Disposable-Email/zipball/eb53ee1a8b261c7cfe2bf018a32e1b3cbf06da70",
+                "reference": "eb53ee1a8b261c7cfe2bf018a32e1b3cbf06da70",
                 "shasum": ""
             },
             "require": {
@@ -5485,7 +5489,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Propaganistas/Laravel-Disposable-Email/issues",
-                "source": "https://github.com/Propaganistas/Laravel-Disposable-Email/tree/2.2.7"
+                "source": "https://github.com/Propaganistas/Laravel-Disposable-Email/tree/2.2.8"
             },
             "funding": [
                 {
@@ -5493,7 +5497,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-05-01T01:20:34+00:00"
+            "time": "2023-06-01T01:57:04+00:00"
         },
         {
             "name": "psr/cache",
@@ -10961,16 +10965,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.1.3",
+            "version": "10.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "2379ebafc1737e71cdc84f402acb6b7f04198b9d"
+                "reference": "599b33294350e8f51163119d5670512f98b0490d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/2379ebafc1737e71cdc84f402acb6b7f04198b9d",
-                "reference": "2379ebafc1737e71cdc84f402acb6b7f04198b9d",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/599b33294350e8f51163119d5670512f98b0490d",
+                "reference": "599b33294350e8f51163119d5670512f98b0490d",
                 "shasum": ""
             },
             "require": {
@@ -11010,7 +11014,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.1-dev"
+                    "dev-main": "10.2-dev"
                 }
             },
             "autoload": {
@@ -11042,7 +11046,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.1.3"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.2.1"
             },
             "funding": [
                 {
@@ -11058,7 +11062,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-11T05:16:22+00:00"
+            "time": "2023-06-05T05:15:51+00:00"
         },
         {
             "name": "predis/predis",

--- a/tests/Unit/Rules/Api/DistinctIgnoringDirectionTest.php
+++ b/tests/Unit/Rules/Api/DistinctIgnoringDirectionTest.php
@@ -8,6 +8,7 @@ use App\Enums\Http\Api\Sort\Direction;
 use App\Http\Api\Sort\Sort;
 use App\Rules\Api\DistinctIgnoringDirectionRule;
 use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Validator;
 use Tests\TestCase;
 
 /**
@@ -26,11 +27,16 @@ class DistinctIgnoringDirectionTest extends TestCase
     {
         $key = $this->faker->word();
 
-        $rule = new DistinctIgnoringDirectionRule();
-
         $sorts = collect()->pad($this->faker->numberBetween(2, 9), $key);
 
-        static::assertFalse($rule->passes($this->faker->word(), $sorts->join(',')));
+        $attribute = $this->faker->word();
+
+        $validator = Validator::make(
+            [$attribute => $sorts->join(',')],
+            [$attribute => new DistinctIgnoringDirectionRule()]
+        );
+
+        static::assertFalse($validator->passes());
     }
 
     /**
@@ -42,8 +48,6 @@ class DistinctIgnoringDirectionTest extends TestCase
     {
         $key = $this->faker->word();
 
-        $rule = new DistinctIgnoringDirectionRule();
-
         $sort = new Sort($key);
 
         $sorts = [];
@@ -52,7 +56,14 @@ class DistinctIgnoringDirectionTest extends TestCase
             $sorts[] = $sort->format($direction);
         }
 
-        static::assertFalse($rule->passes($this->faker->word(), implode(',', $sorts)));
+        $attribute = $this->faker->word();
+
+        $validator = Validator::make(
+            [$attribute => implode(',', $sorts)],
+            [$attribute => new DistinctIgnoringDirectionRule()]
+        );
+
+        static::assertFalse($validator->passes());
     }
 
     /**
@@ -62,10 +73,15 @@ class DistinctIgnoringDirectionTest extends TestCase
      */
     public function testPassesIfNoDuplicates(): void
     {
-        $rule = new DistinctIgnoringDirectionRule();
-
         $sorts = collect($this->faker->words($this->faker->randomDigitNotNull()))->unique();
 
-        static::assertTrue($rule->passes($this->faker->word(), $sorts->join(',')));
+        $attribute = $this->faker->word();
+
+        $validator = Validator::make(
+            [$attribute => $sorts->join(',')],
+            [$attribute => new DistinctIgnoringDirectionRule()]
+        );
+
+        static::assertTrue($validator->passes());
     }
 }

--- a/tests/Unit/Rules/Api/EnumDescriptionTest.php
+++ b/tests/Unit/Rules/Api/EnumDescriptionTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit\Rules\Api;
 use App\Enums\BaseEnum;
 use App\Rules\Api\EnumDescriptionRule;
 use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 use Tests\TestCase;
 
@@ -31,9 +32,14 @@ class EnumDescriptionTest extends TestCase
             public const TWO = 2;
         };
 
-        $rule = new EnumDescriptionRule(get_class($enum));
+        $attribute = $this->faker->word();
 
-        static::assertTrue($rule->passes($this->faker->word(), $enum->description));
+        $validator = Validator::make(
+            [$attribute => $enum->description],
+            [$attribute => new EnumDescriptionRule(get_class($enum))]
+        );
+
+        static::assertTrue($validator->passes());
     }
 
     /**
@@ -50,9 +56,14 @@ class EnumDescriptionTest extends TestCase
             public const TWO = 2;
         };
 
-        $rule = new EnumDescriptionRule(get_class($enum));
+        $attribute = $this->faker->word();
 
-        static::assertFalse($rule->passes($this->faker->word(), $enum->value));
+        $validator = Validator::make(
+            [$attribute => $enum->value],
+            [$attribute => new EnumDescriptionRule(get_class($enum))]
+        );
+
+        static::assertFalse($validator->passes());
     }
 
     /**
@@ -69,8 +80,13 @@ class EnumDescriptionTest extends TestCase
             public const TWO = 2;
         };
 
-        $rule = new EnumDescriptionRule(get_class($enum));
+        $attribute = $this->faker->word();
 
-        static::assertFalse($rule->passes($this->faker->word(), Str::random()));
+        $validator = Validator::make(
+            [$attribute => Str::random()],
+            [$attribute => new EnumDescriptionRule(get_class($enum))]
+        );
+
+        static::assertFalse($validator->passes());
     }
 }

--- a/tests/Unit/Rules/Api/IsValidBooleanTest.php
+++ b/tests/Unit/Rules/Api/IsValidBooleanTest.php
@@ -6,7 +6,7 @@ namespace Tests\Unit\Rules\Api;
 
 use App\Rules\Api\IsValidBoolean;
 use Illuminate\Foundation\Testing\WithFaker;
-use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Validator;
 use Tests\TestCase;
 
 /**
@@ -23,11 +23,14 @@ class IsValidBooleanTest extends TestCase
      */
     public function testPassesIfBoolean(): void
     {
-        $boolean = $this->faker->boolean();
+        $attribute = $this->faker->word();
 
-        $rule = new IsValidBoolean();
+        $validator = Validator::make(
+            [$attribute => $this->faker->boolean()],
+            [$attribute => new IsValidBoolean()]
+        );
 
-        static::assertTrue($rule->passes($this->faker->word(), $boolean));
+        static::assertTrue($validator->passes());
     }
 
     /**
@@ -39,9 +42,14 @@ class IsValidBooleanTest extends TestCase
     {
         $booleanString = $this->faker->boolean() ? 'true' : 'false';
 
-        $rule = new IsValidBoolean();
+        $attribute = $this->faker->word();
 
-        static::assertTrue($rule->passes($this->faker->word(), $booleanString));
+        $validator = Validator::make(
+            [$attribute => $booleanString],
+            [$attribute => new IsValidBoolean()]
+        );
+
+        static::assertTrue($validator->passes());
     }
 
     /**
@@ -53,9 +61,14 @@ class IsValidBooleanTest extends TestCase
     {
         $booleanInteger = $this->faker->boolean() ? 1 : 0;
 
-        $rule = new IsValidBoolean();
+        $attribute = $this->faker->word();
 
-        static::assertTrue($rule->passes($this->faker->word(), $booleanInteger));
+        $validator = Validator::make(
+            [$attribute => $booleanInteger],
+            [$attribute => new IsValidBoolean()]
+        );
+
+        static::assertTrue($validator->passes());
     }
 
     /**
@@ -67,9 +80,14 @@ class IsValidBooleanTest extends TestCase
     {
         $booleanCheckbox = $this->faker->boolean() ? 'on' : 'off';
 
-        $rule = new IsValidBoolean();
+        $attribute = $this->faker->word();
 
-        static::assertTrue($rule->passes($this->faker->word(), $booleanCheckbox));
+        $validator = Validator::make(
+            [$attribute => $booleanCheckbox],
+            [$attribute => new IsValidBoolean()]
+        );
+
+        static::assertTrue($validator->passes());
     }
 
     /**
@@ -79,9 +97,14 @@ class IsValidBooleanTest extends TestCase
      */
     public function testFailsIfString(): void
     {
-        $rule = new IsValidBoolean();
+        $attribute = $this->faker->word();
 
-        static::assertFalse($rule->passes($this->faker->word(), Str::random()));
+        $validator = Validator::make(
+            [$attribute => $this->faker->word()],
+            [$attribute => new IsValidBoolean()]
+        );
+
+        static::assertFalse($validator->passes());
     }
 
     /**
@@ -91,10 +114,13 @@ class IsValidBooleanTest extends TestCase
      */
     public function testFailsIfNumber(): void
     {
-        $number = $this->faker->numberBetween(2, 9);
+        $attribute = $this->faker->word();
 
-        $rule = new IsValidBoolean();
+        $validator = Validator::make(
+            [$attribute => $this->faker->numberBetween(2, 9)],
+            [$attribute => new IsValidBoolean()]
+        );
 
-        static::assertFalse($rule->passes($this->faker->word(), $number));
+        static::assertFalse($validator->passes());
     }
 }

--- a/tests/Unit/Rules/Api/RandomSoleTest.php
+++ b/tests/Unit/Rules/Api/RandomSoleTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit\Rules\Api;
 use App\Http\Api\Criteria\Sort\RandomCriteria;
 use App\Rules\Api\RandomSoleRule;
 use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Validator;
 use Tests\TestCase;
 
 /**
@@ -27,9 +28,14 @@ class RandomSoleTest extends TestCase
 
         $sorts[] = RandomCriteria::PARAM_VALUE;
 
-        $rule = new RandomSoleRule();
+        $attribute = $this->faker->word();
 
-        static::assertFalse($rule->passes($this->faker->word(), implode(',', $sorts)));
+        $validator = Validator::make(
+            [$attribute => implode(',', $sorts)],
+            [$attribute => new RandomSoleRule()]
+        );
+
+        static::assertFalse($validator->passes());
     }
 
     /**
@@ -41,9 +47,14 @@ class RandomSoleTest extends TestCase
     {
         $sorts = $this->faker->words($this->faker->randomDigitNotNull());
 
-        $rule = new RandomSoleRule();
+        $attribute = $this->faker->word();
 
-        static::assertTrue($rule->passes($this->faker->word(), implode(',', $sorts)));
+        $validator = Validator::make(
+            [$attribute => implode(',', $sorts)],
+            [$attribute => new RandomSoleRule()]
+        );
+
+        static::assertTrue($validator->passes());
     }
 
     /**
@@ -53,8 +64,13 @@ class RandomSoleTest extends TestCase
      */
     public function testPassesIfRandomIsSoleSort(): void
     {
-        $rule = new RandomSoleRule();
+        $attribute = $this->faker->word();
 
-        static::assertTrue($rule->passes($this->faker->word(), RandomCriteria::PARAM_VALUE));
+        $validator = Validator::make(
+            [$attribute => RandomCriteria::PARAM_VALUE],
+            [$attribute => new RandomSoleRule()]
+        );
+
+        static::assertTrue($validator->passes());
     }
 }

--- a/tests/Unit/Rules/Billing/TransparencyDateTest.php
+++ b/tests/Unit/Rules/Billing/TransparencyDateTest.php
@@ -9,6 +9,7 @@ use App\Rules\Billing\TransparencyDateRule;
 use DateTimeInterface;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\Validator;
 use Tests\TestCase;
 
 /**
@@ -27,9 +28,14 @@ class TransparencyDateTest extends TestCase
     {
         $validDates = collect([Date::now()]);
 
-        $rule = new TransparencyDateRule($validDates);
+        $attribute = $this->faker->word();
 
-        static::assertFalse($rule->passes($this->faker->word(), $this->faker->word()));
+        $validator = Validator::make(
+            [$attribute => $this->faker->word()],
+            [$attribute => new TransparencyDateRule($validDates)]
+        );
+
+        static::assertFalse($validator->passes());
     }
 
     /**
@@ -41,9 +47,14 @@ class TransparencyDateTest extends TestCase
     {
         $validDates = collect([Date::now()]);
 
-        $rule = new TransparencyDateRule($validDates);
+        $attribute = $this->faker->word();
 
-        static::assertFalse($rule->passes($this->faker->word(), $this->faker->numberBetween()));
+        $validator = Validator::make(
+            [$attribute => $this->faker->numberBetween()],
+            [$attribute => new TransparencyDateRule($validDates)]
+        );
+
+        static::assertFalse($validator->passes());
     }
 
     /**
@@ -55,11 +66,16 @@ class TransparencyDateTest extends TestCase
     {
         $validDates = collect([Date::now()]);
 
-        $rule = new TransparencyDateRule($validDates);
-
         $formattedDate = Date::now()->format(DateTimeInterface::RFC822);
 
-        static::assertFalse($rule->passes($this->faker->word(), $formattedDate));
+        $attribute = $this->faker->word();
+
+        $validator = Validator::make(
+            [$attribute => $formattedDate],
+            [$attribute => new TransparencyDateRule($validDates)]
+        );
+
+        static::assertFalse($validator->passes());
     }
 
     /**
@@ -71,11 +87,16 @@ class TransparencyDateTest extends TestCase
     {
         $validDates = collect([Date::now()]);
 
-        $rule = new TransparencyDateRule($validDates);
-
         $formattedDate = Date::now()->subMonths($this->faker->randomDigitNotNull())->format(AllowedDateFormat::YM);
 
-        static::assertFalse($rule->passes($this->faker->word(), $formattedDate));
+        $attribute = $this->faker->word();
+
+        $validator = Validator::make(
+            [$attribute => $formattedDate],
+            [$attribute => new TransparencyDateRule($validDates)]
+        );
+
+        static::assertFalse($validator->passes());
     }
 
     /**
@@ -87,10 +108,15 @@ class TransparencyDateTest extends TestCase
     {
         $validDates = collect([Date::now()]);
 
-        $rule = new TransparencyDateRule($validDates);
-
         $formattedDate = Date::now()->format(AllowedDateFormat::YM);
 
-        static::assertTrue($rule->passes($this->faker->word(), $formattedDate));
+        $attribute = $this->faker->word();
+
+        $validator = Validator::make(
+            [$attribute => $formattedDate],
+            [$attribute => new TransparencyDateRule($validDates)]
+        );
+
+        static::assertTrue($validator->passes());
     }
 }

--- a/tests/Unit/Rules/ModerationTest.php
+++ b/tests/Unit/Rules/ModerationTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Rules;
+
+use App\Constants\Config\ValidationConstants;
+use App\Enums\Rules\ModerationService;
+use App\Rules\ModerationRule;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Validator;
+use RuntimeException;
+use Tests\TestCase;
+
+/**
+ * Class ModerationTest.
+ */
+class ModerationTest extends TestCase
+{
+    use WithFaker;
+
+    /**
+     * The Moderation Rule shall fail if the moderation service is unknown.
+     *
+     * @return void
+     */
+    public function testFailsIfUnknownModerationService(): void
+    {
+        static::expectException(RuntimeException::class);
+
+        Config::set(ValidationConstants::MODERATION_SERVICE_QUALIFIED, $this->faker->word());
+
+        $attribute = $this->faker->word();
+
+        $validator = Validator::make(
+            [$attribute => $this->faker->word()],
+            [$attribute => new ModerationRule()],
+        );
+
+        $validator->passes();
+    }
+
+    /**
+     * The Moderation Rule shall fail if the value is flagged by OpenAI.
+     *
+     * @return void
+     */
+    public function testFailsIfFlaggedByOpenAI(): void
+    {
+        Config::set(ValidationConstants::MODERATION_SERVICE_QUALIFIED, ModerationService::OPENAI);
+
+        Http::fake([
+            'https://api.openai.com/v1/moderations' => Http::response([
+                'results' => [
+                    0 => [
+                        'flagged' => true,
+                    ],
+                ],
+            ]),
+        ]);
+
+        $attribute = $this->faker->word();
+
+        $validator = Validator::make(
+            [$attribute => $this->faker->word()],
+            [$attribute => new ModerationRule()],
+        );
+
+        static::assertFalse($validator->passes());
+    }
+
+    /**
+     * The Moderation Rule shall fail if the value is flagged by OpenAI.
+     *
+     * @return void
+     */
+    public function testPassesIfNotFlaggedByOpenAI(): void
+    {
+        Config::set(ValidationConstants::MODERATION_SERVICE_QUALIFIED, ModerationService::OPENAI);
+
+        Http::fake([
+            'https://api.openai.com/v1/moderations' => Http::response([
+                'results' => [
+                    0 => [
+                        'flagged' => false,
+                    ],
+                ],
+            ]),
+        ]);
+
+        $attribute = $this->faker->word();
+
+        $validator = Validator::make(
+            [$attribute => $this->faker->word()],
+            [$attribute => new ModerationRule()],
+        );
+
+        static::assertTrue($validator->passes());
+    }
+
+    /**
+     * The Moderation Rule shall fail if OpenAI returns some error.
+     *
+     * @return void
+     */
+    public function testPassesIfOpenAIFails(): void
+    {
+        Config::set(ValidationConstants::MODERATION_SERVICE_QUALIFIED, ModerationService::OPENAI);
+
+        Http::fake([
+            'https://api.openai.com/v1/moderations' => Http::response(status: 404),
+        ]);
+
+        $attribute = $this->faker->word();
+
+        $validator = Validator::make(
+            [$attribute => $this->faker->word()],
+            [$attribute => new ModerationRule()],
+        );
+
+        static::assertTrue($validator->passes());
+    }
+}

--- a/tests/Unit/Rules/Storage/StorageDirectoryExistsTest.php
+++ b/tests/Unit/Rules/Storage/StorageDirectoryExistsTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit\Rules\Storage;
 use App\Rules\Storage\StorageDirectoryExistsRule;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Validator;
 use Tests\TestCase;
 
 /**
@@ -29,9 +30,14 @@ class StorageDirectoryExistsTest extends TestCase
 
         $fs->makeDirectory($directory);
 
-        $rule = new StorageDirectoryExistsRule($fs);
+        $attribute = $this->faker->word();
 
-        static::assertTrue($rule->passes($this->faker->word(), $directory));
+        $validator = Validator::make(
+            [$attribute => $directory],
+            [$attribute => new StorageDirectoryExistsRule($fs)]
+        );
+
+        static::assertTrue($validator->passes());
     }
 
     /**
@@ -43,8 +49,13 @@ class StorageDirectoryExistsTest extends TestCase
     {
         $fs = Storage::fake($this->faker->word());
 
-        $rule = new StorageDirectoryExistsRule($fs);
+        $attribute = $this->faker->word();
 
-        static::assertFalse($rule->passes($this->faker->word(), $this->faker->word()));
+        $validator = Validator::make(
+            [$attribute => $this->faker->word()],
+            [$attribute => new StorageDirectoryExistsRule($fs)]
+        );
+
+        static::assertFalse($validator->passes());
     }
 }

--- a/tests/Unit/Rules/Storage/StorageFileDirectoryExistsTest.php
+++ b/tests/Unit/Rules/Storage/StorageFileDirectoryExistsTest.php
@@ -9,6 +9,7 @@ use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Http\Testing\File;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Validator;
 use Tests\TestCase;
 
 /**
@@ -32,9 +33,14 @@ class StorageFileDirectoryExistsTest extends TestCase
 
         $path = $fs->putFile($this->faker->word(), $file);
 
-        $rule = new StorageFileDirectoryExistsRule($fs);
+        $attribute = $this->faker->word();
 
-        static::assertTrue($rule->passes($this->faker->word(), $path));
+        $validator = Validator::make(
+            [$attribute => $path],
+            [$attribute => new StorageFileDirectoryExistsRule($fs)]
+        );
+
+        static::assertTrue($validator->passes());
     }
 
     /**
@@ -46,8 +52,13 @@ class StorageFileDirectoryExistsTest extends TestCase
     {
         $fs = Storage::fake($this->faker->word());
 
-        $rule = new StorageFileDirectoryExistsRule($fs);
+        $attribute = $this->faker->word();
 
-        static::assertFalse($rule->passes($this->faker->word(), $this->faker->filePath()));
+        $validator = Validator::make(
+            [$attribute => $this->faker->filePath()],
+            [$attribute => new StorageFileDirectoryExistsRule($fs)]
+        );
+
+        static::assertFalse($validator->passes());
     }
 }

--- a/tests/Unit/Rules/Wiki/Resource/AnimeResourceLinkFormatTest.php
+++ b/tests/Unit/Rules/Wiki/Resource/AnimeResourceLinkFormatTest.php
@@ -8,6 +8,7 @@ use App\Enums\Models\Wiki\ResourceSite;
 use App\Rules\Wiki\Resource\AnimeResourceLinkFormatRule;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 use Tests\TestCase;
 
@@ -25,9 +26,14 @@ class AnimeResourceLinkFormatTest extends TestCase
      */
     public function testPassesForNoPattern(): void
     {
-        $rule = new AnimeResourceLinkFormatRule(ResourceSite::OFFICIAL_SITE());
+        $attribute = $this->faker->word();
 
-        static::assertTrue($rule->passes($this->faker->word(), $this->faker->url()));
+        $validator = Validator::make(
+            [$attribute => $this->faker->url()],
+            [$attribute => new AnimeResourceLinkFormatRule(ResourceSite::OFFICIAL_SITE())],
+        );
+
+        static::assertTrue($validator->passes());
     }
 
     /**
@@ -50,9 +56,14 @@ class AnimeResourceLinkFormatTest extends TestCase
 
         $url = $site->formatAnimeResourceLink($this->faker->randomDigitNotNull(), $this->faker->word());
 
-        $rule = new AnimeResourceLinkFormatRule($site);
+        $attribute = $this->faker->word();
 
-        static::assertTrue($rule->passes($this->faker->word(), $url));
+        $validator = Validator::make(
+            [$attribute => $url],
+            [$attribute => new AnimeResourceLinkFormatRule($site)],
+        );
+
+        static::assertTrue($validator->passes());
     }
 
     /**
@@ -79,9 +90,14 @@ class AnimeResourceLinkFormatTest extends TestCase
             ->append('/')
             ->__toString();
 
-        $rule = new AnimeResourceLinkFormatRule($site);
+        $attribute = $this->faker->word();
 
-        static::assertFalse($rule->passes($this->faker->word(), $url));
+        $validator = Validator::make(
+            [$attribute => $url],
+            [$attribute => new AnimeResourceLinkFormatRule($site)],
+        );
+
+        static::assertFalse($validator->passes());
     }
 
     /**
@@ -104,9 +120,14 @@ class AnimeResourceLinkFormatTest extends TestCase
             ->append($this->faker->word())
             ->__toString();
 
-        $rule = new AnimeResourceLinkFormatRule($site);
+        $attribute = $this->faker->word();
 
-        static::assertFalse($rule->passes($this->faker->word(), $url));
+        $validator = Validator::make(
+            [$attribute => $url],
+            [$attribute => new AnimeResourceLinkFormatRule($site)],
+        );
+
+        static::assertFalse($validator->passes());
     }
 
     /**
@@ -127,9 +148,14 @@ class AnimeResourceLinkFormatTest extends TestCase
 
         $url = $site->formatArtistResourceLink($this->faker->randomDigitNotNull(), $this->faker->word());
 
-        $rule = new AnimeResourceLinkFormatRule($site);
+        $attribute = $this->faker->word();
 
-        static::assertFalse($rule->passes($this->faker->word(), $url));
+        $validator = Validator::make(
+            [$attribute => $url],
+            [$attribute => new AnimeResourceLinkFormatRule($site)],
+        );
+
+        static::assertFalse($validator->passes());
     }
 
     /**
@@ -150,8 +176,13 @@ class AnimeResourceLinkFormatTest extends TestCase
 
         $url = $site->formatStudioResourceLink($this->faker->randomDigitNotNull(), $this->faker->word());
 
-        $rule = new AnimeResourceLinkFormatRule($site);
+        $attribute = $this->faker->word();
 
-        static::assertFalse($rule->passes($this->faker->word(), $url));
+        $validator = Validator::make(
+            [$attribute => $url],
+            [$attribute => new AnimeResourceLinkFormatRule($site)],
+        );
+
+        static::assertFalse($validator->passes());
     }
 }

--- a/tests/Unit/Rules/Wiki/Resource/ArtistResourceLinkFormatTest.php
+++ b/tests/Unit/Rules/Wiki/Resource/ArtistResourceLinkFormatTest.php
@@ -8,6 +8,7 @@ use App\Enums\Models\Wiki\ResourceSite;
 use App\Rules\Wiki\Resource\ArtistResourceLinkFormatRule;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 use Tests\TestCase;
 
@@ -25,9 +26,14 @@ class ArtistResourceLinkFormatTest extends TestCase
      */
     public function testPassesForNoPattern(): void
     {
-        $rule = new ArtistResourceLinkFormatRule(ResourceSite::OFFICIAL_SITE());
+        $attribute = $this->faker->word();
 
-        static::assertTrue($rule->passes($this->faker->word(), $this->faker->url()));
+        $validator = Validator::make(
+            [$attribute => $this->faker->url()],
+            [$attribute => new ArtistResourceLinkFormatRule(ResourceSite::OFFICIAL_SITE())],
+        );
+
+        static::assertTrue($validator->passes());
     }
 
     /**
@@ -49,9 +55,14 @@ class ArtistResourceLinkFormatTest extends TestCase
 
         $url = $site->formatArtistResourceLink($this->faker->randomDigitNotNull(), $this->faker->word());
 
-        $rule = new ArtistResourceLinkFormatRule($site);
+        $attribute = $this->faker->word();
 
-        static::assertTrue($rule->passes($this->faker->word(), $url));
+        $validator = Validator::make(
+            [$attribute => $url],
+            [$attribute => new ArtistResourceLinkFormatRule($site)],
+        );
+
+        static::assertTrue($validator->passes());
     }
 
     /**
@@ -63,9 +74,14 @@ class ArtistResourceLinkFormatTest extends TestCase
     {
         $url = ResourceSite::KITSU()->formatAnimeResourceLink($this->faker->randomDigitNotNull(), $this->faker->word());
 
-        $rule = new ArtistResourceLinkFormatRule(ResourceSite::KITSU());
+        $attribute = $this->faker->word();
 
-        static::assertFalse($rule->passes($this->faker->word(), $url));
+        $validator = Validator::make(
+            [$attribute => $url],
+            [$attribute => new ArtistResourceLinkFormatRule(ResourceSite::KITSU())],
+        );
+
+        static::assertFalse($validator->passes());
     }
 
     /**
@@ -91,9 +107,14 @@ class ArtistResourceLinkFormatTest extends TestCase
             ->append('/')
             ->__toString();
 
-        $rule = new ArtistResourceLinkFormatRule($site);
+        $attribute = $this->faker->word();
 
-        static::assertFalse($rule->passes($this->faker->word(), $url));
+        $validator = Validator::make(
+            [$attribute => $url],
+            [$attribute => new ArtistResourceLinkFormatRule($site)],
+        );
+
+        static::assertFalse($validator->passes());
     }
 
     /**
@@ -116,9 +137,14 @@ class ArtistResourceLinkFormatTest extends TestCase
             ->append($this->faker->word())
             ->__toString();
 
-        $rule = new ArtistResourceLinkFormatRule($site);
+        $attribute = $this->faker->word();
 
-        static::assertFalse($rule->passes($this->faker->word(), $url));
+        $validator = Validator::make(
+            [$attribute => $url],
+            [$attribute => new ArtistResourceLinkFormatRule($site)],
+        );
+
+        static::assertFalse($validator->passes());
     }
 
     /**
@@ -139,9 +165,14 @@ class ArtistResourceLinkFormatTest extends TestCase
 
         $url = $site->formatAnimeResourceLink($this->faker->randomDigitNotNull(), $this->faker->word());
 
-        $rule = new ArtistResourceLinkFormatRule($site);
+        $attribute = $this->faker->word();
 
-        static::assertFalse($rule->passes($this->faker->word(), $url));
+        $validator = Validator::make(
+            [$attribute => $url],
+            [$attribute => new ArtistResourceLinkFormatRule($site)],
+        );
+
+        static::assertFalse($validator->passes());
     }
 
     /**
@@ -161,8 +192,13 @@ class ArtistResourceLinkFormatTest extends TestCase
 
         $url = $site->formatStudioResourceLink($this->faker->randomDigitNotNull(), $this->faker->word());
 
-        $rule = new ArtistResourceLinkFormatRule($site);
+        $attribute = $this->faker->word();
 
-        static::assertFalse($rule->passes($this->faker->word(), $url));
+        $validator = Validator::make(
+            [$attribute => $url],
+            [$attribute => new ArtistResourceLinkFormatRule($site)],
+        );
+
+        static::assertFalse($validator->passes());
     }
 }

--- a/tests/Unit/Rules/Wiki/Resource/ResourceLinkFormatTest.php
+++ b/tests/Unit/Rules/Wiki/Resource/ResourceLinkFormatTest.php
@@ -8,6 +8,7 @@ use App\Enums\Models\Wiki\ResourceSite;
 use App\Rules\Wiki\Resource\ResourceLinkFormatRule;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 use Tests\TestCase;
 
@@ -25,9 +26,14 @@ class ResourceLinkFormatTest extends TestCase
      */
     public function testPassesForNoSite(): void
     {
-        $rule = new ResourceLinkFormatRule();
+        $attribute = $this->faker->word();
 
-        static::assertTrue($rule->passes($this->faker->word(), $this->faker->url()));
+        $validator = Validator::make(
+            [$attribute => $this->faker->url()],
+            [$attribute => new ResourceLinkFormatRule()],
+        );
+
+        static::assertTrue($validator->passes());
     }
 
     /**
@@ -37,9 +43,14 @@ class ResourceLinkFormatTest extends TestCase
      */
     public function testPassesForNoPattern(): void
     {
-        $rule = new ResourceLinkFormatRule(ResourceSite::OFFICIAL_SITE());
+        $attribute = $this->faker->word();
 
-        static::assertTrue($rule->passes($this->faker->word(), $this->faker->url()));
+        $validator = Validator::make(
+            [$attribute => $this->faker->url()],
+            [$attribute => new ResourceLinkFormatRule(ResourceSite::OFFICIAL_SITE())],
+        );
+
+        static::assertTrue($validator->passes());
     }
 
     /**
@@ -62,9 +73,14 @@ class ResourceLinkFormatTest extends TestCase
 
         $url = $site->formatAnimeResourceLink($this->faker->randomDigitNotNull(), $this->faker->word());
 
-        $rule = new ResourceLinkFormatRule($site);
+        $attribute = $this->faker->word();
 
-        static::assertTrue($rule->passes($this->faker->word(), $url));
+        $validator = Validator::make(
+            [$attribute => $url],
+            [$attribute => new ResourceLinkFormatRule($site)],
+        );
+
+        static::assertTrue($validator->passes());
     }
 
     /**
@@ -86,9 +102,14 @@ class ResourceLinkFormatTest extends TestCase
 
         $url = $site->formatArtistResourceLink($this->faker->randomDigitNotNull(), $this->faker->word());
 
-        $rule = new ResourceLinkFormatRule($site);
+        $attribute = $this->faker->word();
 
-        static::assertTrue($rule->passes($this->faker->word(), $url));
+        $validator = Validator::make(
+            [$attribute => $url],
+            [$attribute => new ResourceLinkFormatRule($site)],
+        );
+
+        static::assertTrue($validator->passes());
     }
 
     /**
@@ -110,9 +131,14 @@ class ResourceLinkFormatTest extends TestCase
 
         $url = $site->formatStudioResourceLink($this->faker->randomDigitNotNull(), $this->faker->word());
 
-        $rule = new ResourceLinkFormatRule($site);
+        $attribute = $this->faker->word();
 
-        static::assertTrue($rule->passes($this->faker->word(), $url));
+        $validator = Validator::make(
+            [$attribute => $url],
+            [$attribute => new ResourceLinkFormatRule($site)],
+        );
+
+        static::assertTrue($validator->passes());
     }
 
     /**
@@ -138,8 +164,13 @@ class ResourceLinkFormatTest extends TestCase
             ->append('/')
             ->__toString();
 
-        $rule = new ResourceLinkFormatRule($site);
+        $attribute = $this->faker->word();
 
-        static::assertFalse($rule->passes($this->faker->word(), $url));
+        $validator = Validator::make(
+            [$attribute => $url],
+            [$attribute => new ResourceLinkFormatRule($site)],
+        );
+
+        static::assertFalse($validator->passes());
     }
 }

--- a/tests/Unit/Rules/Wiki/Resource/ResourceSiteMatchesLinkTest.php
+++ b/tests/Unit/Rules/Wiki/Resource/ResourceSiteMatchesLinkTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit\Rules\Wiki\Resource;
 use App\Enums\Models\Wiki\ResourceSite;
 use App\Rules\Wiki\Resource\ResourceSiteMatchesLinkRule;
 use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Validator;
 use Tests\TestCase;
 
 /**
@@ -38,9 +39,14 @@ class ResourceSiteMatchesLinkTest extends TestCase
             $url = 'https://'.$domain;
         }
 
-        $rule = new ResourceSiteMatchesLinkRule($url);
+        $attribute = $this->faker->word();
 
-        static::assertTrue($rule->passes($this->faker->word(), $site->value));
+        $validator = Validator::make(
+            [$attribute => $site->value],
+            [$attribute => new ResourceSiteMatchesLinkRule($url)],
+        );
+
+        static::assertTrue($validator->passes());
     }
 
     /**
@@ -50,9 +56,14 @@ class ResourceSiteMatchesLinkTest extends TestCase
      */
     public function testResourceSiteDomainRuleOfficialPasses(): void
     {
-        $rule = new ResourceSiteMatchesLinkRule($this->faker->url());
+        $attribute = $this->faker->word();
 
-        static::assertTrue($rule->passes($this->faker->word(), ResourceSite::OFFICIAL_SITE));
+        $validator = Validator::make(
+            [$attribute => ResourceSite::OFFICIAL_SITE],
+            [$attribute => new ResourceSiteMatchesLinkRule($this->faker->url())],
+        );
+
+        static::assertTrue($validator->passes());
     }
 
     /**
@@ -71,8 +82,13 @@ class ResourceSiteMatchesLinkTest extends TestCase
             }
         }
 
-        $rule = new ResourceSiteMatchesLinkRule($this->faker->url());
+        $attribute = $this->faker->word();
 
-        static::assertFalse($rule->passes($this->faker->word(), $site->value));
+        $validator = Validator::make(
+            [$attribute => $site->value],
+            [$attribute => new ResourceSiteMatchesLinkRule($this->faker->url())],
+        );
+
+        static::assertFalse($validator->passes());
     }
 }

--- a/tests/Unit/Rules/Wiki/Resource/StudioResourceLinkFormatTest.php
+++ b/tests/Unit/Rules/Wiki/Resource/StudioResourceLinkFormatTest.php
@@ -8,6 +8,7 @@ use App\Enums\Models\Wiki\ResourceSite;
 use App\Rules\Wiki\Resource\StudioResourceLinkFormatRule;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 use Tests\TestCase;
 
@@ -25,9 +26,14 @@ class StudioResourceLinkFormatTest extends TestCase
      */
     public function testPassesForNoPattern(): void
     {
-        $rule = new StudioResourceLinkFormatRule(ResourceSite::OFFICIAL_SITE());
+        $attribute = $this->faker->word();
 
-        static::assertTrue($rule->passes($this->faker->word(), $this->faker->url()));
+        $validator = Validator::make(
+            [$attribute => $this->faker->url()],
+            [$attribute => new StudioResourceLinkFormatRule(ResourceSite::OFFICIAL_SITE())],
+        );
+
+        static::assertTrue($validator->passes());
     }
 
     /**
@@ -49,9 +55,14 @@ class StudioResourceLinkFormatTest extends TestCase
 
         $url = $site->formatStudioResourceLink($this->faker->randomDigitNotNull(), $this->faker->word());
 
-        $rule = new StudioResourceLinkFormatRule($site);
+        $attribute = $this->faker->word();
 
-        static::assertTrue($rule->passes($this->faker->word(), $url));
+        $validator = Validator::make(
+            [$attribute => $url],
+            [$attribute => new StudioResourceLinkFormatRule($site)],
+        );
+
+        static::assertTrue($validator->passes());
     }
 
     /**
@@ -63,9 +74,14 @@ class StudioResourceLinkFormatTest extends TestCase
     {
         $url = ResourceSite::KITSU()->formatAnimeResourceLink($this->faker->randomDigitNotNull(), $this->faker->word());
 
-        $rule = new StudioResourceLinkFormatRule(ResourceSite::KITSU());
+        $attribute = $this->faker->word();
 
-        static::assertFalse($rule->passes($this->faker->word(), $url));
+        $validator = Validator::make(
+            [$attribute => $url],
+            [$attribute => new StudioResourceLinkFormatRule(ResourceSite::KITSU())],
+        );
+
+        static::assertFalse($validator->passes());
     }
 
     /**
@@ -91,9 +107,14 @@ class StudioResourceLinkFormatTest extends TestCase
             ->append('/')
             ->__toString();
 
-        $rule = new StudioResourceLinkFormatRule($site);
+        $attribute = $this->faker->word();
 
-        static::assertFalse($rule->passes($this->faker->word(), $url));
+        $validator = Validator::make(
+            [$attribute => $url],
+            [$attribute => new StudioResourceLinkFormatRule($site)],
+        );
+
+        static::assertFalse($validator->passes());
     }
 
     /**
@@ -116,9 +137,14 @@ class StudioResourceLinkFormatTest extends TestCase
             ->append($this->faker->word())
             ->__toString();
 
-        $rule = new StudioResourceLinkFormatRule($site);
+        $attribute = $this->faker->word();
 
-        static::assertFalse($rule->passes($this->faker->word(), $url));
+        $validator = Validator::make(
+            [$attribute => $url],
+            [$attribute => new StudioResourceLinkFormatRule($site)],
+        );
+
+        static::assertFalse($validator->passes());
     }
 
     /**
@@ -139,9 +165,14 @@ class StudioResourceLinkFormatTest extends TestCase
 
         $url = $site->formatAnimeResourceLink($this->faker->randomDigitNotNull(), $this->faker->word());
 
-        $rule = new StudioResourceLinkFormatRule($site);
+        $attribute = $this->faker->word();
 
-        static::assertFalse($rule->passes($this->faker->word(), $url));
+        $validator = Validator::make(
+            [$attribute => $url],
+            [$attribute => new StudioResourceLinkFormatRule($site)],
+        );
+
+        static::assertFalse($validator->passes());
     }
 
     /**
@@ -161,8 +192,13 @@ class StudioResourceLinkFormatTest extends TestCase
 
         $url = $site->formatArtistResourceLink($this->faker->randomDigitNotNull(), $this->faker->word());
 
-        $rule = new StudioResourceLinkFormatRule($site);
+        $attribute = $this->faker->word();
 
-        static::assertFalse($rule->passes($this->faker->word(), $url));
+        $validator = Validator::make(
+            [$attribute => $url],
+            [$attribute => new StudioResourceLinkFormatRule($site)],
+        );
+
+        static::assertFalse($validator->passes());
     }
 }

--- a/tests/Unit/Rules/Wiki/Submission/SubmissionTest.php
+++ b/tests/Unit/Rules/Wiki/Submission/SubmissionTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Rules\Wiki\Submission;
+
+use App\Constants\FeatureConstants;
+use App\Rules\Wiki\Submission\Audio\AudioChannelLayoutStreamRule;
+use App\Rules\Wiki\Submission\Audio\AudioChannelsStreamRule;
+use App\Rules\Wiki\Submission\Audio\AudioCodecStreamRule;
+use App\Rules\Wiki\Submission\Audio\AudioIndexStreamRule;
+use App\Rules\Wiki\Submission\Audio\AudioLoudnessIntegratedTargetStreamRule;
+use App\Rules\Wiki\Submission\Audio\AudioLoudnessTruePeakStreamRule;
+use App\Rules\Wiki\Submission\Audio\AudioSampleRateStreamRule;
+use App\Rules\Wiki\Submission\Format\EncoderNameFormatRule;
+use App\Rules\Wiki\Submission\Format\EncoderVersionFormatRule;
+use App\Rules\Wiki\Submission\Format\ExtraneousChaptersFormatRule;
+use App\Rules\Wiki\Submission\Format\ExtraneousMetadataFormatRule;
+use App\Rules\Wiki\Submission\Format\FormatNameFormatRule;
+use App\Rules\Wiki\Submission\Format\TotalStreamsFormatRule;
+use App\Rules\Wiki\Submission\Format\VideoBitrateRestrictionFormatRule;
+use App\Rules\Wiki\Submission\SubmissionRule;
+use App\Rules\Wiki\Submission\Video\VideoCodecStreamRule;
+use App\Rules\Wiki\Submission\Video\VideoColorPrimariesStreamRule;
+use App\Rules\Wiki\Submission\Video\VideoColorSpaceStreamRule;
+use App\Rules\Wiki\Submission\Video\VideoColorTransferStreamRule;
+use App\Rules\Wiki\Submission\Video\VideoIndexStreamRule;
+use App\Rules\Wiki\Submission\Video\VideoPixelFormatStreamRule;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Process;
+use Illuminate\Support\Facades\Validator;
+use Laravel\Pennant\Feature;
+use Tests\TestCase;
+
+/**
+ * Class SubmissionTest.
+ */
+class SubmissionTest extends TestCase
+{
+    use WithFaker;
+
+    /**
+     * The Submission Rules shall execute FFmpeg processes once.
+     *
+     * @return void
+     */
+    public function testRunsProcessesOnce(): void
+    {
+        Feature::activate(FeatureConstants::REQUIRED_ENCODER_VERSION, 'Lavf59.27.100');
+
+        $height = $this->faker->numberBetween(360, 1080);
+        $bitrate = $height * 3550 + 475000;
+
+        $file = UploadedFile::fake()->create($this->faker->word().'.webm', $this->faker->randomDigitNotNull());
+
+        Process::fake([
+            SubmissionRule::formatLoudnessCommand($file) => Process::result(errorOutput: json_encode([
+                'input_i' => $this->faker->numberBetween(-17, -14),
+                'input_tp' => $this->faker->randomFloat(min: -20, max: 0.1),
+                'input_lra' => $this->faker->randomFloat(),
+                'input_thresh' => $this->faker->randomFloat(),
+                'output_i' => $this->faker->randomFloat(),
+                'output_tp' => $this->faker->randomFloat(),
+                'output_lra' => $this->faker->randomFloat(),
+                'output_thresh' => $this->faker->randomFloat(),
+                'normalization_type' => 'dynamic',
+                'target_offset' => $this->faker->randomFloat(),
+            ])),
+            SubmissionRule::formatFfprobeCommand($file) => Process::result(json_encode([
+                'chapters' => [],
+                'format' => [
+                    'bit_rate' => $bitrate,
+                    'format_name' => 'matroska,webm',
+                    'tags' => [
+                        'ENCODER' => 'Lavf59.27.100',
+                        'DURATION' => '00:01:30.098000000',
+                    ]
+                ],
+                'streams' => [
+                    0 => [
+                        'codec_name' => 'vp9',
+                        'codec_type' => 'video',
+                        'color_primaries' => Arr::random(['bt709', 'smpte170m', 'bt470bg']),
+                        'color_space' => Arr::random(['bt709', 'smpte170m', 'bt470bg']),
+                        'color_transfer' => Arr::random(['bt709', 'smpte170m', 'bt470bg']),
+                        'height' => $height,
+                        'index' => 0,
+                        'pix_fmt' => 'yuv420p',
+                    ],
+                    1 => [
+                        'channel_layout' => 'stereo',
+                        'channels' => 2,
+                        'codec_name' => 'opus',
+                        'codec_type' => 'audio',
+                        'index' => 1,
+                        'sample_rate' => '48000',
+                    ],
+                ],
+            ])),
+        ]);
+
+        $validator = Validator::make(
+            ['file' => $file],
+            [
+                'file' => [
+                    new TotalStreamsFormatRule(2),
+                    new EncoderNameFormatRule(),
+                    new EncoderVersionFormatRule(),
+                    new FormatNameFormatRule('matroska,webm'),
+                    new VideoBitrateRestrictionFormatRule(),
+                    new ExtraneousMetadataFormatRule(),
+                    new ExtraneousChaptersFormatRule(),
+                    new AudioIndexStreamRule(1),
+                    new AudioCodecStreamRule(),
+                    new AudioSampleRateStreamRule(),
+                    new AudioChannelsStreamRule(),
+                    new AudioChannelLayoutStreamRule(),
+                    new AudioLoudnessTruePeakStreamRule(),
+                    new AudioLoudnessIntegratedTargetStreamRule(),
+                    new VideoIndexStreamRule(),
+                    new VideoCodecStreamRule(),
+                    new VideoPixelFormatStreamRule(),
+                    new VideoColorSpaceStreamRule(),
+                    new VideoColorTransferStreamRule(),
+                    new VideoColorPrimariesStreamRule(),
+                ],
+            ],
+        );
+
+        static::assertTrue($validator->passes());
+
+        Process::assertRanTimes(SubmissionRule::formatFfprobeCommand($file));
+        Process::assertRanTimes(SubmissionRule::formatLoudnessCommand($file));
+    }
+}

--- a/tests/Unit/Rules/Wiki/Submission/SubmissionTest.php
+++ b/tests/Unit/Rules/Wiki/Submission/SubmissionTest.php
@@ -76,7 +76,7 @@ class SubmissionTest extends TestCase
                     'tags' => [
                         'ENCODER' => 'Lavf59.27.100',
                         'DURATION' => '00:01:30.098000000',
-                    ]
+                    ],
                 ],
                 'streams' => [
                     0 => [


### PR DESCRIPTION
* Update validation rules to use new interface for default invokable-pattern and avoid deprecation of older design
* Adds missing coverage for some validation rules
* Bump dependencies