### PR TITLE
feat(filament): actions on view page

### DIFF
--- a/app/Filament/Actions/Models/Wiki/Anime/BackfillAnimeAction.php
+++ b/app/Filament/Actions/Models/Wiki/Anime/BackfillAnimeAction.php
@@ -173,7 +173,7 @@ class BackfillAnimeAction extends Action implements ShouldQueue
 
                 Section::make(__('filament.actions.anime.backfill.fields.synonyms.name'))
                     ->schema([
-                        Checkbox::make(self::BACKFILL_STUDIOS)
+                        Checkbox::make(self::BACKFILL_SYNONYMS)
                             ->label(__('filament.actions.anime.backfill.fields.synonyms.name'))
                             ->helperText(__('filament.actions.anime.backfill.fields.synonyms.help'))
                             ->default(fn () => $anime instanceof Anime && $anime->animesynonyms()->count() === 0),

--- a/app/Filament/Components/Columns/TextColumn.php
+++ b/app/Filament/Components/Columns/TextColumn.php
@@ -42,7 +42,7 @@ class TextColumn extends ColumnsTextColumn
                     return "<p style='color: rgb(64, 184, 166);'>{$nameLimited}</p>";
                 });
 
-                return (new $resourceRelated)::getUrl('edit', ['record' => $record]);
+                return (new $resourceRelated)::getUrl('view', ['record' => $record]);
             });
     }
 

--- a/app/Filament/Components/Infolist/TextEntry.php
+++ b/app/Filament/Components/Infolist/TextEntry.php
@@ -39,7 +39,7 @@ class TextEntry extends ComponentsTextEntry
                     return "<p style='color: rgb(64, 184, 166);'>{$name}</p>";
                 });
 
-                return (new $resourceRelated)::getUrl('edit', ['record' => $record]);
+                return (new $resourceRelated)::getUrl('view', ['record' => $record]);
             });
     }
 

--- a/app/Filament/HeaderActions/Models/Wiki/Anime/BackfillAnimeHeaderAction.php
+++ b/app/Filament/HeaderActions/Models/Wiki/Anime/BackfillAnimeHeaderAction.php
@@ -29,7 +29,6 @@ use Filament\Notifications\Notification;
 use Filament\Actions\Action;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Sleep;
@@ -174,7 +173,7 @@ class BackfillAnimeHeaderAction extends Action implements ShouldQueue
 
                 Section::make(__('filament.actions.anime.backfill.fields.synonyms.name'))
                     ->schema([
-                        Checkbox::make(self::BACKFILL_STUDIOS)
+                        Checkbox::make(self::BACKFILL_SYNONYMS)
                             ->label(__('filament.actions.anime.backfill.fields.synonyms.name'))
                             ->helperText(__('filament.actions.anime.backfill.fields.synonyms.help'))
                             ->default(fn () => $anime instanceof Anime && $anime->animesynonyms()->count() === 0),

--- a/app/Filament/RelationManagers/BaseRelationManager.php
+++ b/app/Filament/RelationManagers/BaseRelationManager.php
@@ -32,6 +32,16 @@ abstract class BaseRelationManager extends RelationManager
     protected static bool $isLazy = false;
 
     /**
+     * The actions should appear in the view page.
+     * 
+     * @return bool
+     */
+    public function isReadOnly(): bool
+    {
+        return false;
+    }
+
+    /**
      * The index page of the relation resource.
      *
      * @param  Table  $table
@@ -48,7 +58,7 @@ abstract class BaseRelationManager extends RelationManager
             ->bulkActions(static::getBulkActions())
             ->headerActions(static::getHeaderActions())
             ->paginated([5, 10, 25])
-            ->defaultPaginationPageOption(5);
+            ->defaultPaginationPageOption(10);
     }
 
     /**
@@ -88,7 +98,8 @@ abstract class BaseRelationManager extends RelationManager
     {
         return [
             DetachBulkAction::make()
-                ->label(__('filament.bulk_actions.base.detach')),
+                ->label(__('filament.bulk_actions.base.detach'))
+                ->authorize('deleteany'),
         ];
     }
 
@@ -106,6 +117,7 @@ abstract class BaseRelationManager extends RelationManager
 
             AttachAction::make()
                 ->hidden(fn (BaseRelationManager $livewire) => !($livewire->getRelationship() instanceof BelongsToMany))
+                ->authorize('create')
                 ->recordSelect(function (BaseRelationManager $livewire) {
                     /** @var string */
                     $model = $livewire->getTable()->getModel();

--- a/app/Filament/RelationManagers/BaseRelationManager.php
+++ b/app/Filament/RelationManagers/BaseRelationManager.php
@@ -99,7 +99,7 @@ abstract class BaseRelationManager extends RelationManager
         return [
             DetachBulkAction::make()
                 ->label(__('filament.bulk_actions.base.detach'))
-                ->authorize('deleteany'),
+                ->authorize('forcedeleteany'),
         ];
     }
 

--- a/app/Filament/Resources/Base/BaseViewResource.php
+++ b/app/Filament/Resources/Base/BaseViewResource.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace App\Filament\Resources\Base;
 
 use Filament\Actions\EditAction;
-use Filament\Actions\ForceDeleteAction;
-use Filament\Actions\RestoreAction;
 use Filament\Resources\Pages\ViewRecord;
 
 /**
@@ -23,15 +21,14 @@ class BaseViewResource extends ViewRecord
      */
     protected function getHeaderActions(): array
     {
-        return [
-            EditAction::make()
-                ->label(__('filament.actions.base.edit')),
+        $editPage = (new static::$resource)::getPages()['edit']->getPage();
 
-            ForceDeleteAction::make()
-                ->label(__('filament.actions.base.forcedelete')),
-
-            RestoreAction::make()
-                ->label(__('filament.actions.base.restore')),
-        ];
+        return array_merge(
+            [
+                EditAction::make()
+                    ->label(__('filament.actions.base.edit')),
+            ],
+            (new $editPage)->getHeaderActions(),
+        );
     }
 }

