### PR TITLE
feat(filament): added subnames

### DIFF
--- a/app/Contracts/Models/SubNameable.php
+++ b/app/Contracts/Models/SubNameable.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Contracts\Models;
+
+/**
+ * Interface SubNameable.
+ */
+interface SubNameable
+{
+    /**
+     * Get subname.
+     *
+     * @return string
+     */
+    public function getSubName(): string;
+}

--- a/app/Filament/Actions/Models/Wiki/Video/BackfillAudioAction.php
+++ b/app/Filament/Actions/Models/Wiki/Video/BackfillAudioAction.php
@@ -91,14 +91,14 @@ class BackfillAudioAction extends Action implements ShouldQueue
                     ->label(__('filament.actions.video.backfill.fields.derive_source.name'))
                     ->options(DeriveSourceVideo::asSelectArray())
                     ->rules(['required', new Enum(DeriveSourceVideo::class)])
-                    ->default(DeriveSourceVideo::YES)
+                    ->default(DeriveSourceVideo::YES->value)
                     ->helperText(__('filament.actions.video.backfill.fields.derive_source.help')),
 
                 Select::make(self::OVERWRITE_AUDIO)
                     ->label(__('filament.actions.video.backfill.fields.overwrite.name'))
                     ->options(OverwriteAudio::asSelectArray())
                     ->rules(['required', new Enum(OverwriteAudio::class)])
-                    ->default(OverwriteAudio::NO)
+                    ->default(OverwriteAudio::NO->value)
                     ->helperText(__('filament.actions.video.backfill.fields.overwrite.help')),
             ]);
     }

--- a/app/Filament/Components/Filters/NumberFilter.php
+++ b/app/Filament/Components/Filters/NumberFilter.php
@@ -78,11 +78,11 @@ class NumberFilter extends Filter
         return $query
             ->when(
                 Arr::get($data, $this->attribute.'_'.'from'),
-                fn (Builder $query, $date): Builder => $query->where($this->attribute, ComparisonOperator::GTE->value, $date),
+                fn (Builder $query, $value): Builder => $query->where($this->attribute, ComparisonOperator::GTE->value, $value),
             )
             ->when(
                 Arr::get($data, $this->attribute.'_'.'to'),
-                fn (Builder $query, $date): Builder => $query->where($this->attribute, ComparisonOperator::LTE->value, $date),
+                fn (Builder $query, $value): Builder => $query->where($this->attribute, ComparisonOperator::LTE->value, $value),
             );
     }
 }

--- a/app/Filament/Components/Infolist/TextEntry.php
+++ b/app/Filament/Components/Infolist/TextEntry.php
@@ -17,7 +17,7 @@ class TextEntry extends ComponentsTextEntry
     /**
      * Used for entry relationships.
      *
-     * @param  class-string<BaseResource>  $resourceRelated
+     * @param  class-string<BaseResource>|string  $resourceRelated
      * @param  string  $relation
      * @return static
      */

--- a/app/Filament/HeaderActions/Models/Wiki/Video/BackfillAudioHeaderAction.php
+++ b/app/Filament/HeaderActions/Models/Wiki/Video/BackfillAudioHeaderAction.php
@@ -8,7 +8,6 @@ use App\Actions\Models\Wiki\Video\Audio\BackfillAudioAction as BackfillAudio;
 use App\Enums\Actions\Models\Wiki\Video\DeriveSourceVideo;
 use App\Enums\Actions\Models\Wiki\Video\OverwriteAudio;
 use App\Filament\Components\Fields\Select;
-use App\Models\BaseModel;
 use App\Models\Wiki\Video;
 use Exception;
 use Filament\Forms\Form;
@@ -92,14 +91,14 @@ class BackfillAudioHeaderAction extends Action implements ShouldQueue
                     ->label(__('filament.actions.video.backfill.fields.derive_source.name'))
                     ->options(DeriveSourceVideo::asSelectArray())
                     ->rules(['required', new Enum(DeriveSourceVideo::class)])
-                    ->default(DeriveSourceVideo::YES)
+                    ->default(DeriveSourceVideo::YES->value)
                     ->helperText(__('filament.actions.video.backfill.fields.derive_source.help')),
 
                 Select::make(self::OVERWRITE_AUDIO)
                     ->label(__('filament.actions.video.backfill.fields.overwrite.name'))
                     ->options(OverwriteAudio::asSelectArray())
                     ->rules(['required', new Enum(OverwriteAudio::class)])
-                    ->default(OverwriteAudio::NO)
+                    ->default(OverwriteAudio::NO->value)
                     ->helperText(__('filament.actions.video.backfill.fields.overwrite.help')),
             ]);
     }

--- a/app/Filament/Resources/Admin/Announcement.php
+++ b/app/Filament/Resources/Admin/Announcement.php
@@ -147,6 +147,7 @@ class Announcement extends BaseResource
             ])
             ->defaultSort(AnnouncementModel::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());
     }

--- a/app/Filament/Resources/Admin/Dump.php
+++ b/app/Filament/Resources/Admin/Dump.php
@@ -153,6 +153,7 @@ class Dump extends BaseResource
             ])
             ->defaultSort(DumpModel::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions())
             ->headerActions(static::getHeaderActions());

--- a/app/Filament/Resources/Admin/Feature.php
+++ b/app/Filament/Resources/Admin/Feature.php
@@ -160,6 +160,7 @@ class Feature extends BaseResource
             ])
             ->defaultSort(FeatureModel::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());
     }

--- a/app/Filament/Resources/Admin/FeaturedTheme.php
+++ b/app/Filament/Resources/Admin/FeaturedTheme.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Filament\Resources\Admin;
 
 use App\Enums\Http\Api\Filter\AllowedDateFormat;
+use App\Enums\Http\Api\Filter\ComparisonOperator;
 use App\Filament\Components\Columns\TextColumn;
 use App\Filament\Components\Fields\Select;
 use App\Filament\Components\Infolist\TextEntry;
@@ -202,7 +203,15 @@ class FeaturedTheme extends BaseResource
                 Select::make(FeaturedThemeModel::ATTRIBUTE_USER)
                     ->label(__('filament.resources.singularLabel.user'))
                     ->relationship(FeaturedThemeModel::RELATION_USER, User::ATTRIBUTE_NAME)
-                    ->searchable(),
+                    ->allowHtml()
+                    ->searchable()
+                    ->getSearchResultsUsing(function (string $search) {
+                        return User::query()
+                            ->where(User::ATTRIBUTE_NAME, ComparisonOperator::LIKE->value, "%$search%")
+                            ->get()
+                            ->mapWithKeys(fn (User $model) => [$model->getKey() => Select::getSearchLabelWithBlade($model)])
+                            ->toArray();
+                    }),
             ])
             ->columns(1);
     }

--- a/app/Filament/Resources/Admin/FeaturedTheme.php
+++ b/app/Filament/Resources/Admin/FeaturedTheme.php
@@ -256,6 +256,7 @@ class FeaturedTheme extends BaseResource
             ])
             ->defaultSort(FeaturedThemeModel::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());
     }

--- a/app/Filament/Resources/Admin/FeaturedTheme.php
+++ b/app/Filament/Resources/Admin/FeaturedTheme.php
@@ -245,7 +245,7 @@ class FeaturedTheme extends BaseResource
                     ->label(__('filament.resources.singularLabel.anime_theme_entry'))
                     ->toggleable()
                     ->placeholder('-')
-                    ->formatStateUsing(fn (string $state) => EntryModel::find(intval($state))->load(EntryModel::RELATION_ANIME)->getName())
+                    ->formatStateUsing(fn (string $state) => EntryModel::find(intval($state))->load(EntryModel::RELATION_ANIME_SHALLOW)->getName())
                     ->urlToRelated(EntryResource::class, FeaturedThemeModel::RELATION_ENTRY),
 
                 TextColumn::make(FeaturedThemeModel::RELATION_USER.'.'.User::ATTRIBUTE_NAME)

--- a/app/Filament/Resources/Auth/Permission.php
+++ b/app/Filament/Resources/Auth/Permission.php
@@ -154,6 +154,7 @@ class Permission extends BaseResource
             ])
             ->defaultSort(PermissionModel::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());
     }

--- a/app/Filament/Resources/Auth/Permission/RelationManagers/RolePermissionRelationManager.php
+++ b/app/Filament/Resources/Auth/Permission/RelationManagers/RolePermissionRelationManager.php
@@ -55,6 +55,7 @@ class RolePermissionRelationManager extends BaseRelationManager
             ->columns(RoleResource::table($table)->getColumns())
             ->defaultSort(Role::TABLE.'.'.Role::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Auth/Permission/RelationManagers/UserPermissionRelationManager.php
+++ b/app/Filament/Resources/Auth/Permission/RelationManagers/UserPermissionRelationManager.php
@@ -55,6 +55,7 @@ class UserPermissionRelationManager extends BaseRelationManager
             ->columns(UserResource::table($table)->getColumns())
             ->defaultSort(User::TABLE.'.'.User::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Auth/Role.php
+++ b/app/Filament/Resources/Auth/Role.php
@@ -196,6 +196,7 @@ class Role extends BaseResource
             ])
             ->defaultSort(RoleModel::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());
     }

--- a/app/Filament/Resources/Auth/Role/RelationManagers/PermissionRoleRelationManager.php
+++ b/app/Filament/Resources/Auth/Role/RelationManagers/PermissionRoleRelationManager.php
@@ -56,6 +56,7 @@ class PermissionRoleRelationManager extends BaseRelationManager
             ->columns(PermissionResource::table($table)->getColumns())
             ->defaultSort(Permission::TABLE.'.'.Permission::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Auth/Role/RelationManagers/UserRoleRelationManager.php
+++ b/app/Filament/Resources/Auth/Role/RelationManagers/UserRoleRelationManager.php
@@ -56,6 +56,7 @@ class UserRoleRelationManager extends BaseRelationManager
             ->columns(UserResource::table($table)->getColumns())
             ->defaultSort(User::TABLE.'.'.User::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Auth/User.php
+++ b/app/Filament/Resources/Auth/User.php
@@ -176,6 +176,7 @@ class User extends BaseResource
             ])
             ->defaultSort(UserModel::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());
     }

