### PR TITLE
fix(api): address queue lockout for store playlist track action

### DIFF
--- a/app/Actions/Http/Api/List/Playlist/Track/StoreTrackAction.php
+++ b/app/Actions/Http/Api/List/Playlist/Track/StoreTrackAction.php
@@ -35,8 +35,6 @@ class StoreTrackAction
      */
     public function store(Playlist $playlist, Builder $builder, array $parameters): Model
     {
-        Log::info('StoreTrackAction start');
-
         $trackParameters = $parameters;
 
         $previousHashid = Arr::pull($trackParameters, PlaylistTrack::RELATION_PREVIOUS);
@@ -49,12 +47,8 @@ class StoreTrackAction
 
             $storeAction = new StoreAction();
 
-            Log::info('StoreTrackAction StoreAction start');
-
             /** @var PlaylistTrack $track */
             $track = $storeAction->store($builder, $trackParameters);
-
-            Log::info('StoreTrackAction StoreAction end');
 
             if (! empty($nextHashid) && empty($previousHashid)) {
                 /** @var PlaylistTrack $next */
@@ -85,21 +79,13 @@ class StoreTrackAction
             if (empty($nextHashid) && empty($previousHashid)) {
                 $insertAction = new InsertTrackAction();
 
-                Log::info('StoreTrackAction InsertTrackAction start');
-
                 $insertAction->insert($playlist, $track);
-
-                Log::info('StoreTrackAction InsertTrackAction end');
             }
 
             DB::commit();
 
-            Log::info('StoreTrackAction transaction committed');
-
             return $storeAction->cleanup($track);
         } catch (Exception $e) {
-            Log::error('StoreTrackAction exception caught');
-
             Log::error($e->getMessage());
 
             DB::rollBack();

--- a/app/Jobs/Middleware/RateLimited.php
+++ b/app/Jobs/Middleware/RateLimited.php
@@ -30,7 +30,7 @@ class RateLimited
             Redis::throttle('key')
                 ->block(0)
                 ->allow(1)
-                ->every(15)
+                ->every(3)
                 ->then(
                     function () use ($job, $next) {
                         // Lock obtained...

--- a/app/Listeners/SendDiscordNotification.php
+++ b/app/Listeners/SendDiscordNotification.php
@@ -7,17 +7,13 @@ namespace App\Listeners;
 use App\Constants\FeatureConstants;
 use App\Contracts\Events\DiscordMessageEvent;
 use App\Jobs\SendDiscordNotificationJob;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Queue\InteractsWithQueue;
 use Laravel\Pennant\Feature;
 
 /**
  * Class SendDiscordNotification.
  */
-class SendDiscordNotification implements ShouldQueue
+class SendDiscordNotification
 {
-    use InteractsWithQueue;
-
     /**
      * Handle the event.
      *
@@ -26,19 +22,10 @@ class SendDiscordNotification implements ShouldQueue
      */
     public function handle(DiscordMessageEvent $event): void
     {
-        if (Feature::active(FeatureConstants::ALLOW_DISCORD_NOTIFICATIONS)) {
-            SendDiscordNotificationJob::dispatch($event);
+        if (Feature::active(FeatureConstants::ALLOW_DISCORD_NOTIFICATIONS) && $event->shouldSendDiscordMessage()) {
+            SendDiscordNotificationJob::dispatch($event)
+                ->onQueue('discord')
+                ->afterCommit();
         }
-    }
-
-    /**
-     * Determine whether the listener should be queued.
-     *
-     * @param  DiscordMessageEvent  $event
-     * @return bool
-     */
-    public function shouldQueue(DiscordMessageEvent $event): bool
-    {
-        return $event->shouldSendDiscordMessage();
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -10009,16 +10009,16 @@
         },
         {
             "name": "nunomaduro/larastan",
-            "version": "v2.6.1",
+            "version": "v2.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/larastan.git",
-                "reference": "7823bc1fdbd8e72fd1e9cd8d746e7e104bccf02c"
+                "reference": "fd1b5c2560ccf4a2a0075a30524b63ebb142cd6c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/larastan/zipball/7823bc1fdbd8e72fd1e9cd8d746e7e104bccf02c",
-                "reference": "7823bc1fdbd8e72fd1e9cd8d746e7e104bccf02c",
+                "url": "https://api.github.com/repos/nunomaduro/larastan/zipball/fd1b5c2560ccf4a2a0075a30524b63ebb142cd6c",
+                "reference": "fd1b5c2560ccf4a2a0075a30524b63ebb142cd6c",
                 "shasum": ""
             },
             "require": {
@@ -10081,7 +10081,7 @@
             ],
             "support": {
                 "issues": "https://github.com/nunomaduro/larastan/issues",
-                "source": "https://github.com/nunomaduro/larastan/tree/v2.6.1"
+                "source": "https://github.com/nunomaduro/larastan/tree/v2.6.2"
             },
             "funding": [
                 {
@@ -10101,7 +10101,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2023-06-04T20:55:57+00:00"
+            "time": "2023-06-10T17:23:14+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -10685,16 +10685,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.2.1",
+            "version": "10.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "599b33294350e8f51163119d5670512f98b0490d"
+                "reference": "1ab521b24b88b88310c40c26c0cc4a94ba40ff95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/599b33294350e8f51163119d5670512f98b0490d",
-                "reference": "599b33294350e8f51163119d5670512f98b0490d",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/1ab521b24b88b88310c40c26c0cc4a94ba40ff95",
+                "reference": "1ab521b24b88b88310c40c26c0cc4a94ba40ff95",
                 "shasum": ""
             },
             "require": {
@@ -10766,7 +10766,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.2.1"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.2.2"
             },
             "funding": [
                 {
@@ -10782,7 +10782,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-06-05T05:15:51+00:00"
+            "time": "2023-06-11T06:15:20+00:00"
         },
         {
             "name": "predis/predis",

--- a/config/queue.php
+++ b/config/queue.php
@@ -41,7 +41,7 @@ return [
             'table' => 'jobs',
             'queue' => 'default',
             'retry_after' => 90,
-            'after_commit' => true,
+            'after_commit' => false,
         ],
 
         'beanstalkd' => [
@@ -50,7 +50,7 @@ return [
             'queue' => 'default',
             'retry_after' => 90,
             'block_for' => 0,
-            'after_commit' => true,
+            'after_commit' => false,
         ],
 
         'sqs' => [
@@ -61,7 +61,7 @@ return [
             'queue' => env('SQS_QUEUE', 'default'),
             'suffix' => env('SQS_SUFFIX'),
             'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
-            'after_commit' => true,
+            'after_commit' => false,
         ],
 
         'redis' => [
@@ -70,7 +70,7 @@ return [
             'queue' => env('REDIS_QUEUE', 'default'),
             'retry_after' => 90,
             'block_for' => null,
-            'after_commit' => true,
+            'after_commit' => false,
         ],
 
     ],


### PR DESCRIPTION
* Discord Message event listener should be handled synchronously and queue a job without blocking the hashids listener.
* Remove debug logging from store playlist track action.
* Bump dependencies.