### PR TITLE
feat(filament): URL hint action on discord message field

### DIFF
--- a/app/Actions/Discord/DiscordMessageAction.php
+++ b/app/Actions/Discord/DiscordMessageAction.php
@@ -15,8 +15,6 @@ use Illuminate\Support\Facades\Http;
  */
 class DiscordMessageAction
 {
-    protected array $message;
-
     /**
      * Make the Discord message.
      *
@@ -71,22 +69,12 @@ class DiscordMessageAction
     }
 
     /**
-     * Get the current Discord message.
-     *
-     * @return array
-     */
-    public function getMessage(): array
-    {
-        return $this->message;
-    }
-
-    /**
      * Set the Discord message.
      *
      * @param  string  $url
-     * @return static
+     * @return array
      */
-    public function get(string $url): static
+    public function get(string $url): array
     {
         $message = Http::withHeaders(['x-api-key' => Config::get('services.discord.api_key')])
             ->get(Config::get('services.discord.api_url') . '/message', [
@@ -95,9 +83,7 @@ class DiscordMessageAction
             ->throw()
             ->json();
 
-        $this->message = Arr::get($message, 'message');
-
-        return $this;
+        return Arr::get($message, 'message');
     }
 
     /**

--- a/app/Actions/Discord/DiscordMessageAction.php
+++ b/app/Actions/Discord/DiscordMessageAction.php
@@ -29,19 +29,19 @@ class DiscordMessageAction
 
         $embeds = [];
 
-        foreach (Arr::get($fields, 'embeds') as $embed) {
+        foreach (Arr::get($fields, DiscordMessage::ATTRIBUTE_EMBEDS) as $embed) {
             $newEmbed = (new DiscordEmbed())
-                ->setTitle(Arr::get($embed, 'title') ?? '')
-                ->setDescription(Arr::get($embed, 'description') ?? '')
-                ->setColor(hexdec(Arr::get($embed, 'color') ?? ''))
-                ->setThumbnail(Arr::get($embed, 'thumbnail'))
-                ->setImage(Arr::get($embed, 'image'))
-                ->setFields(Arr::get($embed, 'fields') ?? []);
+                ->setTitle(Arr::get($embed, DiscordEmbed::ATTRIBUTE_TITLE) ?? '')
+                ->setDescription(Arr::get($embed, DiscordEmbed::ATTRIBUTE_DESCRIPTION) ?? '')
+                ->setColor(hexdec(Arr::get($embed, DiscordEmbed::ATTRIBUTE_COLOR) ?? ''))
+                ->setThumbnail(Arr::get($embed, DiscordEmbed::ATTRIBUTE_THUMBNAIL))
+                ->setImage(Arr::get($embed, DiscordEmbed::ATTRIBUTE_IMAGE))
+                ->setFields(Arr::get($embed, DiscordEmbed::ATTRIBUTE_FIELDS) ?? []);
 
-            $embedFields = Arr::get($embed, 'fields');
+            $embedFields = Arr::get($embed, DiscordEmbed::ATTRIBUTE_FIELDS);
             $newEmbedFields = [];
             foreach ($embedFields as $embedField) {
-                if (Arr::get($embedField, 'name') && Arr::get($embedField, 'value')) {
+                if (Arr::get($embedField, DiscordEmbed::ATTRIBUTE_FIELDS_NAME) && Arr::get($embedField, DiscordEmbed::ATTRIBUTE_FIELDS_VALUE)) {
                     $newEmbedFields[] = $embedField;
                 }
             }
@@ -49,22 +49,22 @@ class DiscordMessageAction
             $embeds[] = $newEmbed->setFields($newEmbedFields)->toArray();
         }
 
-        if (Arr::has($fields, 'url')) {
-            preg_match('/https:\/\/discord\.com\/channels\/(\d+)\/(\d+)\/(\d+)/', Arr::get($fields, 'url'), $matches);
+        if (Arr::has($fields, DiscordMessage::ATTRIBUTE_URL)) {
+            preg_match('/https:\/\/discord\.com\/channels\/(\d+)\/(\d+)\/(\d+)/', Arr::get($fields, DiscordMessage::ATTRIBUTE_URL), $matches);
 
             $message = $message
                 ->setChannelId(strval($matches[2]))
                 ->setId(strval($matches[3]));
         }
 
-        if (Arr::has($fields, 'channelId')) {
-            $message = $message->setChannelId(Arr::get($fields, 'channelId'));
+        if (Arr::has($fields, DiscordMessage::ATTRIBUTE_CHANNEL_ID)) {
+            $message = $message->setChannelId(Arr::get($fields, DiscordMessage::ATTRIBUTE_CHANNEL_ID));
         }
 
         $message = $message
-            ->setContent(Arr::get($fields, 'content') ?? '')
+            ->setContent(Arr::get($fields, DiscordMessage::ATTRIBUTE_CONTENT) ?? '')
             ->setEmbeds($embeds)
-            ->setFiles(Arr::get($fields, 'images'))
+            ->setImages(Arr::get($fields, DiscordMessage::ATTRIBUTE_IMAGES))
             ->toArray();
 
         return $message;

--- a/app/Actions/Discord/DiscordThreadAction.php
+++ b/app/Actions/Discord/DiscordThreadAction.php
@@ -51,7 +51,7 @@ class DiscordThreadAction
     }
 
     /**
-     * Get the thread.
+     * Get the thread by ID.
      *
      * @param  string  $id
      * @return array

--- a/app/Actions/Discord/DiscordVideoNotificationAction.php
+++ b/app/Actions/Discord/DiscordVideoNotificationAction.php
@@ -12,6 +12,9 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
 
+/**
+ * Class DiscordVideoNotificationAction.
+ */
 class DiscordVideoNotificationAction
 {
     /**

--- a/app/Discord/DiscordEmbed.php
+++ b/app/Discord/DiscordEmbed.php
@@ -9,6 +9,17 @@ namespace App\Discord;
  */
 class DiscordEmbed
 {
+    final public const ATTRIBUTE_TYPE = 'type';
+    final public const ATTRIBUTE_TITLE = 'title';
+    final public const ATTRIBUTE_DESCRIPTION = 'description';
+    final public const ATTRIBUTE_COLOR = 'color';
+    final public const ATTRIBUTE_THUMBNAIL = 'thumbnail';
+    final public const ATTRIBUTE_IMAGE = 'image';
+    final public const ATTRIBUTE_FIELDS = 'fields';
+    final public const ATTRIBUTE_FIELDS_NAME = 'name';
+    final public const ATTRIBUTE_FIELDS_VALUE = 'value';
+    final public const ATTRIBUTE_FIELDS_INLINE = 'inline';
+
     protected string $type = 'rich';
     protected string $title = '';
     protected string $description = '';

--- a/app/Discord/DiscordMessage.php
+++ b/app/Discord/DiscordMessage.php
@@ -9,11 +9,18 @@ namespace App\Discord;
  */
 class DiscordMessage
 {
+    final public const ATTRIBUTE_CHANNEL_ID = 'channelId';
+    final public const ATTRIBUTE_ID = 'id';
+    final public const ATTRIBUTE_URL = 'url';
+    final public const ATTRIBUTE_CONTENT = 'content';
+    final public const ATTRIBUTE_EMBEDS = 'embeds';
+    final public const ATTRIBUTE_IMAGES = 'images';
+
     protected string $channelId = '0';
     protected string $id = '0';
     protected string $content = '';
     protected array $embeds = [];
-    protected array $files = [];
+    protected array $images = [];
 
     /**
      * Get the channelId of the message.
@@ -56,13 +63,13 @@ class DiscordMessage
     }
 
     /**
-     * Get the files of the message.
+     * Get the images of the message.
      *
      * @return array<string>
      */
-    public function getFiles(): array
+    public function getImages(): array
     {
-        return $this->files;
+        return $this->images;
     }
 
     /**
@@ -92,14 +99,14 @@ class DiscordMessage
     }
 
     /**
-     * Set the files of the message.
+     * Set the images of the message.
      *
-     * @param  array<string>  $files
+     * @param  array<string>  $images
      * @return static
      */
-    public function setFiles(array $files): static
+    public function setImages(array $images): static
     {
-        $this->files = $files;
+        $this->images = $images;
 
         return $this;
     }
@@ -142,7 +149,7 @@ class DiscordMessage
             'id' => $this->getId(),
             'content' => $this->getContent(),
             'embeds' => $this->getEmbeds(),
-            'files' => $this->getFiles(),
+            'files' => $this->getImages(),
         ];
     }
 }

--- a/app/Discord/DiscordMessage.php
+++ b/app/Discord/DiscordMessage.php
@@ -88,7 +88,7 @@ class DiscordMessage
     /**
      * Set the embeds of the message.
      *
-     * @param  DiscordMessage[]  $embeds
+     * @param  array  $embeds
      * @return static
      */
     public function setEmbeds(array $embeds): static

--- a/app/Filament/TableActions/Models/Discord/DiscordEditMessageTableAction.php
+++ b/app/Filament/TableActions/Models/Discord/DiscordEditMessageTableAction.php
@@ -67,7 +67,6 @@ class DiscordEditMessageTableAction extends BaseTableAction
                                 $set("embeds.item{$index}.fields.{$fieldIndex}.name", Arr::get($field, 'name'));
                                 $set("embeds.item{$index}.fields.{$fieldIndex}.value", Arr::get($field, 'value'));
                                 $set("embeds.item{$index}.fields.{$fieldIndex}.inline", Arr::get($field, 'inline'));
-                                $fieldIndex++;
                             }
                         }
 

--- a/app/Filament/TableActions/Models/Discord/DiscordEditMessageTableAction.php
+++ b/app/Filament/TableActions/Models/Discord/DiscordEditMessageTableAction.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Filament\TableActions\Models\Discord;
 
 use App\Actions\Discord\DiscordMessageAction;
+use App\Discord\DiscordEmbed;
+use App\Discord\DiscordMessage;
 use App\Filament\TableActions\BaseTableAction;
 use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\ColorPicker;
@@ -45,23 +47,23 @@ class DiscordEditMessageTableAction extends BaseTableAction
     {
         return $form
             ->schema([
-                TextInput::make('url')
+                TextInput::make(DiscordMessage::ATTRIBUTE_URL)
                     ->label(__('filament.table_actions.discord_thread.message.url.name'))
                     ->helperText(__('filament.table_actions.discord_thread.message.url.help'))
                     ->live(true)
                     ->required()
                     ->rules(['required', 'string'])
-                    ->afterStateUpdated(function (Set $set, TextInput $component, string $state) {
+                    ->afterStateUpdated(function (Set $set, string $state) {
                         $message = (new DiscordMessageAction())->get($state)->getMessage();
 
-                        $set('content', Arr::get($message, 'content'));
+                        $set(DiscordMessage::ATTRIBUTE_CONTENT, Arr::get($message, DiscordMessage::ATTRIBUTE_CONTENT));
 
-                        foreach (Arr::get($message, 'embeds') ?? [] as $index => $embed) {
+                        foreach (Arr::get($message, DiscordMessage::ATTRIBUTE_EMBEDS) ?? [] as $index => $embed) {
                             foreach ($embed as $key => $value) {
-                                $set("embeds.item{$index}.{$key}", $key === 'color' ? '#' . dechex($value) : $value);
+                                $set("embeds.item{$index}.{$key}", $key === DiscordEmbed::ATTRIBUTE_COLOR ? '#' . dechex($value) : $value);
                             }
 
-                            foreach (Arr::get($embed, 'fields') ?? [] as $fieldIndex => $field) {
+                            foreach (Arr::get($embed, DiscordEmbed::ATTRIBUTE_FIELDS) ?? [] as $fieldIndex => $field) {
                                 foreach ($field as $key => $value) {
                                     $set("embeds.item{$index}.fields.{$fieldIndex}.{$key}", $value);
                                 }
@@ -73,70 +75,70 @@ class DiscordEditMessageTableAction extends BaseTableAction
                         }
                     }),
 
-                MarkdownEditor::make('content')
+                MarkdownEditor::make(DiscordMessage::ATTRIBUTE_CONTENT)
                     ->label(__('filament.table_actions.discord_thread.message.content.name'))
                     ->helperText(__('filament.table_actions.discord_thread.message.content.help')),
 
-                Repeater::make('embeds')
+                Repeater::make(DiscordMessage::ATTRIBUTE_EMBEDS)
                     ->label(__('filament.table_actions.discord_thread.message.embeds.name'))
                     ->helperText(__('filament.table_actions.discord_thread.message.embeds.help'))
-                    ->key('embeds')
+                    ->key(DiscordMessage::ATTRIBUTE_EMBEDS)
                     ->collapsible()
                     ->defaultItems(0)
                     ->schema([
-                        TextInput::make('title')
+                        TextInput::make(DiscordEmbed::ATTRIBUTE_TITLE)
                             ->label(__('filament.table_actions.discord_thread.message.embeds.body.title.name'))
                             ->helperText(__('filament.table_actions.discord_thread.message.embeds.body.title.help')),
 
-                        MarkdownEditor::make('description')
+                        MarkdownEditor::make(DiscordEmbed::ATTRIBUTE_DESCRIPTION)
                             ->label(__('filament.table_actions.discord_thread.message.embeds.body.description.name'))
                             ->helperText(__('filament.table_actions.discord_thread.message.embeds.body.description.help'))
                             ->required()
                             ->rules(['required', 'string']),
 
-                        ColorPicker::make('color')
+                        ColorPicker::make(DiscordEmbed::ATTRIBUTE_COLOR)
                             ->label(__('filament.table_actions.discord_thread.message.embeds.body.color.name'))
                             ->helperText(__('filament.table_actions.discord_thread.message.embeds.body.color.help')),
 
-                        TextInput::make('thumbnail')
+                        TextInput::make(DiscordEmbed::ATTRIBUTE_THUMBNAIL)
                             ->label(__('filament.table_actions.discord_thread.message.embeds.body.thumbnail.name'))
                             ->helperText(__('filament.table_actions.discord_thread.message.embeds.body.thumbnail.help')),
 
-                        TextInput::make('image')
+                        TextInput::make(DiscordEmbed::ATTRIBUTE_IMAGE)
                             ->label(__('filament.table_actions.discord_thread.message.embeds.body.image.name'))
                             ->helperText(__('filament.table_actions.discord_thread.message.embeds.body.image.help')),
 
-                        Repeater::make('fields')
+                        Repeater::make(DiscordEmbed::ATTRIBUTE_FIELDS)
                             ->label(__('filament.table_actions.discord_thread.message.embeds.body.fields.title.name'))
                             ->helperText(__('filament.table_actions.discord_thread.message.embeds.body.fields.title.help'))
                             ->collapsible()
                             ->schema([
-                                TextInput::make('name')
+                                TextInput::make(DiscordEmbed::ATTRIBUTE_FIELDS_NAME)
                                     ->label(__('filament.table_actions.discord_thread.message.embeds.body.fields.name.name'))
                                     ->helperText(__('filament.table_actions.discord_thread.message.embeds.body.fields.name.help'))
                                     ->required()
                                     ->rules(['required', 'string']),
 
-                                TextInput::make('value')
+                                TextInput::make(DiscordEmbed::ATTRIBUTE_FIELDS_VALUE)
                                     ->label(__('filament.table_actions.discord_thread.message.embeds.body.fields.value.name'))
                                     ->helperText(__('filament.table_actions.discord_thread.message.embeds.body.fields.value.help'))
                                     ->required()
                                     ->rules(['required', 'string']),
 
-                                Checkbox::make('inline')
+                                Checkbox::make(DiscordEmbed::ATTRIBUTE_FIELDS_INLINE)
                                     ->label(__('filament.table_actions.discord_thread.message.embeds.body.fields.inline.name'))
                                     ->helperText(__('filament.table_actions.discord_thread.message.embeds.body.fields.inline.help')),
                             ]),
                     ]),
 
-                Repeater::make('images')
+                Repeater::make(DiscordMessage::ATTRIBUTE_IMAGES)
                     ->label(__('filament.table_actions.discord_thread.message.images.name'))
                     ->helperText(__('filament.table_actions.discord_thread.message.images.help'))
-                    ->key('images')
+                    ->key(DiscordMessage::ATTRIBUTE_IMAGES)
                     ->collapsible()
                     ->defaultItems(0)
                     ->schema([
-                        TextInput::make('url')
+                        TextInput::make(DiscordMessage::ATTRIBUTE_URL)
                             ->label(__('filament.table_actions.discord_thread.message.images.body.url.name'))
                             ->helperText(__('filament.table_actions.discord_thread.message.images.body.url.help'))
                             ->required()

--- a/app/Filament/TableActions/Models/Discord/DiscordEditMessageTableAction.php
+++ b/app/Filament/TableActions/Models/Discord/DiscordEditMessageTableAction.php
@@ -56,28 +56,23 @@ class DiscordEditMessageTableAction extends BaseTableAction
 
                         $set('content', Arr::get($message, 'content'));
 
-                        $index = 0;
-                        foreach (Arr::get($message, 'embeds') ?? [] as $embed) {
+                        foreach (Arr::get($message, 'embeds') ?? [] as $index => $embed) {
                             $set("embeds.item{$index}.title", Arr::get($embed, 'title'));
                             $set("embeds.item{$index}.description", Arr::get($embed, 'description'));
                             $set("embeds.item{$index}.color", '#' . dechex(Arr::get($embed, 'color')));
                             $set("embeds.item{$index}.thumbnail", Arr::get($embed, 'thumbnail'));
                             $set("embeds.item{$index}.image", Arr::get($embed, 'image'));
 
-                            $fieldIndex = 0;
-                            foreach (Arr::get($embed, 'fields') ?? [] as $field) {
+                            foreach (Arr::get($embed, 'fields') ?? [] as $fieldIndex => $field) {
                                 $set("embeds.item{$index}.fields.{$fieldIndex}.name", Arr::get($field, 'name'));
                                 $set("embeds.item{$index}.fields.{$fieldIndex}.value", Arr::get($field, 'value'));
                                 $set("embeds.item{$index}.fields.{$fieldIndex}.inline", Arr::get($field, 'inline'));
                                 $fieldIndex++;
                             }
-                            $index++;
                         }
 
-                        $index = 0;
-                        foreach (Arr::get($message, 'files') as $file) {
+                        foreach (Arr::get($message, 'files') as $index => $file) {
                             $set("images.item{$index}.url", $file);
-                            $index++;
                         }
                     }),
 

--- a/app/Filament/TableActions/Models/Discord/DiscordEditMessageTableAction.php
+++ b/app/Filament/TableActions/Models/Discord/DiscordEditMessageTableAction.php
@@ -10,8 +10,8 @@ use App\Discord\DiscordMessage;
 use App\Filament\TableActions\BaseTableAction;
 use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\ColorPicker;
-use Filament\Forms\Components\MarkdownEditor;
 use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\RichEditor;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
 use Filament\Forms\Set;
@@ -75,7 +75,7 @@ class DiscordEditMessageTableAction extends BaseTableAction
                         }
                     }),
 
-                MarkdownEditor::make(DiscordMessage::ATTRIBUTE_CONTENT)
+                RichEditor::make(DiscordMessage::ATTRIBUTE_CONTENT)
                     ->label(__('filament.table_actions.discord_thread.message.content.name'))
                     ->helperText(__('filament.table_actions.discord_thread.message.content.help')),
 
@@ -90,7 +90,7 @@ class DiscordEditMessageTableAction extends BaseTableAction
                             ->label(__('filament.table_actions.discord_thread.message.embeds.body.title.name'))
                             ->helperText(__('filament.table_actions.discord_thread.message.embeds.body.title.help')),
 
-                        MarkdownEditor::make(DiscordEmbed::ATTRIBUTE_DESCRIPTION)
+                        RichEditor::make(DiscordEmbed::ATTRIBUTE_DESCRIPTION)
                             ->label(__('filament.table_actions.discord_thread.message.embeds.body.description.name'))
                             ->helperText(__('filament.table_actions.discord_thread.message.embeds.body.description.help'))
                             ->required()

--- a/app/Filament/TableActions/Models/Discord/DiscordEditMessageTableAction.php
+++ b/app/Filament/TableActions/Models/Discord/DiscordEditMessageTableAction.php
@@ -77,19 +77,7 @@ class DiscordEditMessageTableAction extends BaseTableAction
                         $index = 0;
                         foreach (Arr::get($message, 'files') as $file) {
                             $set("images.item{$index}.url", $file);
-                        }
-
-                        $embedRepeater = $component->getContainer()->getComponent('embeds')->getState();
-                        $imagesRepeater = $component->getContainer()->getComponent('images')->getState();
-
-                        if (count($embedRepeater) > 1) {
-                            array_shift($embedRepeater);
-                            $set('embeds', $embedRepeater);
-                        }
-
-                        if (count($imagesRepeater) > 1) {
-                            array_shift($imagesRepeater);
-                            $set('images', $imagesRepeater);
+                            $index++;
                         }
                     }),
 
@@ -102,6 +90,7 @@ class DiscordEditMessageTableAction extends BaseTableAction
                     ->helperText(__('filament.table_actions.discord_thread.message.embeds.help'))
                     ->key('embeds')
                     ->collapsible()
+                    ->defaultItems(0)
                     ->schema([
                         TextInput::make('title')
                             ->label(__('filament.table_actions.discord_thread.message.embeds.body.title.name'))
@@ -153,6 +142,7 @@ class DiscordEditMessageTableAction extends BaseTableAction
                     ->helperText(__('filament.table_actions.discord_thread.message.images.help'))
                     ->key('images')
                     ->collapsible()
+                    ->defaultItems(0)
                     ->schema([
                         TextInput::make('url')
                             ->label(__('filament.table_actions.discord_thread.message.images.body.url.name'))

--- a/app/Filament/TableActions/Models/Discord/DiscordEditMessageTableAction.php
+++ b/app/Filament/TableActions/Models/Discord/DiscordEditMessageTableAction.php
@@ -68,7 +68,7 @@ class DiscordEditMessageTableAction extends BaseTableAction
 
                                 $component->hint(null);
 
-                                $message = (new DiscordMessageAction())->get($state)->getMessage();
+                                $message = (new DiscordMessageAction())->get($state);
 
                                 $set(DiscordMessage::ATTRIBUTE_CONTENT, Arr::get($message, DiscordMessage::ATTRIBUTE_CONTENT));
 

--- a/app/Filament/TableActions/Models/Discord/DiscordEditMessageTableAction.php
+++ b/app/Filament/TableActions/Models/Discord/DiscordEditMessageTableAction.php
@@ -57,11 +57,9 @@ class DiscordEditMessageTableAction extends BaseTableAction
                         $set('content', Arr::get($message, 'content'));
 
                         foreach (Arr::get($message, 'embeds') ?? [] as $index => $embed) {
-                            $set("embeds.item{$index}.title", Arr::get($embed, 'title'));
-                            $set("embeds.item{$index}.description", Arr::get($embed, 'description'));
-                            $set("embeds.item{$index}.color", '#' . dechex(Arr::get($embed, 'color')));
-                            $set("embeds.item{$index}.thumbnail", Arr::get($embed, 'thumbnail'));
-                            $set("embeds.item{$index}.image", Arr::get($embed, 'image'));
+                            foreach ($embed as $key => $value) {
+                                $set("embeds.item{$index}.{$key}", $key === 'color' ? '#' . dechex($value) : $value);
+                            }
 
                             foreach (Arr::get($embed, 'fields') ?? [] as $fieldIndex => $field) {
                                 foreach ($field as $key => $value) {

--- a/app/Filament/TableActions/Models/Discord/DiscordEditMessageTableAction.php
+++ b/app/Filament/TableActions/Models/Discord/DiscordEditMessageTableAction.php
@@ -64,9 +64,9 @@ class DiscordEditMessageTableAction extends BaseTableAction
                             $set("embeds.item{$index}.image", Arr::get($embed, 'image'));
 
                             foreach (Arr::get($embed, 'fields') ?? [] as $fieldIndex => $field) {
-                                $set("embeds.item{$index}.fields.{$fieldIndex}.name", Arr::get($field, 'name'));
-                                $set("embeds.item{$index}.fields.{$fieldIndex}.value", Arr::get($field, 'value'));
-                                $set("embeds.item{$index}.fields.{$fieldIndex}.inline", Arr::get($field, 'inline'));
+                                foreach ($field as $key => $value) {
+                                    $set("embeds.item{$index}.fields.{$fieldIndex}.{$key}", $value);
+                                }
                             }
                         }
 

--- a/app/Filament/TableActions/Models/Discord/DiscordSendMessageTableAction.php
+++ b/app/Filament/TableActions/Models/Discord/DiscordSendMessageTableAction.php
@@ -9,9 +9,9 @@ use App\Discord\DiscordEmbed;
 use App\Discord\DiscordMessage;
 use App\Filament\TableActions\BaseTableAction;
 use Filament\Forms\Components\Checkbox;
-use Filament\Forms\Components\ColorPicker;
-use Filament\Forms\Components\MarkdownEditor;
+use Filament\Forms\Components\ColorPicker;;
 use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\RichEditor;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
 
@@ -51,7 +51,7 @@ class DiscordSendMessageTableAction extends BaseTableAction
                     ->required()
                     ->rules(['required', 'string']),
 
-                MarkdownEditor::make(DiscordMessage::ATTRIBUTE_CONTENT)
+                RichEditor::make(DiscordMessage::ATTRIBUTE_CONTENT)
                     ->label(__('filament.table_actions.discord_thread.message.content.name'))
                     ->helperText(__('filament.table_actions.discord_thread.message.content.help')),
 
@@ -65,7 +65,7 @@ class DiscordSendMessageTableAction extends BaseTableAction
                             ->label(__('filament.table_actions.discord_thread.message.embeds.body.title.name'))
                             ->helperText(__('filament.table_actions.discord_thread.message.embeds.body.title.help')),
 
-                        MarkdownEditor::make(DiscordEmbed::ATTRIBUTE_DESCRIPTION)
+                        RichEditor::make(DiscordEmbed::ATTRIBUTE_DESCRIPTION)
                             ->label(__('filament.table_actions.discord_thread.message.embeds.body.description.name'))
                             ->helperText(__('filament.table_actions.discord_thread.message.embeds.body.description.help'))
                             ->required()

--- a/app/Filament/TableActions/Models/Discord/DiscordSendMessageTableAction.php
+++ b/app/Filament/TableActions/Models/Discord/DiscordSendMessageTableAction.php
@@ -57,6 +57,7 @@ class DiscordSendMessageTableAction extends BaseTableAction
                     ->label(__('filament.table_actions.discord_thread.message.embeds.name'))
                     ->helperText(__('filament.table_actions.discord_thread.message.embeds.help'))
                     ->collapsible()
+                    ->defaultItems(0)
                     ->schema([
                         TextInput::make('title')
                             ->label(__('filament.table_actions.discord_thread.message.embeds.body.title.name'))
@@ -107,6 +108,7 @@ class DiscordSendMessageTableAction extends BaseTableAction
                     ->label(__('filament.table_actions.discord_thread.message.images.name'))
                     ->helperText(__('filament.table_actions.discord_thread.message.images.help'))
                     ->collapsible()
+                    ->defaultItems(0)
                     ->schema([
                         TextInput::make('url')
                             ->label(__('filament.table_actions.discord_thread.message.images.body.url.name'))

--- a/app/Filament/TableActions/Models/Discord/DiscordSendMessageTableAction.php
+++ b/app/Filament/TableActions/Models/Discord/DiscordSendMessageTableAction.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Filament\TableActions\Models\Discord;
 
 use App\Actions\Discord\DiscordMessageAction;
+use App\Discord\DiscordEmbed;
+use App\Discord\DiscordMessage;
 use App\Filament\TableActions\BaseTableAction;
 use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\ColorPicker;
@@ -43,74 +45,74 @@ class DiscordSendMessageTableAction extends BaseTableAction
     {
         return $form
             ->schema([
-                TextInput::make('channelId')
+                TextInput::make(DiscordMessage::ATTRIBUTE_CHANNEL_ID)
                     ->label(__('filament.table_actions.discord_thread.message.channelId.name'))
                     ->helperText(__('filament.table_actions.discord_thread.message.channelId.help'))
                     ->required()
                     ->rules(['required', 'string']),
 
-                MarkdownEditor::make('content')
+                MarkdownEditor::make(DiscordMessage::ATTRIBUTE_CONTENT)
                     ->label(__('filament.table_actions.discord_thread.message.content.name'))
                     ->helperText(__('filament.table_actions.discord_thread.message.content.help')),
 
-                Repeater::make('embeds')
+                Repeater::make(DiscordMessage::ATTRIBUTE_EMBEDS)
                     ->label(__('filament.table_actions.discord_thread.message.embeds.name'))
                     ->helperText(__('filament.table_actions.discord_thread.message.embeds.help'))
                     ->collapsible()
                     ->defaultItems(0)
                     ->schema([
-                        TextInput::make('title')
+                        TextInput::make(DiscordEmbed::ATTRIBUTE_TITLE)
                             ->label(__('filament.table_actions.discord_thread.message.embeds.body.title.name'))
                             ->helperText(__('filament.table_actions.discord_thread.message.embeds.body.title.help')),
 
-                        MarkdownEditor::make('description')
+                        MarkdownEditor::make(DiscordEmbed::ATTRIBUTE_DESCRIPTION)
                             ->label(__('filament.table_actions.discord_thread.message.embeds.body.description.name'))
                             ->helperText(__('filament.table_actions.discord_thread.message.embeds.body.description.help'))
                             ->required()
                             ->rules(['required', 'string']),
 
-                        ColorPicker::make('color')
+                        ColorPicker::make(DiscordEmbed::ATTRIBUTE_COLOR)
                             ->label(__('filament.table_actions.discord_thread.message.embeds.body.color.name'))
                             ->helperText(__('filament.table_actions.discord_thread.message.embeds.body.color.help')),
 
-                        TextInput::make('thumbnail')
+                        TextInput::make(DiscordEmbed::ATTRIBUTE_THUMBNAIL)
                             ->label(__('filament.table_actions.discord_thread.message.embeds.body.thumbnail.name'))
                             ->helperText(__('filament.table_actions.discord_thread.message.embeds.body.thumbnail.help')),
 
-                        TextInput::make('image')
+                        TextInput::make(DiscordEmbed::ATTRIBUTE_IMAGE)
                             ->label(__('filament.table_actions.discord_thread.message.embeds.body.image.name'))
                             ->helperText(__('filament.table_actions.discord_thread.message.embeds.body.image.help')),
 
-                        Repeater::make('fields')
+                        Repeater::make(DiscordEmbed::ATTRIBUTE_FIELDS)
                             ->label(__('filament.table_actions.discord_thread.message.embeds.body.fields.title.name'))
                             ->helperText(__('filament.table_actions.discord_thread.message.embeds.body.fields.title.help'))
                             ->collapsible()
                             ->schema([
-                                TextInput::make('name')
+                                TextInput::make(DiscordEmbed::ATTRIBUTE_FIELDS_NAME)
                                     ->label(__('filament.table_actions.discord_thread.message.embeds.body.fields.name.name'))
                                     ->helperText(__('filament.table_actions.discord_thread.message.embeds.body.fields.name.help'))
                                     ->required()
                                     ->rules(['required', 'string']),
 
-                                TextInput::make('value')
+                                TextInput::make(DiscordEmbed::ATTRIBUTE_FIELDS_VALUE)
                                     ->label(__('filament.table_actions.discord_thread.message.embeds.body.fields.value.name'))
                                     ->helperText(__('filament.table_actions.discord_thread.message.embeds.body.fields.value.help'))
                                     ->required()
                                     ->rules(['required', 'string']),
 
-                                Checkbox::make('inline')
+                                Checkbox::make(DiscordEmbed::ATTRIBUTE_FIELDS_INLINE)
                                     ->label(__('filament.table_actions.discord_thread.message.embeds.body.fields.inline.name'))
                                     ->helperText(__('filament.table_actions.discord_thread.message.embeds.body.fields.inline.help')),
                             ]),
                     ]),
 
-                Repeater::make('images')
+                Repeater::make(DiscordMessage::ATTRIBUTE_IMAGES)
                     ->label(__('filament.table_actions.discord_thread.message.images.name'))
                     ->helperText(__('filament.table_actions.discord_thread.message.images.help'))
                     ->collapsible()
                     ->defaultItems(0)
                     ->schema([
-                        TextInput::make('url')
+                        TextInput::make(DiscordMessage::ATTRIBUTE_URL)
                             ->label(__('filament.table_actions.discord_thread.message.images.body.url.name'))
                             ->helperText(__('filament.table_actions.discord_thread.message.images.body.url.help'))
                             ->required()

--- a/lang/en/filament.php
+++ b/lang/en/filament.php
@@ -1025,8 +1025,10 @@ return [
                     ],
                 ],
                 'url' => [
+                    'action' => 'Load',
                     'help' => 'Click on "Copy Message Link" on Discord',
                     'name' => 'URL',
+                    'validation' => 'This is not a valid URL',
                 ],
             ],
         ],


### PR DESCRIPTION
* Added url regex validator;
* Changed from state updated to hint action;
* Changed field from markdown editor to rich editor;
* Changed from msg files to msg images;
* Default repeater items is now 0;
* Refactored discord message action;
* Using defined consts instead of loose strings;