--- a/app/Filament/Resources/Auth/User/RelationManagers/PermissionUserRelationManager.php
+++ b/app/Filament/Resources/Auth/User/RelationManagers/PermissionUserRelationManager.php
@@ -56,6 +56,7 @@ class PermissionUserRelationManager extends BaseRelationManager
             ->columns(PermissionResource::table($table)->getColumns())
             ->defaultSort(Permission::TABLE.'.'.Permission::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Auth/User/RelationManagers/PlaylistUserRelationManager.php
+++ b/app/Filament/Resources/Auth/User/RelationManagers/PlaylistUserRelationManager.php
@@ -54,6 +54,7 @@ class PlaylistUserRelationManager extends BaseRelationManager
             ->columns(PlaylistResource::table($table)->getColumns())
             ->defaultSort(Playlist::TABLE.'.'.Playlist::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Auth/User/RelationManagers/RoleUserRelationManager.php
+++ b/app/Filament/Resources/Auth/User/RelationManagers/RoleUserRelationManager.php
@@ -56,6 +56,7 @@ class RoleUserRelationManager extends BaseRelationManager
             ->columns(RoleResource::table($table)->getColumns())
             ->defaultSort(Role::TABLE.'.'.Role::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/BaseRelationManager.php
+++ b/app/Filament/Resources/BaseRelationManager.php
@@ -18,6 +18,7 @@ use Filament\Tables\Actions\RestoreBulkAction;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Filters\TrashedFilter;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 /**
  * Class BaseRelationManager.
@@ -114,6 +115,7 @@ abstract class BaseRelationManager extends RelationManager
             CreateAction::make(),
 
             AttachAction::make()
+                ->hidden(fn (BaseRelationManager $livewire) => !($livewire->getRelationship() instanceof BelongsToMany))
                 ->recordSelect(function (BaseRelationManager $livewire) {
                     /** @var string */
                     $model = $livewire->getTable()->getModel();

--- a/app/Filament/Resources/BaseRelationManager.php
+++ b/app/Filament/Resources/BaseRelationManager.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources;
 
+use App\Filament\Components\Fields\Select;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables\Actions\AttachAction;
 use Filament\Tables\Actions\BulkActionGroup;
@@ -111,7 +112,16 @@ abstract class BaseRelationManager extends RelationManager
     {
         return [
             CreateAction::make(),
-            AttachAction::make(),
+
+            AttachAction::make()
+                ->recordSelect(function (BaseRelationManager $livewire) {
+                    /** @var string */
+                    $model = $livewire->getTable()->getModel();
+                    $title = $livewire->getTable()->getRecordTitle(new $model);
+                    return Select::make($title)
+                        ->label($title)
+                        ->useScout($model);
+                }),
         ];
     }
 }

--- a/app/Filament/Resources/Document/Page.php
+++ b/app/Filament/Resources/Document/Page.php
@@ -183,6 +183,7 @@ class Page extends BaseResource
             ])
             ->defaultSort(PageModel::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());
     }

--- a/app/Filament/Resources/List/Playlist.php
+++ b/app/Filament/Resources/List/Playlist.php
@@ -219,6 +219,7 @@ class Playlist extends BaseResource
             ->searchable()
             ->defaultSort(PlaylistModel::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());
     }

--- a/app/Filament/Resources/List/Playlist/RelationManagers/ImagePlaylistRelationManager.php
+++ b/app/Filament/Resources/List/Playlist/RelationManagers/ImagePlaylistRelationManager.php
@@ -54,6 +54,7 @@ class ImagePlaylistRelationManager extends BaseRelationManager
             ->columns(ImageResource::table($table)->getColumns())
             ->defaultSort(Image::TABLE.'.'.Image::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/List/Playlist/RelationManagers/TrackPlaylistRelationManager.php
+++ b/app/Filament/Resources/List/Playlist/RelationManagers/TrackPlaylistRelationManager.php
@@ -54,6 +54,7 @@ class TrackPlaylistRelationManager extends BaseRelationManager
             ->columns(TrackResource::table($table)->getColumns())
             ->defaultSort(PlaylistTrack::TABLE.'.'.PlaylistTrack::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/List/Playlist/Track.php
+++ b/app/Filament/Resources/List/Playlist/Track.php
@@ -185,6 +185,7 @@ class Track extends BaseResource
             ])
             ->defaultSort(TrackModel::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());
     }

--- a/app/Filament/Resources/List/Playlist/Track.php
+++ b/app/Filament/Resources/List/Playlist/Track.php
@@ -207,16 +207,24 @@ class Track extends BaseResource
                             ->label(__('filament.resources.singularLabel.playlist'))
                             ->urlToRelated(PlaylistResource::class, TrackModel::RELATION_PLAYLIST),
 
-                        TextEntry::make(TrackModel::RELATION_VIDEO.'.'.VideoModel::ATTRIBUTE_FILENAME)
-                            ->label(__('filament.resources.singularLabel.video'))
-                            ->urlToRelated(VideoResource::class, TrackModel::RELATION_VIDEO),
-
                         TextEntry::make(TrackModel::ATTRIBUTE_HASHID)
                             ->label(__('filament.fields.playlist_track.hashid.name'))
                             ->placeholder('-'),
 
                         TextEntry::make(TrackModel::ATTRIBUTE_ID)
                             ->label(__('filament.fields.base.id')),
+
+                        TextEntry::make(TrackModel::RELATION_VIDEO.'.'.VideoModel::ATTRIBUTE_FILENAME)
+                            ->label(__('filament.resources.singularLabel.video'))
+                            ->urlToRelated(VideoResource::class, TrackModel::RELATION_VIDEO),
+
+                        TextEntry::make(TrackModel::RELATION_PREVIOUS.'.'.TrackModel::RELATION_VIDEO.'.'.VideoModel::ATTRIBUTE_FILENAME)
+                            ->label(__('filament.fields.playlist_track.previous.name'))
+                            ->urlToRelated(Track::class, TrackModel::RELATION_PREVIOUS),
+        
+                        TextEntry::make(TrackModel::RELATION_NEXT.'.'.TrackModel::RELATION_VIDEO.'.'.VideoModel::ATTRIBUTE_FILENAME)
+                            ->label(__('filament.fields.playlist_track.next.name'))
+                            ->urlToRelated(Track::class, TrackModel::RELATION_NEXT),
                     ])
                     ->columns(3),
 

--- a/app/Filament/Resources/Wiki/Anime.php
+++ b/app/Filament/Resources/Wiki/Anime.php
@@ -280,6 +280,7 @@ class Anime extends BaseResource
             ->searchable()
             ->defaultSort(AnimeModel::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());
     }

--- a/app/Filament/Resources/Wiki/Anime/RelationManagers/ImageAnimeRelationManager.php
+++ b/app/Filament/Resources/Wiki/Anime/RelationManagers/ImageAnimeRelationManager.php
@@ -54,6 +54,7 @@ class ImageAnimeRelationManager extends BaseRelationManager
             ->columns(ImageResource::table($table)->getColumns())
             ->defaultSort(Image::TABLE.'.'.Image::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Wiki/Anime/RelationManagers/ResourceAnimeRelationManager.php
+++ b/app/Filament/Resources/Wiki/Anime/RelationManagers/ResourceAnimeRelationManager.php
@@ -54,6 +54,7 @@ class ResourceAnimeRelationManager extends BaseRelationManager
             ->columns(ExternalResourceResource::table($table)->getColumns())
             ->defaultSort(ExternalResource::TABLE.'.'.ExternalResource::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Wiki/Anime/RelationManagers/SeriesAnimeRelationManager.php
+++ b/app/Filament/Resources/Wiki/Anime/RelationManagers/SeriesAnimeRelationManager.php
@@ -54,6 +54,7 @@ class SeriesAnimeRelationManager extends BaseRelationManager
             ->columns(SeriesResource::table($table)->getColumns())
             ->defaultSort(Series::TABLE.'.'.Series::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Wiki/Anime/RelationManagers/StudioAnimeRelationManager.php
+++ b/app/Filament/Resources/Wiki/Anime/RelationManagers/StudioAnimeRelationManager.php
@@ -54,6 +54,7 @@ class StudioAnimeRelationManager extends BaseRelationManager
             ->columns(StudioResource::table($table)->getColumns())
             ->defaultSort(Studio::TABLE.'.'.Studio::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Wiki/Anime/RelationManagers/SynonymAnimeRelationManager.php
+++ b/app/Filament/Resources/Wiki/Anime/RelationManagers/SynonymAnimeRelationManager.php
@@ -54,6 +54,7 @@ class SynonymAnimeRelationManager extends BaseRelationManager
             ->columns(Synonym::table($table)->getColumns())
             ->defaultSort(SynonymModel::TABLE.'.'.SynonymModel::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Wiki/Anime/RelationManagers/ThemeAnimeRelationManager.php
+++ b/app/Filament/Resources/Wiki/Anime/RelationManagers/ThemeAnimeRelationManager.php
@@ -54,6 +54,7 @@ class ThemeAnimeRelationManager extends BaseRelationManager
             ->columns(Theme::table($table)->getColumns())
             ->defaultSort(ThemeModel::TABLE.'.'.ThemeModel::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Wiki/Anime/Synonym.php
+++ b/app/Filament/Resources/Wiki/Anime/Synonym.php
@@ -178,6 +178,7 @@ class Synonym extends BaseResource
             ->searchable()
             ->defaultSort(SynonymModel::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());
     }

--- a/app/Filament/Resources/Wiki/Anime/Theme.php
+++ b/app/Filament/Resources/Wiki/Anime/Theme.php
@@ -253,6 +253,7 @@ class Theme extends BaseResource
             ->searchable()
             ->defaultSort(ThemeModel::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());
     }

--- a/app/Filament/Resources/Wiki/Anime/Theme/Entry.php
+++ b/app/Filament/Resources/Wiki/Anime/Theme/Entry.php
@@ -270,6 +270,7 @@ class Entry extends BaseResource
             ->searchable()
             ->defaultSort(EntryModel::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());
     }

--- a/app/Filament/Resources/Wiki/Anime/Theme/Entry.php
+++ b/app/Filament/Resources/Wiki/Anime/Theme/Entry.php
@@ -32,6 +32,7 @@ use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Filters\Filter;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Log;
 
 /**
  * Class Entry.
@@ -153,7 +154,7 @@ class Entry extends BaseResource
     {
         return $form
             ->schema([
-                Select::make(EntryModel::RELATION_ANIME.'.'.AnimeModel::ATTRIBUTE_NAME)
+                Select::make(EntryModel::RELATION_ANIME.'.'.AnimeModel::ATTRIBUTE_ID)
                     ->label(__('filament.resources.singularLabel.anime'))
                     ->relationship(EntryModel::RELATION_ANIME_SHALLOW, AnimeModel::ATTRIBUTE_NAME)
                     ->searchable()
@@ -166,11 +167,7 @@ class Entry extends BaseResource
                         }
                         return $state;
                     })
-                    ->saveRelationshipsUsing(function (Model $record, $state) {
-                        if ($record instanceof EntryModel) {
-                            $record->animetheme->anime()->associate($state)->save();
-                        }
-                    }),
+                    ->saveRelationshipsUsing(fn (EntryModel $record, $state) => $record->anime()->associate(intval($state))->save()),
 
                 Select::make(EntryModel::ATTRIBUTE_THEME)
                     ->label(__('filament.resources.singularLabel.anime_theme'))
@@ -181,7 +178,9 @@ class Entry extends BaseResource
                         if ($livewire instanceof BaseRelationManager) {
                             /** @var EntryModel */
                             $entry = $livewire->getOwnerRecord();
-                            return $entry->animetheme->slug;
+                            /** @var ThemeModel|null */
+                            $theme = $entry->animetheme;
+                            return $theme === null ? $state : $theme->slug;
                         }
                         return $state;
                     }),