--- a/app/Filament/Resources/BaseResource.php
+++ b/app/Filament/Resources/BaseResource.php
@@ -60,7 +60,7 @@ abstract class BaseResource extends Resource
             ->actions(static::getActions())
             ->bulkActions(static::getBulkActions())
             ->headerActions(static::getHeaderActions())
-            ->recordUrl(fn (Model $record): string => static::getUrl('edit', ['record' => $record]))
+            ->recordUrl(fn (Model $record): string => static::getUrl('view', ['record' => $record]))
             ->paginated([10, 25, 50, 100, 'all'])
             ->defaultPaginationPageOption(25);
     }
@@ -130,7 +130,8 @@ abstract class BaseResource extends Resource
             ActionGroup::make([
                 DetachAction::make()
                     ->label(__('filament.actions.base.detach'))
-                    ->hidden(fn ($livewire) => !($livewire instanceof BaseRelationManager)),
+                    ->hidden(fn ($livewire) => !($livewire instanceof BaseRelationManager))
+                    ->authorize('delete'),
 
                 DeleteAction::make()
                     ->label(__('filament.actions.base.delete')),

--- a/app/Filament/Resources/Wiki/Anime/Theme/Entry/RelationManagers/VideoEntryRelationManager.php
+++ b/app/Filament/Resources/Wiki/Anime/Theme/Entry/RelationManagers/VideoEntryRelationManager.php
@@ -94,7 +94,6 @@ class VideoEntryRelationManager extends VideoRelationManager
     {
         return array_merge(
             parent::getHeaderActions(),
-            VideoResource::getHeaderActions(),
             [],
         );
     }

--- a/tests/Feature/Http/Api/ThrottleTest.php
+++ b/tests/Feature/Http/Api/ThrottleTest.php
@@ -21,6 +21,8 @@ class ThrottleTest extends TestCase
      */
     public function testRateLimited(): void
     {
+        $this->call('GET', route('api.anime.index'), [], [], [], ['REMOTE_ADDR' => fake()->ipv4()]);
+
         $response = $this->get(route('api.anime.index'));
 
         $response->assertHeader('X-RateLimit-Limit');
@@ -28,11 +30,37 @@ class ThrottleTest extends TestCase
     }
 
     /**
+     * Client with forwarded ip shall be rate limited.
+     *
+     * @return void
+     */
+    public function testForwardedIpRateLimited(): void
+    {
+        $response = $this->withHeader('x-forwarded-ip', fake()->ipv4())->get(route('api.anime.index'));
+
+        $response->assertHeader('X-RateLimit-Limit');
+        $response->assertHeader('X-RateLimit-Remaining');
+    }
+
+    /**
+     * Client with no forwarded ip shall not be rate limited.
+     *
+     * @return void
+     */
+    public function testClientNoForwardedIpNotRateLimited(): void
+    {
+        $response = $this->get(route('api.anime.index'));
+
+        $response->assertHeaderMissing('X-RateLimit-Limit');
+        $response->assertHeaderMissing('X-RateLimit-Remaining');
+    }
+
+    /**
      * Users with the 'bypass api rate limiter' permission  shall not be rate limited.
      *
      * @return void
      */
-    public function testClientNotRateLimited(): void
+    public function testUserNotRateLimited(): void
     {
         $user = User::factory()->withPermissions(SpecialPermission::BYPASS_API_RATE_LIMITER->value)->createOne();
 

--- a/tests/Feature/Http/Api/ThrottleTest.php
+++ b/tests/Feature/Http/Api/ThrottleTest.php
@@ -15,21 +15,6 @@ use Tests\TestCase;
 class ThrottleTest extends TestCase
 {
     /**
-     * By default, the user shall be rate limited when using the API.
-     *
-     * @return void
-     */
-    public function testRateLimited(): void
-    {
-        $this->call('GET', route('api.anime.index'), [], [], [], ['REMOTE_ADDR' => fake()->ipv4()]);
-
-        $response = $this->get(route('api.anime.index'));
-
-        $response->assertHeader('X-RateLimit-Limit');
-        $response->assertHeader('X-RateLimit-Remaining');
-    }
-
-    /**
      * Client with forwarded ip shall be rate limited.
      *
      * @return void


### PR DESCRIPTION
* Added actions on view page;
* Added forwarded ip tests;
* Fixed backfill synonyms action;
* Changed redirect rows from edit to view page;
* Changed default pagination page option from 5 to 10 on relation managers;