--- a/app/Filament/Resources/Wiki/Anime/Theme/Entry.php
+++ b/app/Filament/Resources/Wiki/Anime/Theme/Entry.php
@@ -167,7 +167,7 @@ class Entry extends BaseResource
                         }
                         return $state;
                     })
-                    ->saveRelationshipsUsing(fn (EntryModel $record, $state) => $record->anime()->associate(intval($state))->save()),
+                    ->saveRelationshipsUsing(fn (EntryModel $record, $state) => $record->animetheme->anime()->associate(intval($state))->save()),
 
                 Select::make(EntryModel::ATTRIBUTE_THEME)
                     ->label(__('filament.resources.singularLabel.anime_theme'))

--- a/app/Filament/Resources/Wiki/Anime/Theme/Entry/RelationManagers/VideoEntryRelationManager.php
+++ b/app/Filament/Resources/Wiki/Anime/Theme/Entry/RelationManagers/VideoEntryRelationManager.php
@@ -54,6 +54,7 @@ class VideoEntryRelationManager extends BaseRelationManager
             ->columns(VideoResource::table($table)->getColumns())
             ->defaultSort(Video::TABLE.'.'.Video::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Wiki/Anime/Theme/RelationManagers/EntryThemeRelationManager.php
+++ b/app/Filament/Resources/Wiki/Anime/Theme/RelationManagers/EntryThemeRelationManager.php
@@ -54,6 +54,7 @@ class EntryThemeRelationManager extends BaseRelationManager
             ->columns(EntryResource::table($table)->getColumns())
             ->defaultSort(AnimeThemeEntry::TABLE.'.'.AnimeThemeEntry::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Wiki/Artist.php
+++ b/app/Filament/Resources/Wiki/Artist.php
@@ -215,6 +215,7 @@ class Artist extends BaseResource
             ->searchable()
             ->defaultSort(ArtistModel::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());
     }

--- a/app/Filament/Resources/Wiki/Artist/RelationManagers/GroupArtistRelationManager.php
+++ b/app/Filament/Resources/Wiki/Artist/RelationManagers/GroupArtistRelationManager.php
@@ -53,6 +53,7 @@ class GroupArtistRelationManager extends BaseRelationManager
             ->columns(ArtistResource::table($table)->getColumns())
             ->defaultSort(Artist::TABLE.'.'.Artist::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Wiki/Artist/RelationManagers/ImageArtistRelationManager.php
+++ b/app/Filament/Resources/Wiki/Artist/RelationManagers/ImageArtistRelationManager.php
@@ -54,6 +54,7 @@ class ImageArtistRelationManager extends BaseRelationManager
             ->columns(ImageResource::table($table)->getColumns())
             ->defaultSort(Image::TABLE.'.'.Image::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Wiki/Artist/RelationManagers/MemberArtistRelationManager.php
+++ b/app/Filament/Resources/Wiki/Artist/RelationManagers/MemberArtistRelationManager.php
@@ -53,6 +53,7 @@ class MemberArtistRelationManager extends BaseRelationManager
             ->columns(ArtistResource::table($table)->getColumns())
             ->defaultSort(Artist::TABLE.'.'.Artist::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Wiki/Artist/RelationManagers/ResourceArtistRelationManager.php
+++ b/app/Filament/Resources/Wiki/Artist/RelationManagers/ResourceArtistRelationManager.php
@@ -54,6 +54,7 @@ class ResourceArtistRelationManager extends BaseRelationManager
             ->columns(ExternalResourceResource::table($table)->getColumns())
             ->defaultSort(ExternalResource::TABLE.'.'.ExternalResource::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Wiki/Artist/RelationManagers/SongArtistRelationManager.php
+++ b/app/Filament/Resources/Wiki/Artist/RelationManagers/SongArtistRelationManager.php
@@ -54,6 +54,7 @@ class SongArtistRelationManager extends BaseRelationManager
             ->columns(SongResource::table($table)->getColumns())
             ->defaultSort(Song::TABLE.'.'.Song::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Wiki/Audio.php
+++ b/app/Filament/Resources/Wiki/Audio.php
@@ -8,7 +8,6 @@ use App\Filament\Actions\Models\Wiki\Audio\AttachAudioToRelatedVideosAction;
 use App\Filament\Actions\Storage\Wiki\Audio\DeleteAudioAction;
 use App\Filament\Actions\Storage\Wiki\Audio\MoveAudioAction;
 use App\Filament\Components\Columns\TextColumn;
-use App\Filament\Components\Filters\NumberFilter;
 use App\Filament\Components\Filters\TextFilter;
 use App\Filament\Components\Infolist\TextEntry;
 use App\Filament\Resources\BaseResource;
@@ -173,6 +172,7 @@ class Audio extends BaseResource
             ])
             ->defaultSort(AudioModel::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions())
             ->headerActions(static::getHeaderActions());
@@ -242,10 +242,6 @@ class Audio extends BaseResource
     {
         return array_merge(
             [
-                NumberFilter::make(AudioModel::ATTRIBUTE_SIZE)
-                    ->labels(__('filament.filters.audio.size_from'), __('filament.filters.audio.size_to'))
-                    ->attribute(AudioModel::ATTRIBUTE_SIZE),
-
                 TextFilter::make(AudioModel::ATTRIBUTE_MIMETYPE)
                     ->label(__('filament.fields.audio.mimetype.name'))
                     ->attribute(AudioModel::ATTRIBUTE_MIMETYPE),

--- a/app/Filament/Resources/Wiki/Audio.php
+++ b/app/Filament/Resources/Wiki/Audio.php
@@ -10,6 +10,7 @@ use App\Filament\Actions\Storage\Wiki\Audio\MoveAudioAction;
 use App\Filament\Components\Columns\TextColumn;
 use App\Filament\Components\Filters\NumberFilter;
 use App\Filament\Components\Filters\TextFilter;
+use App\Filament\Components\Infolist\TextEntry;
 use App\Filament\Resources\BaseResource;
 use App\Filament\Resources\Wiki\Audio\Pages\CreateAudio;
 use App\Filament\Resources\Wiki\Audio\Pages\EditAudio;
@@ -23,7 +24,6 @@ use App\Models\Wiki\Video;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
 use Filament\Infolists\Components\Section;
-use Filament\Infolists\Components\TextEntry;
 use Filament\Infolists\Infolist;
 use Filament\Resources\RelationManagers\RelationGroup;
 use Filament\Support\Enums\MaxWidth;
@@ -206,7 +206,8 @@ class Audio extends BaseResource
 
                         TextEntry::make(AudioModel::ATTRIBUTE_MIMETYPE)
                             ->label(__('filament.fields.audio.mimetype.name')),
-                    ]),
+                    ])
+                    ->columns(3),
 
                 Section::make(__('filament.fields.base.timestamps'))
                     ->schema(parent::timestamps())

--- a/app/Filament/Resources/Wiki/Audio.php
+++ b/app/Filament/Resources/Wiki/Audio.php
@@ -8,6 +8,7 @@ use App\Filament\Actions\Models\Wiki\Audio\AttachAudioToRelatedVideosAction;
 use App\Filament\Actions\Storage\Wiki\Audio\DeleteAudioAction;
 use App\Filament\Actions\Storage\Wiki\Audio\MoveAudioAction;
 use App\Filament\Components\Columns\TextColumn;
+use App\Filament\Components\Filters\NumberFilter;
 use App\Filament\Components\Filters\TextFilter;
 use App\Filament\Components\Infolist\TextEntry;
 use App\Filament\Resources\BaseResource;
@@ -242,9 +243,9 @@ class Audio extends BaseResource
     {
         return array_merge(
             [
-                TextFilter::make(AudioModel::ATTRIBUTE_MIMETYPE)
-                    ->label(__('filament.fields.audio.mimetype.name'))
-                    ->attribute(AudioModel::ATTRIBUTE_MIMETYPE),
+                NumberFilter::make(AudioModel::ATTRIBUTE_SIZE)
+                    ->labels(__('filament.filters.audio.size_from'), __('filament.filters.audio.size_to'))
+                    ->attribute(AudioModel::ATTRIBUTE_SIZE),
             ],
             parent::getFilters(),
         );

--- a/app/Filament/Resources/Wiki/Audio/RelationManagers/VideoAudioRelationManager.php
+++ b/app/Filament/Resources/Wiki/Audio/RelationManagers/VideoAudioRelationManager.php
@@ -55,6 +55,7 @@ class VideoAudioRelationManager extends BaseRelationManager
             ->columns(VideoResource::table($table)->getColumns())
             ->defaultSort(Video::TABLE.'.'.Video::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Wiki/ExternalResource.php
+++ b/app/Filament/Resources/Wiki/ExternalResource.php
@@ -201,6 +201,7 @@ class ExternalResource extends BaseResource
             ])
             ->defaultSort(ExternalResourceModel::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());
     }

--- a/app/Filament/Resources/Wiki/ExternalResource/RelationManagers/AnimeResourceRelationManager.php
+++ b/app/Filament/Resources/Wiki/ExternalResource/RelationManagers/AnimeResourceRelationManager.php
@@ -54,6 +54,7 @@ class AnimeResourceRelationManager extends BaseRelationManager
             ->columns(AnimeResource::table($table)->getColumns())
             ->defaultSort(Anime::TABLE.'.'.Anime::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Wiki/ExternalResource/RelationManagers/ArtistResourceRelationManager.php
+++ b/app/Filament/Resources/Wiki/ExternalResource/RelationManagers/ArtistResourceRelationManager.php
@@ -54,6 +54,7 @@ class ArtistResourceRelationManager extends BaseRelationManager
             ->columns(ArtistResource::table($table)->getColumns())
             ->defaultSort(Artist::TABLE.'.'.Artist::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Wiki/ExternalResource/RelationManagers/SongResourceRelationManager.php
+++ b/app/Filament/Resources/Wiki/ExternalResource/RelationManagers/SongResourceRelationManager.php
@@ -54,6 +54,7 @@ class SongResourceRelationManager extends BaseRelationManager
             ->columns(SongResource::table($table)->getColumns())
             ->defaultSort(Song::TABLE.'.'.Song::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Wiki/ExternalResource/RelationManagers/StudioResourceRelationManager.php
+++ b/app/Filament/Resources/Wiki/ExternalResource/RelationManagers/StudioResourceRelationManager.php
@@ -54,6 +54,7 @@ class StudioResourceRelationManager extends BaseRelationManager
             ->columns(StudioResource::table($table)->getColumns())
             ->defaultSort(Studio::TABLE.'.'.Studio::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Wiki/Group.php
+++ b/app/Filament/Resources/Wiki/Group.php
@@ -176,6 +176,7 @@ class Group extends BaseResource
             ])
             ->defaultSort(GroupModel::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());
     }

--- a/app/Filament/Resources/Wiki/Group/RelationManagers/ThemeGroupRelationManager.php
+++ b/app/Filament/Resources/Wiki/Group/RelationManagers/ThemeGroupRelationManager.php
@@ -54,6 +54,7 @@ class ThemeGroupRelationManager extends BaseRelationManager
             ->columns(ThemeResource::table($table)->getColumns())
             ->defaultSort(ThemeModel::TABLE.'.'.ThemeModel::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Wiki/Image.php
+++ b/app/Filament/Resources/Wiki/Image.php
@@ -166,6 +166,7 @@ class Image extends BaseResource
             ])
             ->defaultSort(ImageModel::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions())
             ->headerActions(static::getHeaderActions());

--- a/app/Filament/Resources/Wiki/Image/RelationManagers/AnimeImageRelationManager.php
+++ b/app/Filament/Resources/Wiki/Image/RelationManagers/AnimeImageRelationManager.php
@@ -54,6 +54,7 @@ class AnimeImageRelationManager extends BaseRelationManager
             ->columns(AnimeResource::table($table)->getColumns())
             ->defaultSort(Anime::TABLE.'.'.Anime::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Wiki/Image/RelationManagers/ArtistImageRelationManager.php
+++ b/app/Filament/Resources/Wiki/Image/RelationManagers/ArtistImageRelationManager.php
@@ -54,6 +54,7 @@ class ArtistImageRelationManager extends BaseRelationManager
             ->columns(ArtistResource::table($table)->getColumns())
             ->defaultSort(Artist::TABLE.'.'.Artist::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Wiki/Image/RelationManagers/PlaylistImageRelationManager.php
+++ b/app/Filament/Resources/Wiki/Image/RelationManagers/PlaylistImageRelationManager.php
@@ -54,6 +54,7 @@ class PlaylistImageRelationManager extends BaseRelationManager
             ->columns(PlaylistResource::table($table)->getColumns())
             ->defaultSort(Playlist::TABLE.'.'.Playlist::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Wiki/Image/RelationManagers/StudioImageRelationManager.php
+++ b/app/Filament/Resources/Wiki/Image/RelationManagers/StudioImageRelationManager.php
@@ -54,6 +54,7 @@ class StudioImageRelationManager extends BaseRelationManager
             ->columns(StudioResource::table($table)->getColumns())
             ->defaultSort(Studio::TABLE.'.'.Studio::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Wiki/Series.php
+++ b/app/Filament/Resources/Wiki/Series.php
@@ -192,6 +192,7 @@ class Series extends BaseResource
             ->searchable()
             ->defaultSort(SeriesModel::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());
     }

--- a/app/Filament/Resources/Wiki/Series/RelationManagers/AnimeSeriesRelationManager.php
+++ b/app/Filament/Resources/Wiki/Series/RelationManagers/AnimeSeriesRelationManager.php
@@ -54,6 +54,7 @@ class AnimeSeriesRelationManager extends BaseRelationManager
             ->columns(AnimeResource::table($table)->getColumns())
             ->defaultSort(Anime::TABLE.'.'.Anime::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Wiki/Song.php
+++ b/app/Filament/Resources/Wiki/Song.php
@@ -193,6 +193,7 @@ class Song extends BaseResource
             ->searchable()
             ->defaultSort(SongModel::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());
     }

--- a/app/Filament/Resources/Wiki/Song/RelationManagers/ArtistSongRelationManager.php
+++ b/app/Filament/Resources/Wiki/Song/RelationManagers/ArtistSongRelationManager.php
@@ -54,6 +54,7 @@ class ArtistSongRelationManager extends BaseRelationManager
             ->columns(ArtistResource::table($table)->getColumns())
             ->defaultSort(Artist::TABLE.'.'.Artist::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Wiki/Song/RelationManagers/ResourceSongRelationManager.php
+++ b/app/Filament/Resources/Wiki/Song/RelationManagers/ResourceSongRelationManager.php
@@ -54,6 +54,7 @@ class ResourceSongRelationManager extends BaseRelationManager
             ->columns(ExternalResourceResource::table($table)->getColumns())
             ->defaultSort(ExternalResource::TABLE.'.'.ExternalResource::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Wiki/Song/RelationManagers/ThemeSongRelationManager.php
+++ b/app/Filament/Resources/Wiki/Song/RelationManagers/ThemeSongRelationManager.php
@@ -54,6 +54,7 @@ class ThemeSongRelationManager extends BaseRelationManager
             ->columns(ThemeResource::table($table)->getColumns())
             ->defaultSort(ThemeModel::TABLE.'.'.ThemeModel::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Wiki/Studio.php
+++ b/app/Filament/Resources/Wiki/Studio.php
@@ -188,6 +188,7 @@ class Studio extends BaseResource
             ->searchable()
             ->defaultSort(StudioModel::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());
     }

--- a/app/Filament/Resources/Wiki/Studio/RelationManagers/AnimeStudioRelationManager.php
+++ b/app/Filament/Resources/Wiki/Studio/RelationManagers/AnimeStudioRelationManager.php
@@ -54,6 +54,7 @@ class AnimeStudioRelationManager extends BaseRelationManager
             ->columns(AnimeResource::table($table)->getColumns())
             ->defaultSort(Anime::TABLE.'.'.Anime::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Wiki/Studio/RelationManagers/ImageStudioRelationManager.php
+++ b/app/Filament/Resources/Wiki/Studio/RelationManagers/ImageStudioRelationManager.php
@@ -54,6 +54,7 @@ class ImageStudioRelationManager extends BaseRelationManager
             ->columns(ImageResource::table($table)->getColumns())
             ->defaultSort(Image::TABLE.'.'.Image::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Wiki/Studio/RelationManagers/ResourceStudioRelationManager.php
+++ b/app/Filament/Resources/Wiki/Studio/RelationManagers/ResourceStudioRelationManager.php
@@ -54,6 +54,7 @@ class ResourceStudioRelationManager extends BaseRelationManager
             ->columns(ExternalResourceResource::table($table)->getColumns())
             ->defaultSort(ExternalResource::TABLE.'.'.ExternalResource::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Wiki/Video.php
+++ b/app/Filament/Resources/Wiki/Video.php
@@ -358,10 +358,6 @@ class Video extends BaseResource
                 NumberFilter::make(VideoModel::ATTRIBUTE_SIZE)
                     ->labels(__('filament.filters.video.size_from'), __('filament.filters.video.size_to'))
                     ->attribute(VideoModel::ATTRIBUTE_SIZE),
-
-                TextFilter::make(VideoModel::ATTRIBUTE_MIMETYPE)
-                    ->label(__('filament.fields.video.mimetype.name'))
-                    ->attribute(VideoModel::ATTRIBUTE_MIMETYPE),
             ],
             parent::getFilters(),
         );

--- a/app/Filament/Resources/Wiki/Video.php
+++ b/app/Filament/Resources/Wiki/Video.php
@@ -251,6 +251,7 @@ class Video extends BaseResource
             ->searchable()
             ->defaultSort(VideoModel::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions())
             ->headerActions(static::getHeaderActions());

--- a/app/Filament/Resources/Wiki/Video.php
+++ b/app/Filament/Resources/Wiki/Video.php
@@ -13,6 +13,7 @@ use App\Filament\Components\Columns\TextColumn;
 use App\Filament\Components\Fields\Select;
 use App\Filament\Components\Filters\NumberFilter;
 use App\Filament\Components\Filters\TextFilter;
+use App\Filament\Components\Infolist\TextEntry;
 use App\Filament\Resources\BaseResource;
 use App\Filament\Resources\Wiki\Video\Pages\CreateVideo;
 use App\Filament\Resources\Wiki\Video\Pages\EditVideo;
@@ -23,13 +24,13 @@ use App\Filament\Resources\Wiki\Video\RelationManagers\ScriptVideoRelationManage
 use App\Filament\Resources\Wiki\Video\RelationManagers\TrackVideoRelationManager;
 use App\Filament\TableActions\Repositories\Storage\Wiki\Video\ReconcileVideoTableAction;
 use App\Filament\TableActions\Storage\Wiki\Video\UploadVideoTableAction;
+use App\Http\Resources\Wiki\Resource\AudioResource;
 use App\Models\Wiki\Audio as AudioModel;
 use App\Models\Wiki\Video as VideoModel;
 use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
 use Filament\Infolists\Components\Section;
-use Filament\Infolists\Components\TextEntry;
 use Filament\Infolists\Infolist;
 use Filament\Resources\RelationManagers\RelationGroup;
 use Filament\Support\Enums\MaxWidth;
@@ -283,7 +284,13 @@ class Video extends BaseResource
 
                         TextEntry::make(VideoModel::ATTRIBUTE_MIMETYPE)
                             ->label(__('filament.fields.video.mimetype.name')),
-                    ]),
+
+                        TextEntry::make(VideoModel::RELATION_AUDIO.'.'.AudioModel::ATTRIBUTE_FILENAME)
+                            ->label(__('filament.resources.singularLabel.audio'))
+                            ->placeholder('-')
+                            ->urlToRelated(AudioResource::class, VideoModel::RELATION_AUDIO),
+                    ])
+                    ->columns(3),
 
                 Section::make(__('filament.fields.base.timestamps'))
                     ->schema(parent::timestamps()),

--- a/app/Filament/Resources/Wiki/Video.php
+++ b/app/Filament/Resources/Wiki/Video.php
@@ -12,7 +12,6 @@ use App\Filament\Actions\Storage\Wiki\Video\MoveVideoAction;
 use App\Filament\Components\Columns\TextColumn;
 use App\Filament\Components\Fields\Select;
 use App\Filament\Components\Filters\NumberFilter;
-use App\Filament\Components\Filters\TextFilter;
 use App\Filament\Components\Infolist\TextEntry;
 use App\Filament\Resources\BaseResource;
 use App\Filament\Resources\Wiki\Video\Pages\CreateVideo;

--- a/app/Filament/Resources/Wiki/Video/RelationManagers/EntryVideoRelationManager.php
+++ b/app/Filament/Resources/Wiki/Video/RelationManagers/EntryVideoRelationManager.php
@@ -54,6 +54,7 @@ class EntryVideoRelationManager extends BaseRelationManager
             ->columns(EntryResource::table($table)->getColumns())
             ->defaultSort(AnimeThemeEntry::TABLE.'.'.AnimeThemeEntry::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Wiki/Video/RelationManagers/ScriptVideoRelationManager.php
+++ b/app/Filament/Resources/Wiki/Video/RelationManagers/ScriptVideoRelationManager.php
@@ -53,6 +53,7 @@ class ScriptVideoRelationManager extends BaseRelationManager
             ->inverseRelationship(VideoScript::RELATION_VIDEO)
             ->columns(ScriptResource::table($table)->getColumns())
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Wiki/Video/RelationManagers/TrackVideoRelationManager.php
+++ b/app/Filament/Resources/Wiki/Video/RelationManagers/TrackVideoRelationManager.php
@@ -54,6 +54,7 @@ class TrackVideoRelationManager extends BaseRelationManager
             ->columns(TrackResource::table($table)->getColumns())
             ->defaultSort(PlaylistTrack::TABLE.'.'.PlaylistTrack::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->headerActions(static::getHeaderActions())
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions());

--- a/app/Filament/Resources/Wiki/Video/Script.php
+++ b/app/Filament/Resources/Wiki/Video/Script.php
@@ -149,6 +149,7 @@ class Script extends BaseResource
             ])
             ->defaultSort(ScriptModel::ATTRIBUTE_ID, 'desc')
             ->filters(static::getFilters())
+            ->filtersFormMaxHeight('400px')
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions())
             ->headerActions(static::getHeaderActions());

--- a/app/Filament/TableActions/Storage/Admin/DumpTableAction.php
+++ b/app/Filament/TableActions/Storage/Admin/DumpTableAction.php
@@ -6,7 +6,6 @@ namespace App\Filament\TableActions\Storage\Admin;
 
 use App\Actions\Storage\Admin\Dump\DumpAction as DumpDatabase;
 use App\Filament\Components\Fields\Select;
-use App\Models\Admin\Dump;
 use Exception;
 use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\TextInput;
@@ -31,13 +30,12 @@ abstract class DumpTableAction extends Action
     {
         parent::setUp();
 
-        $this->action(fn (Dump $record, array $data) => $this->handle($record, $data));
+        $this->action(fn (array $data) => $this->handle($data));
     }
 
     /**
      * Perform the action on the given models.
      *
-     * @param  Dump  $model
      * @param  array  $fields
      * @return void
      *
@@ -45,7 +43,7 @@ abstract class DumpTableAction extends Action
      *
      * @noinspection PhpUnusedParameterInspection
      */
-    public function handle(Dump $model, array $fields): void
+    public function handle(array $fields): void
     {
         $action = $this->storageAction($fields);
 

--- a/app/Filament/TableActions/Storage/Base/UploadTableAction.php
+++ b/app/Filament/TableActions/Storage/Base/UploadTableAction.php
@@ -35,7 +35,9 @@ abstract class UploadTableAction extends StorageTableAction implements Interacts
                 ->label(__('filament.actions.storage.upload.fields.file.name'))
                 ->helperText(__('filament.actions.storage.upload.fields.file.help'))
                 ->required()
+                ->live(true)
                 ->rules($this->fileRules())
+                ->preserveFilenames()
                 ->storeFiles(false),
 
             TextInput::make('path')

--- a/app/Models/Admin/Announcement.php
+++ b/app/Models/Admin/Announcement.php
@@ -75,4 +75,14 @@ class Announcement extends BaseModel
     {
         return strval($this->getKey());
     }
+
+    /**
+     * Get subname.
+     *
+     * @return string
+     */
+    public function getSubName(): string
+    {
+        return $this->getName();
+    }
 }

--- a/app/Models/Admin/Dump.php
+++ b/app/Models/Admin/Dump.php
@@ -75,4 +75,14 @@ class Dump extends BaseModel
     {
         return $this->path;
     }
+
+    /**
+     * Get subname.
+     *
+     * @return string
+     */
+    public function getSubName(): string
+    {
+        return $this->getName();
+    }
 }

--- a/app/Models/Admin/Feature.php
+++ b/app/Models/Admin/Feature.php
@@ -85,6 +85,16 @@ class Feature extends Model
     }
 
     /**
+     * Get subname.
+     *
+     * @return string
+     */
+    public function getSubName(): string
+    {
+        return $this->scope;
+    }
+
+    /**
      * Determine if the feature scope is global.
      *
      * @return bool

--- a/app/Models/Admin/FeaturedTheme.php
+++ b/app/Models/Admin/FeaturedTheme.php
@@ -121,6 +121,16 @@ class FeaturedTheme extends BaseModel
     }
 
     /**
+     * Get subname.
+     *
+     * @return string
+     */
+    public function getSubName(): string
+    {
+        return "{$this->entry->getName()}";
+    }
+
+    /**
      * Get the user that recommended the featured theme.
      *
      * @return BelongsTo

--- a/app/Models/Admin/FeaturedTheme.php
+++ b/app/Models/Admin/FeaturedTheme.php
@@ -23,7 +23,7 @@ use Laravel\Nova\Actions\Actionable;
  * Class FeaturedTheme.
  *
  * @property Carbon|null $end_at
- * @property AnimeThemeEntry|null $entry
+ * @property AnimeThemeEntry|null $animethemeentry
  * @property int $entry_id
  * @property int $feature_id
  * @property Carbon|null $start_at
@@ -127,7 +127,7 @@ class FeaturedTheme extends BaseModel
      */
     public function getSubName(): string
     {
-        return $this->entry->getName();
+        return $this->animethemeentry->getName();
     }
 
     /**

--- a/app/Models/Admin/FeaturedTheme.php
+++ b/app/Models/Admin/FeaturedTheme.php
@@ -127,7 +127,7 @@ class FeaturedTheme extends BaseModel
      */
     public function getSubName(): string
     {
-        return "{$this->entry->getName()}";
+        return $this->entry->getName();
     }
 
     /**

--- a/app/Models/Auth/User.php
+++ b/app/Models/Auth/User.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Models\Auth;
 
 use App\Contracts\Models\Nameable;
+use App\Contracts\Models\SubNameable;
 use App\Enums\Auth\SpecialPermission;
 use App\Events\Auth\User\UserCreated;
 use App\Events\Auth\User\UserDeleted;
@@ -50,7 +51,7 @@ use Spatie\Permission\Traits\HasRoles;
  *
  * @method static UserFactory factory(...$parameters)
  */
-class User extends Authenticatable implements MustVerifyEmail, Nameable, FilamentUser, HasAvatar
+class User extends Authenticatable implements MustVerifyEmail, Nameable, SubNameable, FilamentUser, HasAvatar
 {
     use Actionable;
     use HasApiTokens;
@@ -152,6 +153,16 @@ class User extends Authenticatable implements MustVerifyEmail, Nameable, Filamen
     }
 
     /**
+     * Get subname.
+     *
+     * @return string
+     */
+    public function getSubName(): string
+    {
+        return $this->email;
+    }
+
+    /**
      * Restore a soft-deleted model instance.
      *
      * @return bool|null
@@ -200,7 +211,7 @@ class User extends Authenticatable implements MustVerifyEmail, Nameable, Filamen
     {
         $hash = md5(strtolower(trim($this->email)));
 
-        return 'https://www.gravatar.com/avatar/'.$hash;
+        return "https://www.gravatar.com/avatar/$hash";
     }
 
     /**

--- a/app/Models/BaseModel.php
+++ b/app/Models/BaseModel.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Contracts\Models\Nameable;
+use App\Contracts\Models\SubNameable;
 use App\Enums\Http\Api\Filter\ComparisonOperator;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -22,7 +23,7 @@ use Illuminate\Support\Str;
  * @property Carbon $deleted_at
  * @property Carbon $updated_at
  */
-abstract class BaseModel extends Model implements Nameable
+abstract class BaseModel extends Model implements Nameable, SubNameable
 {
     use HasFactory;
     use Prunable;

--- a/app/Models/Document/Page.php
+++ b/app/Models/Document/Page.php
@@ -102,4 +102,14 @@ class Page extends BaseModel
     {
         return $this->name;
     }
+
+    /**
+     * Get subname.
+     *
+     * @return string
+     */
+    public function getSubName(): string
+    {
+        return $this->slug;
+    }
 }

--- a/app/Models/List/Playlist.php
+++ b/app/Models/List/Playlist.php
@@ -149,6 +149,16 @@ class Playlist extends BaseModel implements HasHashids, Viewable
     }
 
     /**
+     * Get subname.
+     *
+     * @return string
+     */
+    public function getSubName(): string
+    {
+        return $this->user->getName();
+    }
+
+    /**
      * Determine if the model should be searchable.
      *
      * @return bool

--- a/app/Models/List/Playlist/PlaylistTrack.php
+++ b/app/Models/List/Playlist/PlaylistTrack.php
@@ -128,6 +128,16 @@ class PlaylistTrack extends BaseModel implements HasHashids
     }
 
     /**
+     * Get subname.
+     *
+     * @return string
+     */
+    public function getSubName(): string
+    {
+        return "{$this->playlist->user->getName()} - {$this->playlist->getName()}";
+    }
+
+    /**
      * Get the playlist the track belongs to.
      *
      * @return BelongsTo

--- a/app/Models/Wiki/Anime.php
+++ b/app/Models/Wiki/Anime.php
@@ -179,6 +179,16 @@ class Anime extends BaseModel
     }
 
     /**
+     * Get subname.
+     *
+     * @return string
+     */
+    public function getSubName(): string
+    {
+        return $this->slug;
+    }
+
+    /**
      * Get the synonyms for the anime.
      *
      * @return HasMany

--- a/app/Models/Wiki/Anime/AnimeSynonym.php
+++ b/app/Models/Wiki/Anime/AnimeSynonym.php
@@ -101,6 +101,16 @@ class AnimeSynonym extends BaseModel
     }
 
     /**
+     * Get subname.
+     *
+     * @return string
+     */
+    public function getSubName(): string
+    {
+        return $this->anime->getName();
+    }
+
+    /**
      * Gets the anime that owns the synonym.
      *
      * @return BelongsTo

--- a/app/Models/Wiki/Anime/AnimeTheme.php
+++ b/app/Models/Wiki/Anime/AnimeTheme.php
@@ -159,6 +159,16 @@ class AnimeTheme extends BaseModel
     }
 
     /**
+     * Get subname.
+     *
+     * @return string
+     */
+    public function getSubName(): string
+    {
+        return $this->anime->getName();
+    }
+
+    /**
      * Gets the anime that owns the theme.
      *
      * @return BelongsTo

--- a/app/Models/Wiki/Anime/Theme/AnimeThemeEntry.php
+++ b/app/Models/Wiki/Anime/Theme/AnimeThemeEntry.php
@@ -163,6 +163,16 @@ class AnimeThemeEntry extends BaseModel
     }
 
     /**
+     * Get subname.
+     *
+     * @return string
+     */
+    public function getSubName(): string
+    {
+        return "{$this->anime->getName()} {$this->animetheme->getName()}";
+    }
+
+    /**
      * Get the theme that owns the entry.
      *
      * @return BelongsTo

--- a/app/Models/Wiki/Artist.php
+++ b/app/Models/Wiki/Artist.php
@@ -143,6 +143,16 @@ class Artist extends BaseModel
     }
 
     /**
+     * Get subname.
+     *
+     * @return string
+     */
+    public function getSubName(): string
+    {
+        return $this->slug;
+    }
+
+    /**
      * Get the songs the artist has performed in.
      *
      * @return BelongsToMany

--- a/app/Models/Wiki/Audio.php
+++ b/app/Models/Wiki/Audio.php
@@ -120,6 +120,16 @@ class Audio extends BaseModel implements Streamable, Viewable
     }
 
     /**
+     * Get subname.
+     *
+     * @return string
+     */
+    public function getSubName(): string
+    {
+        return $this->path();
+    }
+
+    /**
      * Get the path of the streamable model in the filesystem.
      *
      * @return string

--- a/app/Models/Wiki/ExternalResource.php
+++ b/app/Models/Wiki/ExternalResource.php
@@ -113,6 +113,16 @@ class ExternalResource extends BaseModel
     }
 
     /**
+     * Get subname.
+     *
+     * @return string
+     */
+    public function getSubName(): string
+    {
+        return strval($this->external_id);
+    }
+
+    /**
      * Get the anime that reference this resource.
      *
      * @return BelongsToMany

--- a/app/Models/Wiki/Group.php
+++ b/app/Models/Wiki/Group.php
@@ -90,6 +90,16 @@ class Group extends BaseModel
     }
 
     /**
+     * Get subname.
+     *
+     * @return string
+     */
+    public function getSubName(): string
+    {
+        return $this->slug;
+    }
+
+    /**
      * Get the themes for the group.
      *
      * @return HasMany

--- a/app/Models/Wiki/Image.php
+++ b/app/Models/Wiki/Image.php
@@ -114,6 +114,16 @@ class Image extends BaseModel
     }
 
     /**
+     * Get subname.
+     *
+     * @return string
+     */
+    public function getSubName(): string
+    {
+        return $this->path;
+    }
+
+    /**
      * Get the anime that use this image.
      *
      * @return BelongsToMany

--- a/app/Models/Wiki/Series.php
+++ b/app/Models/Wiki/Series.php
@@ -101,6 +101,16 @@ class Series extends BaseModel
     }
 
     /**
+     * Get subname.
+     *
+     * @return string
+     */
+    public function getSubName(): string
+    {
+        return $this->slug;
+    }
+
+    /**
      * Get the anime included in the series.
      *
      * @return BelongsToMany

--- a/app/Models/Wiki/Song.php
+++ b/app/Models/Wiki/Song.php
@@ -102,6 +102,11 @@ class Song extends BaseModel
         return $this->title;
     }
 
+    public function getSubName(): string
+    {
+        return $this->animethemes->first()->anime->getName();
+    }
+
     /**
      * Get the anime themes that use this song.
      *

--- a/app/Models/Wiki/Song.php
+++ b/app/Models/Wiki/Song.php
@@ -102,9 +102,14 @@ class Song extends BaseModel
         return $this->title;
     }
 
+    /**
+     * Get subname.
+     *
+     * @return string
+     */
     public function getSubName(): string
     {
-        return $this->animethemes->first()->anime->getName();
+        return "{$this->animethemes->first()->anime->getName()} {$this->animethemes->first()->slug}" ;
     }
 
     /**

--- a/app/Models/Wiki/Studio.php
+++ b/app/Models/Wiki/Studio.php
@@ -108,6 +108,16 @@ class Studio extends BaseModel
     }
 
     /**
+     * Get subname.
+     *
+     * @return string
+     */
+    public function getSubName(): string
+    {
+        return $this->slug;
+    }
+
+    /**
      * Get the anime that the studio produced.
      *
      * @return BelongsToMany

--- a/app/Models/Wiki/Video.php
+++ b/app/Models/Wiki/Video.php
@@ -273,6 +273,16 @@ class Video extends BaseModel implements Streamable, Viewable
     }
 
     /**
+     * Get subname.
+     *
+     * @return string
+     */
+    public function getSubName(): string
+    {
+        return $this->path();
+    }
+
+    /**
      * Get the path of the streamable model in the filesystem.
      *
      * @return string

--- a/app/Models/Wiki/Video/VideoScript.php
+++ b/app/Models/Wiki/Video/VideoScript.php
@@ -85,6 +85,16 @@ class VideoScript extends BaseModel
     }
 
     /**
+     * Get subname.
+     *
+     * @return string
+     */
+    public function getSubName(): string
+    {
+        return $this->path;
+    }
+
+    /**
      * Get the video that owns the script.
      *
      * @return BelongsTo

--- a/app/Rules/Wiki/Submission/SubmissionRule.php
+++ b/app/Rules/Wiki/Submission/SubmissionRule.php
@@ -22,7 +22,7 @@ abstract class SubmissionRule implements ValidationRule, ValidatorAwareRule
      *
      * @var array
      */
-    public static array $ffprobeData;
+    public static array $ffprobeData = [];
 
     /**
      * The loudness stats of the input file as parsed by the ffmpeg audio filter.
@@ -39,25 +39,42 @@ abstract class SubmissionRule implements ValidationRule, ValidatorAwareRule
      */
     public function setValidator(Validator $validator): self
     {
-        /** @var array $files */
+        /** @var UploadedFile|array $files */
         $files = Arr::get($validator->getData(), 'file');
 
-        foreach ($files as $file) {
-            /** @var UploadedFile $file*/
-
+        // Nova
+        if ($files instanceof UploadedFile) {
             $ffprobeData = Arr::get($validator->getData(), 'ffprobeData');
-            if ($ffprobeData === null && $file !== null) {
-                $ffprobeData = $this->getFFprobeData($file);
+            if ($ffprobeData === null && $files !== null) {
+                $ffprobeData = $this->getFFprobeData($files);
                 $validator->setValue('ffprobeData', $ffprobeData);
             }
             static::$ffprobeData = $ffprobeData;
 
             $loudnessStats = Arr::get($validator->getData(), 'loudnessStats');
-            if ($loudnessStats === null && $file !== null) {
-                $loudnessStats = $this->getLoudnessStats($file);
+            if ($loudnessStats === null && $files !== null) {
+                $loudnessStats = $this->getLoudnessStats($files);
                 $validator->setValue('loudnessStats', $loudnessStats);
             }
             $this->loudnessStats = $loudnessStats;
+        } else { // Filament
+            foreach ($files as $file) {
+                /** @var UploadedFile $file*/
+    
+                $ffprobeData = Arr::get($validator->getData(), 'ffprobeData');
+                if ($ffprobeData === null && $file !== null) {
+                    $ffprobeData = $this->getFFprobeData($file);
+                    $validator->setValue('ffprobeData', $ffprobeData);
+                }
+                static::$ffprobeData = $ffprobeData;
+    
+                $loudnessStats = Arr::get($validator->getData(), 'loudnessStats');
+                if ($loudnessStats === null && $file !== null) {
+                    $loudnessStats = $this->getLoudnessStats($file);
+                    $validator->setValue('loudnessStats', $loudnessStats);
+                }
+                $this->loudnessStats = $loudnessStats;
+            }
         }
 
         return $this;

--- a/app/Rules/Wiki/Submission/SubmissionRule.php
+++ b/app/Rules/Wiki/Submission/SubmissionRule.php
@@ -39,22 +39,26 @@ abstract class SubmissionRule implements ValidationRule, ValidatorAwareRule
      */
     public function setValidator(Validator $validator): self
     {
-        /** @var UploadedFile|null $file */
-        $file = Arr::get($validator->getData(), 'file');
+        /** @var array $files */
+        $files = Arr::get($validator->getData(), 'file');
 
-        $ffprobeData = Arr::get($validator->getData(), 'ffprobeData');
-        if ($ffprobeData === null && $file !== null) {
-            $ffprobeData = $this->getFFprobeData($file);
-            $validator->setValue('ffprobeData', $ffprobeData);
-        }
-        static::$ffprobeData = $ffprobeData;
+        foreach ($files as $file) {
+            /** @var UploadedFile $file*/
 
-        $loudnessStats = Arr::get($validator->getData(), 'loudnessStats');
-        if ($loudnessStats === null && $file !== null) {
-            $loudnessStats = $this->getLoudnessStats($file);
-            $validator->setValue('loudnessStats', $loudnessStats);
+            $ffprobeData = Arr::get($validator->getData(), 'ffprobeData');
+            if ($ffprobeData === null && $file !== null) {
+                $ffprobeData = $this->getFFprobeData($file);
+                $validator->setValue('ffprobeData', $ffprobeData);
+            }
+            static::$ffprobeData = $ffprobeData;
+
+            $loudnessStats = Arr::get($validator->getData(), 'loudnessStats');
+            if ($loudnessStats === null && $file !== null) {
+                $loudnessStats = $this->getLoudnessStats($file);
+                $validator->setValue('loudnessStats', $loudnessStats);
+            }
+            $this->loudnessStats = $loudnessStats;
         }
-        $this->loudnessStats = $loudnessStats;
 
         return $this;
     }

--- a/resources/views/filament/components/select.blade.php
+++ b/resources/views/filament/components/select.blade.php
@@ -1,0 +1,17 @@
+<div class="flex rounded-md relative">
+    <div class="flex">
+        @if ($image !== null)
+        <div class="px-2 py-3">
+            <div class="h-10 w-10">
+                <img src="{{ $image }}" role="img" class="h-full w-full rounded-full overflow-hidden shadow object-cover" />
+            </div>
+        </div>
+        @endif
+        <div class="flex flex-col justify-center pl-3 py-2">
+            <p class="text-sm font-bold pb-1">{{ $name }}</p>
+            <div class="flex flex-col items-start">
+                <p class="text-xs leading-5">{{ $subname }}</p>
+            </div>
+        </div>
+    </div>
+</div>

--- a/tests/Unit/Models/Admin/AnnouncementTest.php
+++ b/tests/Unit/Models/Admin/AnnouncementTest.php
@@ -23,4 +23,16 @@ class AnnouncementTest extends TestCase
 
         static::assertIsString($announcement->getName());
     }
+
+    /**
+     * Announcements shall be subnameable.
+     *
+     * @return void
+     */
+    public function testSubNameable(): void
+    {
+        $announcement = Announcement::factory()->createOne();
+
+        static::assertIsString($announcement->getSubName());
+    }
 }

--- a/tests/Unit/Models/Admin/DumpTest.php
+++ b/tests/Unit/Models/Admin/DumpTest.php
@@ -23,4 +23,16 @@ class DumpTest extends TestCase
 
         static::assertIsString($dump->getName());
     }
+
+    /**
+     * Dumps shall be subnameable.
+     *
+     * @return void
+     */
+    public function testSubNameable(): void
+    {
+        $dump = Dump::factory()->createOne();
+
+        static::assertIsString($dump->getSubName());
+    }
 }

--- a/tests/Unit/Models/Admin/FeatureTest.php
+++ b/tests/Unit/Models/Admin/FeatureTest.php
@@ -28,6 +28,18 @@ class FeatureTest extends TestCase
     }
 
     /**
+     * Features shall be subnameable.
+     *
+     * @return void
+     */
+    public function testSubNameable(): void
+    {
+        $feature = Feature::factory()->createOne();
+
+        static::assertIsString($feature->getSubName());
+    }
+
+    /**
      * Feature shall indicate if the scope is null.
      *
      * @return void

--- a/tests/Unit/Models/Admin/FeaturedThemeTest.php
+++ b/tests/Unit/Models/Admin/FeaturedThemeTest.php
@@ -38,7 +38,9 @@ class FeaturedThemeTest extends TestCase
      */
     public function testSubNameable(): void
     {
-        $featuredTheme = FeaturedTheme::factory()->createOne();
+        $featuredTheme = FeaturedTheme::factory()
+            ->for(AnimeThemeEntry::factory()->for(AnimeTheme::factory()->for(Anime::factory())))
+            ->createOne();
 
         static::assertIsString($featuredTheme->getSubName());
     }

--- a/tests/Unit/Models/Admin/FeaturedThemeTest.php
+++ b/tests/Unit/Models/Admin/FeaturedThemeTest.php
@@ -32,6 +32,18 @@ class FeaturedThemeTest extends TestCase
     }
 
     /**
+     * Featured Themes shall be subnameable.
+     *
+     * @return void
+     */
+    public function testSubNameable(): void
+    {
+        $featuredTheme = FeaturedTheme::factory()->createOne();
+
+        static::assertIsString($featuredTheme->getSubName());
+    }
+
+    /**
      * Featured Themes shall cast the end_at attribute to datetime.
      *
      * @return void

--- a/tests/Unit/Models/Auth/UserTest.php
+++ b/tests/Unit/Models/Auth/UserTest.php
@@ -64,6 +64,18 @@ class UserTest extends TestCase
     }
 
     /**
+     * Users shall be subnameable.
+     *
+     * @return void
+     */
+    public function testSubNameable(): void
+    {
+        $user = User::factory()->createOne();
+
+        static::assertIsString($user->getSubName());
+    }
+
+    /**
      * User shall have a one-to-many relationship with the type Playlist.
      *
      * @return void

--- a/tests/Unit/Models/Document/PageTest.php
+++ b/tests/Unit/Models/Document/PageTest.php
@@ -23,4 +23,16 @@ class PageTest extends TestCase
 
         static::assertIsString($page->getName());
     }
+
+    /**
+     * Pages shall be subnameable.
+     *
+     * @return void
+     */
+    public function testSubNameable(): void
+    {
+        $page = Page::factory()->createOne();
+
+        static::assertIsString($page->getSubName());
+    }
 }

--- a/tests/Unit/Models/List/Playlist/TrackTest.php
+++ b/tests/Unit/Models/List/Playlist/TrackTest.php
@@ -16,7 +16,7 @@ use Tests\TestCase;
 class TrackTest extends TestCase
 {
     /**
-     * Anime shall be nameable.
+     * Playlist Tracks shall be nameable.
      *
      * @return void
      */
@@ -27,6 +27,20 @@ class TrackTest extends TestCase
             ->createOne();
 
         static::assertIsString($track->getName());
+    }
+
+    /**
+     * Playlist Tracks shall be subnameable.
+     *
+     * @return void
+     */
+    public function testSubNameable(): void
+    {
+        $track = PlaylistTrack::factory()
+            ->for(Playlist::factory())
+            ->createOne();
+
+        static::assertIsString($track->getSubName());
     }
 
     /**

--- a/tests/Unit/Models/List/Playlist/TrackTest.php
+++ b/tests/Unit/Models/List/Playlist/TrackTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Models\List\Playlist;
 
+use App\Models\Auth\User;
 use App\Models\List\Playlist;
 use App\Models\List\Playlist\PlaylistTrack;
 use App\Models\Wiki\Video;
@@ -37,7 +38,7 @@ class TrackTest extends TestCase
     public function testSubNameable(): void
     {
         $track = PlaylistTrack::factory()
-            ->for(Playlist::factory())
+            ->for(Playlist::factory()->for(User::factory()))
             ->createOne();
 
         static::assertIsString($track->getSubName());

--- a/tests/Unit/Models/List/PlaylistTest.php
+++ b/tests/Unit/Models/List/PlaylistTest.php
@@ -41,7 +41,7 @@ class PlaylistTest extends TestCase
     }
 
     /**
-     * Anime shall be nameable.
+     * Playlist shall be nameable.
      *
      * @return void
      */
@@ -50,6 +50,18 @@ class PlaylistTest extends TestCase
         $playlist = Playlist::factory()->createOne();
 
         static::assertIsString($playlist->getName());
+    }
+
+    /**
+     * Playlist shall be subnameable.
+     *
+     * @return void
+     */
+    public function testSubNameable(): void
+    {
+        $playlist = Playlist::factory()->createOne();
+
+        static::assertIsString($playlist->getSubName());
     }
 
     /**

--- a/tests/Unit/Models/List/PlaylistTest.php
+++ b/tests/Unit/Models/List/PlaylistTest.php
@@ -59,7 +59,9 @@ class PlaylistTest extends TestCase
      */
     public function testSubNameable(): void
     {
-        $playlist = Playlist::factory()->createOne();
+        $playlist = Playlist::factory()
+            ->for(User::factory())
+            ->createOne();
 
         static::assertIsString($playlist->getSubName());
     }

--- a/tests/Unit/Models/Wiki/Anime/AnimeSynonymTest.php
+++ b/tests/Unit/Models/Wiki/Anime/AnimeSynonymTest.php
@@ -77,6 +77,20 @@ class AnimeSynonymTest extends TestCase
     }
 
     /**
+     * Synonyms shall be subnameable.
+     *
+     * @return void
+     */
+    public function testSubNameable(): void
+    {
+        $synonym = AnimeSynonym::factory()
+            ->for(Anime::factory())
+            ->createOne();
+
+        static::assertIsString($synonym->getSubName());
+    }
+
+    /**
      * Synonyms shall belong to an Anime.
      *
      * @return void

--- a/tests/Unit/Models/Wiki/Anime/AnimeThemeTest.php
+++ b/tests/Unit/Models/Wiki/Anime/AnimeThemeTest.php
@@ -81,6 +81,20 @@ class AnimeThemeTest extends TestCase
     }
 
     /**
+     * Themes shall be subnameable.
+     *
+     * @return void
+     */
+    public function testSubNameable(): void
+    {
+        $theme = AnimeTheme::factory()
+            ->for(Anime::factory())
+            ->createOne();
+
+        static::assertIsString($theme->getSubName());
+    }
+
+    /**
      * Themes shall belong to an Anime.
      *
      * @return void

--- a/tests/Unit/Models/Wiki/Anime/Theme/AnimeThemeEntryTest.php
+++ b/tests/Unit/Models/Wiki/Anime/Theme/AnimeThemeEntryTest.php
@@ -65,6 +65,20 @@ class AnimeThemeEntryTest extends TestCase
     }
 
     /**
+     * Entries shall be subnameable.
+     *
+     * @return void
+     */
+    public function testSubNameable(): void
+    {
+        $entry = AnimeThemeEntry::factory()
+            ->for(AnimeTheme::factory()->for(Anime::factory()))
+            ->createOne();
+
+        static::assertIsString($entry->getSubName());
+    }
+
+    /**
      * Entries shall belong to a Theme.
      *
      * @return void

--- a/tests/Unit/Models/Wiki/AnimeTest.php
+++ b/tests/Unit/Models/Wiki/AnimeTest.php
@@ -94,6 +94,18 @@ class AnimeTest extends TestCase
     }
 
     /**
+     * Anime shall be subnameable.
+     *
+     * @return void
+     */
+    public function testSubNameable(): void
+    {
+        $anime = Anime::factory()->createOne();
+
+        static::assertIsString($anime->getSubName());
+    }
+
+    /**
      * Anime shall have a one-to-many relationship with the type Synonym.
      *
      * @return void

--- a/tests/Unit/Models/Wiki/ArtistTest.php
+++ b/tests/Unit/Models/Wiki/ArtistTest.php
@@ -60,6 +60,18 @@ class ArtistTest extends TestCase
     }
 
     /**
+     * Artists shall be subnameable.
+     *
+     * @return void
+     */
+    public function testSubNameable(): void
+    {
+        $artist = Artist::factory()->createOne();
+
+        static::assertIsString($artist->getSubName());
+    }
+
+    /**
      * Artist shall have a many-to-many relationship with the type Song.
      *
      * @return void

--- a/tests/Unit/Models/Wiki/AudioTest.php
+++ b/tests/Unit/Models/Wiki/AudioTest.php
@@ -32,6 +32,18 @@ class AudioTest extends TestCase
     }
 
     /**
+     * Audios shall be subnameable.
+     *
+     * @return void
+     */
+    public function testSubNameable(): void
+    {
+        $audio = Audio::factory()->createOne();
+
+        static::assertIsString($audio->getSubName());
+    }
+
+    /**
      * Audio shall have a one-to-many relationship with the type Video.
      *
      * @return void

--- a/tests/Unit/Models/Wiki/ExternalResourceTest.php
+++ b/tests/Unit/Models/Wiki/ExternalResourceTest.php
@@ -52,6 +52,18 @@ class ExternalResourceTest extends TestCase
     }
 
     /**
+     * Resources shall be subnameable.
+     *
+     * @return void
+     */
+    public function testSubNameable(): void
+    {
+        $resource = ExternalResource::factory()->createOne();
+
+        static::assertIsString($resource->getSubName());
+    }
+
+    /**
      * Resource shall have a many-to-many relationship with the type Anime.
      *
      * @return void

--- a/tests/Unit/Models/Wiki/GroupTest.php
+++ b/tests/Unit/Models/Wiki/GroupTest.php
@@ -31,6 +31,18 @@ class GroupTest extends TestCase
     }
 
     /**
+     * Groups shall be subnameable.
+     *
+     * @return void
+     */
+    public function testSubNameable(): void
+    {
+        $group = Group::factory()->createOne();
+
+        static::assertIsString($group->getSubName());
+    }
+
+    /**
      * Group shall have a one-to-many relationship with the type Theme.
      *
      * @return void

--- a/tests/Unit/Models/Wiki/ImageTest.php
+++ b/tests/Unit/Models/Wiki/ImageTest.php
@@ -57,6 +57,18 @@ class ImageTest extends TestCase
     }
 
     /**
+     * Images shall be subnameable.
+     *
+     * @return void
+     */
+    public function testSubNameable(): void
+    {
+        $image = Image::factory()->createOne();
+
+        static::assertIsString($image->getSubName());
+    }
+
+    /**
      * Image shall have a many-to-many relationship with the type Anime.
      *
      * @return void

--- a/tests/Unit/Models/Wiki/SeriesTest.php
+++ b/tests/Unit/Models/Wiki/SeriesTest.php
@@ -55,6 +55,18 @@ class SeriesTest extends TestCase
     }
 
     /**
+     * Series shall be subnameable.
+     *
+     * @return void
+     */
+    public function testSubNameable(): void
+    {
+        $series = Series::factory()->createOne();
+
+        static::assertIsString($series->getSubName());
+    }
+
+    /**
      * Series shall have a many-to-many relationship with the type Anime.
      *
      * @return void

--- a/tests/Unit/Models/Wiki/SongTest.php
+++ b/tests/Unit/Models/Wiki/SongTest.php
@@ -66,7 +66,9 @@ class SongTest extends TestCase
      */
     public function testSubNameable(): void
     {
-        $song = Song::factory()->createOne();
+        $song = Song::factory()
+            ->for(AnimeTheme::factory()->for(Anime::factory()))
+            ->createOne();
 
         static::assertIsString($song->getSubName());
     }

--- a/tests/Unit/Models/Wiki/SongTest.php
+++ b/tests/Unit/Models/Wiki/SongTest.php
@@ -67,7 +67,7 @@ class SongTest extends TestCase
     public function testSubNameable(): void
     {
         $song = Song::factory()
-            ->for(AnimeTheme::factory()->for(Anime::factory()))
+            ->has(AnimeTheme::factory()->for(Anime::factory()))
             ->createOne();
 
         static::assertIsString($song->getSubName());

--- a/tests/Unit/Models/Wiki/SongTest.php
+++ b/tests/Unit/Models/Wiki/SongTest.php
@@ -60,6 +60,18 @@ class SongTest extends TestCase
     }
 
     /**
+     * Songs shall be subnameable.
+     *
+     * @return void
+     */
+    public function testSubNameable(): void
+    {
+        $song = Song::factory()->createOne();
+
+        static::assertIsString($song->getSubName());
+    }
+
+    /**
      * Song shall have a one-to-many relationship with the type Theme.
      *
      * @return void

--- a/tests/Unit/Models/Wiki/StudioTest.php
+++ b/tests/Unit/Models/Wiki/StudioTest.php
@@ -59,6 +59,18 @@ class StudioTest extends TestCase
     }
 
     /**
+     * Studio shall be subnameable.
+     *
+     * @return void
+     */
+    public function testSubNameable(): void
+    {
+        $studio = Studio::factory()->createOne();
+
+        static::assertIsString($studio->getSubName());
+    }
+
+    /**
      * Studio shall have a many-to-many relationship with the type Anime.
      *
      * @return void

--- a/tests/Unit/Models/Wiki/Video/ScriptTest.php
+++ b/tests/Unit/Models/Wiki/Video/ScriptTest.php
@@ -15,7 +15,7 @@ use Tests\TestCase;
 class ScriptTest extends TestCase
 {
     /**
-     * Dumps shall be nameable.
+     * Scripts shall be nameable.
      *
      * @return void
      */
@@ -24,6 +24,18 @@ class ScriptTest extends TestCase
         $script = VideoScript::factory()->createOne();
 
         static::assertIsString($script->getName());
+    }
+
+    /**
+     * Scripts shall be subnameable.
+     *
+     * @return void
+     */
+    public function testSubNameable(): void
+    {
+        $script = VideoScript::factory()->createOne();
+
+        static::assertIsString($script->getSubName());
     }
 
     /**

--- a/tests/Unit/Models/Wiki/VideoTest.php
+++ b/tests/Unit/Models/Wiki/VideoTest.php
@@ -99,6 +99,18 @@ class VideoTest extends TestCase
     }
 
     /**
+     * Videos shall be subnameable.
+     *
+     * @return void
+     */
+    public function testSubNameable(): void
+    {
+        $video = Video::factory()->createOne();
+
+        static::assertIsString($video->getSubName());
+    }
+
+    /**
      * Videos shall have a one-to-many polymorphic relationship to View.
      *
      * @return void


### PR DESCRIPTION
* Added subnames;
* Added SubNameable trait;
* Added custom blade for subnames on filament search;
* Added Tracks entries on view page;
* Added filters scrollable;
* Fixed support for filament uploads;
* Fixed save relationship anime-entry;
* Fixed DumpTableAction;
* Fixed BackfillAudioAction;
* Removed attach action when relation is not BelongsToMany;
* Removed mimetype filters.