### PR TITLE
feat: added new way to authorize pivots

### DIFF
--- a/app/Enums/Models/List/ExternalProfileSite.php
+++ b/app/Enums/Models/List/ExternalProfileSite.php
@@ -45,7 +45,7 @@ enum ExternalProfileSite: int
         if ($this === static::MAL) {
             $codeVerifier = bin2hex(random_bytes(64));
 
-            $id = Str::uuid()->toString();
+            $id = Str::uuid()->__toString();
 
             Cache::set("mal-external-token-request-{$id}", $codeVerifier);
 

--- a/app/Filament/Actions/Base/AttachAction.php
+++ b/app/Filament/Actions/Base/AttachAction.php
@@ -40,7 +40,7 @@ class AttachAction extends DefaultAttachAction
 
             $ability = Str::of('attachAny')
                 ->append(Str::singular(class_basename($livewire->getTable()->getModel())))
-                ->toString();
+                ->__toString();
 
             return is_object($gate) & method_exists($gate, $ability)
                 ? Gate::forUser(Auth::user())->any($ability, $ownerRecord)

--- a/app/Filament/Actions/Base/CreateAction.php
+++ b/app/Filament/Actions/Base/CreateAction.php
@@ -66,7 +66,7 @@ class CreateAction extends DefaultCreateAction
 
             $ability = Str::of($method)
                 ->append(Str::singular(class_basename($livewire->getTable()->getModel())))
-                ->toString();
+                ->__toString();
 
             return is_object($gate) & method_exists($gate, $ability)
                 ? Gate::forUser(Auth::user())->any($ability, $ownerRecord)

--- a/app/Filament/Actions/Base/DetachAction.php
+++ b/app/Filament/Actions/Base/DetachAction.php
@@ -46,11 +46,11 @@ class DetachAction extends DefaultDetachAction
 
             $detachAny = Str::of('detachAny')
                 ->append($model)
-                ->toString();
+                ->__toString();
 
             $detach = Str::of('detach')
                 ->append($model)
-                ->toString();
+                ->__toString();
 
             return is_object($gate) & method_exists($gate, $detachAny)
                 ? Gate::forUser(Auth::user())->any([$detachAny, $detach], [$ownerRecord, $this->getRecord()])

--- a/app/Filament/Actions/Base/DetachAction.php
+++ b/app/Filament/Actions/Base/DetachAction.php
@@ -8,6 +8,9 @@ use App\Concerns\Filament\ActionLogs\HasPivotActionLogs;
 use App\Filament\RelationManagers\BaseRelationManager;
 use Filament\Tables\Actions\DetachAction as DefaultDetachAction;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Str;
 
 /**
  * Class DetachAction.
@@ -27,9 +30,32 @@ class DetachAction extends DefaultDetachAction
 
         $this->label(__('filament.actions.base.detach'));
 
-        $this->hidden(fn ($livewire) => !($livewire instanceof BaseRelationManager && $livewire->getRelationship() instanceof BelongsToMany));
+        $this->visible(function (mixed $livewire) {
+            if (
+                !($livewire instanceof BaseRelationManager)
+                || !($livewire->getRelationship() instanceof BelongsToMany)
+            ) {
+                return false;
+            }
 
-        $this->authorize('delete');
+            $ownerRecord = $livewire->getOwnerRecord();
+
+            $gate = Gate::getPolicyFor($ownerRecord);
+
+            $model = Str::singular(class_basename($livewire->getTable()->getModel()));
+
+            $detachAny = Str::of('detachAny')
+                ->append($model)
+                ->toString();
+
+            $detach = Str::of('detach')
+                ->append($model)
+                ->toString();
+
+            return is_object($gate) & method_exists($gate, $detachAny)
+                ? Gate::forUser(Auth::user())->any([$detachAny, $detach], [$ownerRecord, $this->getRecord()])
+                : true;
+        });
 
         $this->after(function ($livewire, $record) {
             $relationship = $livewire->getRelationship();

--- a/app/Http/Controllers/Api/Pivot/PivotController.php
+++ b/app/Http/Controllers/Api/Pivot/PivotController.php
@@ -8,6 +8,7 @@ use App\Contracts\Http\Api\InteractsWithSchema;
 use App\Http\Api\Schema\Schema;
 use App\Http\Controllers\Controller;
 use App\Http\Middleware\Auth\Authenticate;
+use App\Http\Middleware\Models\AuthorizesPivot;
 use Illuminate\Support\Str;
 
 /**
@@ -25,8 +26,9 @@ abstract class PivotController extends Controller implements InteractsWithSchema
      */
     public function __construct(string $foreignModel, string $foreignParameter, string $relatedModel, string $relatedParameter)
     {
-        $this->authorizeResource($foreignModel, $foreignParameter);
-        $this->authorizeResource($relatedModel, $relatedParameter);
+        $this->middleware(AuthorizesPivot::class.":{$foreignParameter},{$relatedParameter}")->only(['store', 'destroy']);
+        //$this->authorizeResource($foreignModel, $foreignParameter);
+        //$this->authorizeResource($relatedModel, $relatedParameter);
         $this->middleware(Authenticate::using('sanctum'))->except(['index', 'show']);
     }
 

--- a/app/Http/Controllers/Api/Pivot/PivotController.php
+++ b/app/Http/Controllers/Api/Pivot/PivotController.php
@@ -26,10 +26,8 @@ abstract class PivotController extends Controller implements InteractsWithSchema
      */
     public function __construct(string $foreignModel, string $foreignParameter, string $relatedModel, string $relatedParameter)
     {
-        /** @phpstan-ignore-unused $foreignModel */
-        /** @phpstan-ignore-unused $relatedModel */
-        $this->middleware(AuthorizesPivot::class.":{$foreignParameter},{$relatedParameter}");
-        //$this->authorizeResource($foreignModel, $foreignParameter);
+        $this->middleware(AuthorizesPivot::class.":{$foreignModel},{$foreignParameter},{$relatedModel},{$relatedParameter}");
+        $this->authorizeResource($foreignModel, $foreignParameter);
         //$this->authorizeResource($relatedModel, $relatedParameter);
         $this->middleware(Authenticate::using('sanctum'))->except(['index', 'show']);
     }

--- a/app/Http/Controllers/Api/Pivot/PivotController.php
+++ b/app/Http/Controllers/Api/Pivot/PivotController.php
@@ -28,7 +28,7 @@ abstract class PivotController extends Controller implements InteractsWithSchema
     {
         /** @phpstan-ignore-unused $foreignModel */
         /** @phpstan-ignore-unused $relatedModel */
-        $this->middleware(AuthorizesPivot::class.":{$foreignParameter},{$relatedParameter}")->except('index');
+        $this->middleware(AuthorizesPivot::class.":{$foreignParameter},{$relatedParameter}");
         //$this->authorizeResource($foreignModel, $foreignParameter);
         //$this->authorizeResource($relatedModel, $relatedParameter);
         $this->middleware(Authenticate::using('sanctum'))->except(['index', 'show']);

--- a/app/Http/Controllers/Api/Pivot/PivotController.php
+++ b/app/Http/Controllers/Api/Pivot/PivotController.php
@@ -27,8 +27,6 @@ abstract class PivotController extends Controller implements InteractsWithSchema
     public function __construct(string $foreignModel, string $foreignParameter, string $relatedModel, string $relatedParameter)
     {
         $this->middleware(AuthorizesPivot::class.":{$foreignModel},{$foreignParameter},{$relatedModel},{$relatedParameter}");
-        $this->authorizeResource($foreignModel, $foreignParameter);
-        //$this->authorizeResource($relatedModel, $relatedParameter);
         $this->middleware(Authenticate::using('sanctum'))->except(['index', 'show']);
     }
 

--- a/app/Http/Controllers/Api/Pivot/PivotController.php
+++ b/app/Http/Controllers/Api/Pivot/PivotController.php
@@ -26,7 +26,7 @@ abstract class PivotController extends Controller implements InteractsWithSchema
      */
     public function __construct(string $foreignModel, string $foreignParameter, string $relatedModel, string $relatedParameter)
     {
-        $this->middleware(AuthorizesPivot::class.":{$foreignParameter},{$relatedParameter}")->only(['store', 'destroy']);
+        $this->middleware(AuthorizesPivot::class.":{$foreignParameter},{$relatedParameter}")->only(['store', 'destroy', 'update']);
         //$this->authorizeResource($foreignModel, $foreignParameter);
         //$this->authorizeResource($relatedModel, $relatedParameter);
         $this->middleware(Authenticate::using('sanctum'))->except(['index', 'show']);

--- a/app/Http/Controllers/Api/Pivot/PivotController.php
+++ b/app/Http/Controllers/Api/Pivot/PivotController.php
@@ -26,8 +26,10 @@ abstract class PivotController extends Controller implements InteractsWithSchema
      */
     public function __construct(string $foreignModel, string $foreignParameter, string $relatedModel, string $relatedParameter)
     {
+        /** @phpstan-ignore-unused $foreignModel */
+        /** @phpstan-ignore-unused $relatedModel */
         $this->middleware(AuthorizesPivot::class.":{$foreignParameter},{$relatedParameter}")->except('index');
-        $this->authorizeResource($foreignModel, $foreignParameter);
+        //$this->authorizeResource($foreignModel, $foreignParameter);
         //$this->authorizeResource($relatedModel, $relatedParameter);
         $this->middleware(Authenticate::using('sanctum'))->except(['index', 'show']);
     }

--- a/app/Http/Controllers/Api/Pivot/PivotController.php
+++ b/app/Http/Controllers/Api/Pivot/PivotController.php
@@ -26,7 +26,7 @@ abstract class PivotController extends Controller implements InteractsWithSchema
      */
     public function __construct(string $foreignModel, string $foreignParameter, string $relatedModel, string $relatedParameter)
     {
-        $this->middleware(AuthorizesPivot::class.":{$foreignParameter},{$relatedParameter}")->only(['store', 'destroy', 'update']);
+        $this->middleware(AuthorizesPivot::class.":{$foreignParameter},{$relatedParameter}")->except('index');
         //$this->authorizeResource($foreignModel, $foreignParameter);
         //$this->authorizeResource($relatedModel, $relatedParameter);
         $this->middleware(Authenticate::using('sanctum'))->except(['index', 'show']);

--- a/app/Http/Controllers/Api/Pivot/PivotController.php
+++ b/app/Http/Controllers/Api/Pivot/PivotController.php
@@ -27,7 +27,7 @@ abstract class PivotController extends Controller implements InteractsWithSchema
     public function __construct(string $foreignModel, string $foreignParameter, string $relatedModel, string $relatedParameter)
     {
         $this->middleware(AuthorizesPivot::class.":{$foreignParameter},{$relatedParameter}")->except('index');
-        //$this->authorizeResource($foreignModel, $foreignParameter);
+        $this->authorizeResource($foreignModel, $foreignParameter);
         //$this->authorizeResource($relatedModel, $relatedParameter);
         $this->middleware(Authenticate::using('sanctum'))->except(['index', 'show']);
     }

--- a/app/Http/Middleware/LogRequest.php
+++ b/app/Http/Middleware/LogRequest.php
@@ -24,7 +24,7 @@ class LogRequest
      */
     public function handle(Request $request, Closure $next): mixed
     {
-        $requestId = Str::uuid()->toString();
+        $requestId = Str::uuid()->__toString();
 
         Log::withContext([
             'request-id' => $requestId,

--- a/app/Http/Middleware/Models/AuthorizesPivot.php
+++ b/app/Http/Middleware/Models/AuthorizesPivot.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware\Models;
+
+use App\Models\Auth\User;
+use Closure;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Str;
+
+/**
+ * AuthorizesPivot
+ */
+class AuthorizesPivot
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Request  $request
+     * @param  Closure(Request): mixed  $next
+     * @param  string  $foreignParameter
+     * @param  string  $relatedParameter
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next, string $foreignParameter, string $relatedParameter): mixed
+    {
+        /** @var Model $foreignModel */
+        $foreignModel = $request->route($foreignParameter);
+
+        /** @var Model $relatedModel */
+        $relatedModel = $request->route($relatedParameter);
+
+        $isAuthorized = match ($request->route()->getActionMethod()) {
+            'store' => $this->forStore($request->user(), $foreignModel, $relatedModel),
+            'destroy' => $this->forDestroy($request->user(), $foreignModel, $relatedModel),
+        };
+
+        if (!$isAuthorized) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+
+    /**
+     * Get the authorization to store a pivot.
+     *
+     * @param  User  $user
+     * @param  Model  $foreignModel
+     * @param  Model  $relatedModel
+     * @return bool
+     */
+    protected function forStore(User $user, Model $foreignModel, Model $relatedModel): bool
+    {
+        $attach = Str::of('attach')
+            ->append(Str::singular(class_basename($relatedModel)))
+            ->toString();
+
+        return Gate::forUser($user)->check($attach, [$foreignModel, $relatedModel]);
+    }
+
+    /**
+     * Get the authorization to destroy a pivot.
+     *
+     * @param  User  $user
+     * @param  Model  $foreignModel
+     * @param  Model  $relatedModel
+     * @return bool
+     */
+    protected function forDestroy(User $user, Model $foreignModel, Model $relatedModel): bool
+    {
+        $detachAny = Str::of('detachAny')
+            ->append(Str::singular(class_basename($relatedModel)))
+            ->__toString();
+
+        $detach = Str::of('detach')
+            ->append(Str::singular(class_basename($relatedModel)))
+            ->__toString();
+
+        return Gate::forUser($user)->any([$detach, $detachAny], $foreignModel);
+    }
+}

--- a/app/Http/Middleware/Models/AuthorizesPivot.php
+++ b/app/Http/Middleware/Models/AuthorizesPivot.php
@@ -21,11 +21,13 @@ class AuthorizesPivot
      *
      * @param  Request  $request
      * @param  Closure(Request): mixed  $next
+     * @param  string  $foreignClass
      * @param  string  $foreignParameter
+     * @param  string  $relatedClass
      * @param  string  $relatedParameter
      * @return mixed
      */
-    public function handle(Request $request, Closure $next, string $foreignParameter, string $relatedParameter): mixed
+    public function handle(Request $request, Closure $next, string $foreignClass, string $foreignParameter, string $relatedClass, string $relatedParameter): mixed
     {
         /** @var Model $foreignModel */
         $foreignModel = $request->route($foreignParameter);
@@ -34,11 +36,11 @@ class AuthorizesPivot
         $relatedModel = $request->route($relatedParameter);
 
         $isAuthorized = match ($request->route()->getActionMethod()) {
-            'index' => $this->forIndex($request->user(), $foreignModel, $relatedModel),
+            'index' => $this->forIndex($request->user(), $foreignClass, $relatedClass),
             'show' => $this->forShow($request->user(), $foreignModel, $relatedModel),
-            'store' => $this->forStore($request->user(), $foreignModel, $relatedModel),
+            'create', 'store' => $this->forStore($request->user(), $foreignModel, $relatedModel),
             'destroy' => $this->forDestroy($request->user(), $foreignModel, $relatedModel),
-            'update' => $this->forUpdate($request->user(), $foreignModel, $relatedModel),
+            'edit', 'update' => $this->forUpdate($request->user(), $foreignModel, $relatedModel),
             default => false,
         };
 
@@ -53,14 +55,14 @@ class AuthorizesPivot
      * Get the authorization to index.
      *
      * @param  User|null  $user
-     * @param  Model  $foreignModel
-     * @param  Model  $relatedModel
+     * @param  string  $foreignClass
+     * @param  string  $relatedClass
      * @return bool
      */
-    protected function forIndex(?User $user, Model $foreignModel, Model $relatedModel): bool
+    protected function forIndex(?User $user, string $foreignClass, string $relatedClass): bool
     {
-        return Gate::forUser($user)->check('viewAny', $foreignModel)
-            && Gate::forUser($user)->check('viewAny', $relatedModel);
+        return Gate::forUser($user)->check('viewAny', $foreignClass)
+            && Gate::forUser($user)->check('viewAny', $relatedClass);
     }
 
     /**

--- a/app/Http/Middleware/Models/AuthorizesPivot.php
+++ b/app/Http/Middleware/Models/AuthorizesPivot.php
@@ -34,6 +34,7 @@ class AuthorizesPivot
         $relatedModel = $request->route($relatedParameter);
 
         $isAuthorized = match ($request->route()->getActionMethod()) {
+            'index' => $this->forIndex($request->user(), $foreignModel, $relatedModel),
             'show' => $this->forShow($request->user(), $foreignModel, $relatedModel),
             'store' => $this->forStore($request->user(), $foreignModel, $relatedModel),
             'destroy' => $this->forDestroy($request->user(), $foreignModel, $relatedModel),
@@ -46,6 +47,20 @@ class AuthorizesPivot
         }
 
         return $next($request);
+    }
+
+    /**
+     * Get the authorization to index.
+     *
+     * @param  User|null  $user
+     * @param  Model  $foreignModel
+     * @param  Model  $relatedModel
+     * @return bool
+     */
+    protected function forIndex(?User $user, Model $foreignModel, Model $relatedModel): bool
+    {
+        return Gate::forUser($user)->check('viewAny', $foreignModel)
+            && Gate::forUser($user)->check('viewAny', $relatedModel);
     }
 
     /**

--- a/app/Http/Middleware/Models/AuthorizesPivot.php
+++ b/app/Http/Middleware/Models/AuthorizesPivot.php
@@ -36,6 +36,8 @@ class AuthorizesPivot
         $isAuthorized = match ($request->route()->getActionMethod()) {
             'store' => $this->forStore($request->user(), $foreignModel, $relatedModel),
             'destroy' => $this->forDestroy($request->user(), $foreignModel, $relatedModel),
+            'update' => $this->forUpdate($request->user(), $foreignModel, $relatedModel),
+            default => false,
         };
 
         if (!$isAuthorized) {
@@ -81,5 +83,19 @@ class AuthorizesPivot
             ->__toString();
 
         return Gate::forUser($user)->any([$detach, $detachAny], $foreignModel);
+    }
+
+    /**
+     * Get the authorization to update a pivot.
+     *
+     * @param  User  $user
+     * @param  Model  $foreignModel
+     * @param  Model  $relatedModel
+     * @return bool
+     */
+    protected function forUpdate(User $user, Model $foreignModel, Model $relatedModel): bool
+    {
+        return Gate::forUser($user)->check('update', $foreignModel)
+            && Gate::forUser($user)->check('update', $relatedModel);
     }
 }

--- a/app/Http/Middleware/Models/AuthorizesPivot.php
+++ b/app/Http/Middleware/Models/AuthorizesPivot.php
@@ -91,7 +91,7 @@ class AuthorizesPivot
     {
         $attach = Str::of('attach')
             ->append(Str::singular(class_basename($relatedModel)))
-            ->toString();
+            ->__toString();
 
         return Gate::forUser($user)->check($attach, [$foreignModel, $relatedModel]);
     }

--- a/app/Http/Middleware/Models/AuthorizesPivot.php
+++ b/app/Http/Middleware/Models/AuthorizesPivot.php
@@ -34,6 +34,7 @@ class AuthorizesPivot
         $relatedModel = $request->route($relatedParameter);
 
         $isAuthorized = match ($request->route()->getActionMethod()) {
+            'show' => $this->forShow($request->user(), $foreignModel, $relatedModel),
             'store' => $this->forStore($request->user(), $foreignModel, $relatedModel),
             'destroy' => $this->forDestroy($request->user(), $foreignModel, $relatedModel),
             'update' => $this->forUpdate($request->user(), $foreignModel, $relatedModel),
@@ -45,6 +46,20 @@ class AuthorizesPivot
         }
 
         return $next($request);
+    }
+
+    /**
+     * Get the authorization to show a pivot.
+     *
+     * @param  User  $user
+     * @param  Model  $foreignModel
+     * @param  Model  $relatedModel
+     * @return bool
+     */
+    protected function forShow(User $user, Model $foreignModel, Model $relatedModel): bool
+    {
+        return Gate::forUser($user)->check('view', $foreignModel)
+            && Gate::forUser($user)->check('view', $relatedModel);
     }
 
     /**

--- a/app/Http/Middleware/Models/AuthorizesPivot.php
+++ b/app/Http/Middleware/Models/AuthorizesPivot.php
@@ -51,12 +51,12 @@ class AuthorizesPivot
     /**
      * Get the authorization to show a pivot.
      *
-     * @param  User  $user
+     * @param  User|null  $user
      * @param  Model  $foreignModel
      * @param  Model  $relatedModel
      * @return bool
      */
-    protected function forShow(User $user, Model $foreignModel, Model $relatedModel): bool
+    protected function forShow(?User $user, Model $foreignModel, Model $relatedModel): bool
     {
         return Gate::forUser($user)->check('view', $foreignModel)
             && Gate::forUser($user)->check('view', $relatedModel);

--- a/app/Http/Middleware/Models/AuthorizesPivot.php
+++ b/app/Http/Middleware/Models/AuthorizesPivot.php
@@ -12,7 +12,7 @@ use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Str;
 
 /**
- * AuthorizesPivot
+ * Class AuthorizesPivot.
  */
 class AuthorizesPivot
 {

--- a/app/Policies/Auth/PermissionPolicy.php
+++ b/app/Policies/Auth/PermissionPolicy.php
@@ -104,6 +104,16 @@ class PermissionPolicy extends BasePolicy
     }
 
     /**
+     * Determine whether the user can detach any role from the permission.
+     *
+     * @return bool
+     */
+    public function detachAnyRole(): bool
+    {
+        return false;
+    }
+
+    /**
      * Determine whether the user can detach a role from the permission.
      *
      * @return bool
@@ -129,6 +139,16 @@ class PermissionPolicy extends BasePolicy
      * @return bool
      */
     public function attachUser(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can detach any user from the permission.
+     *
+     * @return bool
+     */
+    public function detachAnyUser(): bool
     {
         return false;
     }

--- a/app/Policies/Auth/RolePolicy.php
+++ b/app/Policies/Auth/RolePolicy.php
@@ -45,7 +45,7 @@ class RolePolicy extends BasePolicy
      * @param  User  $user
      * @param  Role  $role
      * @return bool
-     * 
+     *
      * @noinspection PhpUnusedParameterInspection
      */
     public function update(User $user, Model $role): bool
@@ -59,7 +59,7 @@ class RolePolicy extends BasePolicy
      * @param  User  $user
      * @param  Role  $role
      * @return bool
-     * 
+     *
      * @noinspection PhpUnusedParameterInspection
      */
     public function delete(User $user, Model $role): bool
@@ -73,7 +73,7 @@ class RolePolicy extends BasePolicy
      * @param  User  $user
      * @param  Role  $role
      * @return bool
-     * 
+     *
      * @noinspection PhpUnusedParameterInspection
      */
     public function restore(User $user, Model $role): bool
@@ -97,6 +97,16 @@ class RolePolicy extends BasePolicy
      * @return bool
      */
     public function attachPermission(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can detach any permission from the role.
+     *
+     * @return bool
+     */
+    public function detachAnyPermission(): bool
     {
         return false;
     }
@@ -127,6 +137,16 @@ class RolePolicy extends BasePolicy
      * @return bool
      */
     public function attachUser(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can detach any user from the role.
+     *
+     * @return bool
+     */
+    public function detachAnyUser(): bool
     {
         return false;
     }

--- a/app/Policies/Auth/UserPolicy.php
+++ b/app/Policies/Auth/UserPolicy.php
@@ -33,7 +33,7 @@ class UserPolicy extends BasePolicy
      * @param  User|null  $user
      * @param  User  $userModel
      * @return bool
-     * 
+     *
      * @noinspection PhpUnusedParameterInspection
      */
     public function view(?User $user, Model $userModel): bool
@@ -47,7 +47,7 @@ class UserPolicy extends BasePolicy
      * @param  User  $user
      * @param  User  $userModel
      * @return bool
-     * 
+     *
      * @noinspection PhpUnusedParameterInspection
      */
     public function update(User $user, Model $userModel): bool
@@ -61,7 +61,7 @@ class UserPolicy extends BasePolicy
      * @param  User  $user
      * @param  User  $userModel
      * @return bool
-     * 
+     *
      * @noinspection PhpUnusedParameterInspection
      */
     public function delete(User $user, Model $userModel): bool
@@ -75,7 +75,7 @@ class UserPolicy extends BasePolicy
      * @param  User  $user
      * @param  User  $userModel
      * @return bool
-     * 
+     *
      * @noinspection PhpUnusedParameterInspection
      */
     public function restore(User $user, Model $userModel): bool
@@ -99,6 +99,16 @@ class UserPolicy extends BasePolicy
      * @return bool
      */
     public function attachRole(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can detach any role from the user.
+     *
+     * @return bool
+     */
+    public function detachAnyRole(): bool
     {
         return false;
     }
@@ -129,6 +139,16 @@ class UserPolicy extends BasePolicy
      * @return bool
      */
     public function attachPermission(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can detach any permission from the user.
+     *
+     * @return bool
+     */
+    public function detachAnyPermission(): bool
     {
         return false;
     }

--- a/app/Policies/BasePolicy.php
+++ b/app/Policies/BasePolicy.php
@@ -15,6 +15,9 @@ use Illuminate\Support\Str;
 
 /**
  * Class BasePolicy.
+ *
+ * Filament and API will read any attach{model}, attachAny{model}, detach{model}, detachAny{model}
+ * to make the validation for pivots. {model} must be the name of the model.
  */
 abstract class BasePolicy
 {

--- a/app/Policies/List/External/ExternalEntryPolicy.php
+++ b/app/Policies/List/External/ExternalEntryPolicy.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Policies\List\External;
 
 use App\Enums\Auth\CrudPermission;
+use App\Enums\Auth\Role;
 use App\Enums\Models\List\ExternalProfileVisibility;
 use App\Models\Auth\User;
 use App\Models\BaseModel;
@@ -28,7 +29,7 @@ class ExternalEntryPolicy extends BasePolicy
     public function viewAny(?User $user): bool
     {
         if (Filament::isServing()) {
-            return $user !== null && $user->hasRole('Admin');
+            return $user !== null && $user->hasRole(Role::ADMIN->value);
         }
 
         /** @var ExternalProfile|null $profile */
@@ -51,7 +52,7 @@ class ExternalEntryPolicy extends BasePolicy
     public function view(?User $user, BaseModel|Model $entry): bool
     {
         if (Filament::isServing()) {
-            return $user !== null && $user->hasRole('Admin');
+            return $user !== null && $user->hasRole(Role::ADMIN->value);
         }
 
         /** @var ExternalProfile|null $profile */
@@ -71,7 +72,7 @@ class ExternalEntryPolicy extends BasePolicy
     public function create(User $user): bool
     {
         if (Filament::isServing()) {
-            return $user->hasRole('Admin');
+            return $user->hasRole(Role::ADMIN->value);
         }
 
         /** @var ExternalProfile|null $profile */
@@ -92,7 +93,7 @@ class ExternalEntryPolicy extends BasePolicy
     public function update(User $user, BaseModel|Model $entry): bool
     {
         if (Filament::isServing()) {
-            return $user->hasRole('Admin');
+            return $user->hasRole(Role::ADMIN->value);
         }
 
         /** @var ExternalProfile|null $profile */
@@ -113,7 +114,7 @@ class ExternalEntryPolicy extends BasePolicy
     public function delete(User $user, BaseModel|Model $entry): bool
     {
         if (Filament::isServing()) {
-            return $user->hasRole('Admin');
+            return $user->hasRole(Role::ADMIN->value);
         }
 
         /** @var ExternalProfile|null $profile */
@@ -134,7 +135,7 @@ class ExternalEntryPolicy extends BasePolicy
     public function restore(User $user, BaseModel|Model $entry): bool
     {
         if (Filament::isServing()) {
-            return $user->hasRole('Admin');
+            return $user->hasRole(Role::ADMIN->value);
         }
 
         /** @var ExternalProfile|null $profile */

--- a/app/Policies/List/ExternalProfilePolicy.php
+++ b/app/Policies/List/ExternalProfilePolicy.php
@@ -6,6 +6,7 @@ namespace App\Policies\List;
 
 use App\Enums\Auth\CrudPermission;
 use App\Enums\Auth\ExtendedCrudPermission;
+use App\Enums\Auth\Role;
 use App\Enums\Models\List\ExternalProfileVisibility;
 use App\Models\Auth\User;
 use App\Models\BaseModel;
@@ -28,7 +29,7 @@ class ExternalProfilePolicy extends BasePolicy
     public function viewAny(?User $user): bool
     {
         if (Filament::isServing()) {
-            return $user !== null && $user->hasRole('Admin');
+            return $user !== null && $user->hasRole(Role::ADMIN->value);
         }
 
         return $user === null || $user->can(CrudPermission::VIEW->format(ExternalProfile::class));
@@ -44,7 +45,7 @@ class ExternalProfilePolicy extends BasePolicy
     public function view(?User $user, BaseModel|Model $profile): bool
     {
         if (Filament::isServing()) {
-            return $user !== null && $user->hasRole('Admin');
+            return $user !== null && $user->hasRole(Role::ADMIN->value);
         }
 
         return $user !== null
@@ -61,7 +62,7 @@ class ExternalProfilePolicy extends BasePolicy
     public function create(User $user): bool
     {
         if (Filament::isServing()) {
-            return $user->hasRole('Admin');
+            return $user->hasRole(Role::ADMIN->value);
         }
 
         return $user->can(CrudPermission::CREATE->format(ExternalProfile::class));
@@ -77,7 +78,7 @@ class ExternalProfilePolicy extends BasePolicy
     public function update(User $user, BaseModel|Model $profile): bool
     {
         if (Filament::isServing()) {
-            return $user->hasRole('Admin');
+            return $user->hasRole(Role::ADMIN->value);
         }
 
         return !$profile->trashed() && $user->getKey() === $profile->user_id && $user->can(CrudPermission::UPDATE->format(ExternalProfile::class));
@@ -93,7 +94,7 @@ class ExternalProfilePolicy extends BasePolicy
     public function delete(User $user, BaseModel|Model $profile): bool
     {
         if (Filament::isServing()) {
-            return $user->hasRole('Admin');
+            return $user->hasRole(Role::ADMIN->value);
         }
 
         return !$profile->trashed() && $user->getKey() === $profile->user_id && $user->can(CrudPermission::DELETE->format(ExternalProfile::class));
@@ -109,7 +110,7 @@ class ExternalProfilePolicy extends BasePolicy
     public function restore(User $user, BaseModel|Model $profile): bool
     {
         if (Filament::isServing()) {
-            return $user->hasRole('Admin');
+            return $user->hasRole(Role::ADMIN->value);
         }
 
         return $profile->trashed() && $user->getKey() === $profile->user_id && $user->can(ExtendedCrudPermission::RESTORE->format(ExternalProfile::class));
@@ -121,8 +122,8 @@ class ExternalProfilePolicy extends BasePolicy
      * @param  User  $user
      * @return bool
      */
-    public function addEntry(User $user): bool
+    public function addExternalEntry(User $user): bool
     {
-        return $user->hasRole('Admin');
+        return $user->hasRole(Role::ADMIN->value);
     }
 }

--- a/app/Policies/List/PlaylistPolicy.php
+++ b/app/Policies/List/PlaylistPolicy.php
@@ -124,7 +124,7 @@ class PlaylistPolicy extends BasePolicy
      * @param  User  $user
      * @return bool
      */
-    public function addTrack(User $user): bool
+    public function addPlaylistTrack(User $user): bool
     {
         return $user->hasRole(RoleEnum::ADMIN->value);
     }
@@ -151,21 +151,39 @@ class PlaylistPolicy extends BasePolicy
     public function attachImage(User $user, Playlist $playlist, Image $image): bool
     {
         $attached = PlaylistImage::query()
-            ->where($image->getKeyName(), $image->getKey())
-            ->where($playlist->getKeyName(), $playlist->getKey())
+            ->where(PlaylistImage::ATTRIBUTE_PLAYLIST, $playlist->getKey())
+            ->where(PlaylistImage::ATTRIBUTE_IMAGE, $image->getKey())
             ->exists();
 
         return !$attached && $user->hasRole(RoleEnum::ADMIN->value);
     }
 
     /**
-     * Determine whether the user can detach an image from the playlist.
+     * Determine whether the user can detach any image from the playlist.
      *
      * @param  User  $user
      * @return bool
      */
-    public function detachImage(User $user): bool
+    public function detachAnyImage(User $user): bool
     {
         return $user->hasRole(RoleEnum::ADMIN->value);
+    }
+
+    /**
+     * Determine whether the user can detach an image from the playlist.
+     *
+     * @param  User  $user
+     * @param  Playlist  $playlist
+     * @param  Image  $image
+     * @return bool
+     */
+    public function detachImage(User $user, Playlist $playlist, Image $image): bool
+    {
+        $attached = PlaylistImage::query()
+            ->where(PlaylistImage::ATTRIBUTE_PLAYLIST, $playlist->getKey())
+            ->where(PlaylistImage::ATTRIBUTE_IMAGE, $image->getKey())
+            ->exists();
+
+        return $attached && $user->hasRole(RoleEnum::ADMIN->value);
     }
 }

--- a/app/Policies/Wiki/Anime/AnimeThemePolicy.php
+++ b/app/Policies/Wiki/Anime/AnimeThemePolicy.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace App\Policies\Wiki\Anime;
 
+use App\Enums\Auth\CrudPermission;
+use App\Models\Auth\User;
+use App\Models\Wiki\Anime\AnimeTheme;
 use App\Policies\BasePolicy;
 
 /**
@@ -11,4 +14,14 @@ use App\Policies\BasePolicy;
  */
 class AnimeThemePolicy extends BasePolicy
 {
+    /**
+     * Determine whether the user can add a entry to the theme.
+     *
+     * @param  User  $user
+     * @return bool
+     */
+    public function addAnyAnimeThemeEntry(User $user): bool
+    {
+        return $user->can(CrudPermission::UPDATE->format(AnimeTheme::class));
+    }
 }

--- a/app/Policies/Wiki/Anime/AnimeThemePolicy.php
+++ b/app/Policies/Wiki/Anime/AnimeThemePolicy.php
@@ -6,7 +6,7 @@ namespace App\Policies\Wiki\Anime;
 
 use App\Enums\Auth\CrudPermission;
 use App\Models\Auth\User;
-use App\Models\Wiki\Anime\AnimeTheme;
+use App\Models\Wiki\Anime\Theme\AnimeThemeEntry;
 use App\Policies\BasePolicy;
 
 /**
@@ -22,6 +22,6 @@ class AnimeThemePolicy extends BasePolicy
      */
     public function addAnyAnimeThemeEntry(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(AnimeTheme::class));
+        return $user->can(CrudPermission::UPDATE->format(AnimeThemeEntry::class));
     }
 }

--- a/app/Policies/Wiki/Anime/Theme/AnimeThemeEntryPolicy.php
+++ b/app/Policies/Wiki/Anime/Theme/AnimeThemeEntryPolicy.php
@@ -31,15 +31,15 @@ class AnimeThemeEntryPolicy extends BasePolicy
      * Determine whether the user can attach an entry to the video.
      *
      * @param  User  $user
-     * @param  Video  $video
      * @param  AnimeThemeEntry  $entry
+     * @param  Video  $video
      * @return bool
      */
-    public function attachVideo(User $user, Video $video, AnimeThemeEntry $entry): bool
+    public function attachVideo(User $user, AnimeThemeEntry $entry, Video $video): bool
     {
         $attached = AnimeThemeEntryVideo::query()
-            ->where(AnimeThemeEntryVideo::ATTRIBUTE_VIDEO, $video->getKey())
             ->where(AnimeThemeEntryVideo::ATTRIBUTE_ENTRY, $entry->getKey())
+            ->where(AnimeThemeEntryVideo::ATTRIBUTE_VIDEO, $video->getKey())
             ->exists();
 
         return !$attached

--- a/app/Policies/Wiki/Anime/Theme/AnimeThemeEntryPolicy.php
+++ b/app/Policies/Wiki/Anime/Theme/AnimeThemeEntryPolicy.php
@@ -7,6 +7,8 @@ namespace App\Policies\Wiki\Anime\Theme;
 use App\Enums\Auth\CrudPermission;
 use App\Models\Auth\User;
 use App\Models\Wiki\Anime\Theme\AnimeThemeEntry;
+use App\Models\Wiki\Video;
+use App\Pivots\Wiki\AnimeThemeEntryVideo;
 use App\Policies\BasePolicy;
 
 /**
@@ -22,7 +24,27 @@ class AnimeThemeEntryPolicy extends BasePolicy
      */
     public function attachAnyVideo(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(AnimeThemeEntry::class));
+        return $user->can(CrudPermission::CREATE->format(AnimeThemeEntry::class)) && $user->can(CrudPermission::CREATE->format(Video::class));
+    }
+
+    /**
+     * Determine whether the user can attach an entry to the video.
+     *
+     * @param  User  $user
+     * @param  Video  $video
+     * @param  AnimeThemeEntry  $entry
+     * @return bool
+     */
+    public function attachVideo(User $user, Video $video, AnimeThemeEntry $entry): bool
+    {
+        $attached = AnimeThemeEntryVideo::query()
+            ->where(AnimeThemeEntryVideo::ATTRIBUTE_VIDEO, $video->getKey())
+            ->where(AnimeThemeEntryVideo::ATTRIBUTE_ENTRY, $entry->getKey())
+            ->exists();
+
+        return !$attached
+            && $user->can(CrudPermission::CREATE->format(AnimeThemeEntry::class))
+            && $user->can(CrudPermission::CREATE->format(Video::class));
     }
 
     /**
@@ -33,17 +55,6 @@ class AnimeThemeEntryPolicy extends BasePolicy
      */
     public function detachAnyVideo(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(AnimeThemeEntry::class));
-    }
-
-    /**
-     * Determine whether the user can detach a video from the entry.
-     *
-     * @param  User  $user
-     * @return bool
-     */
-    public function detachVideo(User $user): bool
-    {
-        return $user->can(CrudPermission::UPDATE->format(AnimeThemeEntry::class));
+        return $user->can(CrudPermission::DELETE->format(AnimeThemeEntry::class)) && $user->can(CrudPermission::DELETE->format(Video::class));
     }
 }

--- a/app/Policies/Wiki/Anime/Theme/AnimeThemeEntryPolicy.php
+++ b/app/Policies/Wiki/Anime/Theme/AnimeThemeEntryPolicy.php
@@ -7,8 +7,6 @@ namespace App\Policies\Wiki\Anime\Theme;
 use App\Enums\Auth\CrudPermission;
 use App\Models\Auth\User;
 use App\Models\Wiki\Anime\Theme\AnimeThemeEntry;
-use App\Models\Wiki\Video;
-use App\Pivots\Wiki\AnimeThemeEntryVideo;
 use App\Policies\BasePolicy;
 
 /**
@@ -28,21 +26,14 @@ class AnimeThemeEntryPolicy extends BasePolicy
     }
 
     /**
-     * Determine whether the user can attach a video to the entry.
+     * Determine whether the user can detach any video from the entry.
      *
      * @param  User  $user
-     * @param  AnimeThemeEntry  $entry
-     * @param  Video  $video
      * @return bool
      */
-    public function attachVideo(User $user, AnimeThemeEntry $entry, Video $video): bool
+    public function detachAnyVideo(User $user): bool
     {
-        $attached = AnimeThemeEntryVideo::query()
-            ->where($entry->getKeyName(), $entry->getKey())
-            ->where($video->getKeyName(), $video->getKey())
-            ->exists();
-
-        return !$attached && $user->can(CrudPermission::UPDATE->format(AnimeThemeEntry::class));
+        return $user->can(CrudPermission::UPDATE->format(AnimeThemeEntry::class));
     }
 
     /**

--- a/app/Policies/Wiki/AnimePolicy.php
+++ b/app/Policies/Wiki/AnimePolicy.php
@@ -8,6 +8,8 @@ use App\Enums\Auth\CrudPermission;
 use App\Enums\Auth\Role;
 use App\Models\Auth\User;
 use App\Models\Wiki\Anime;
+use App\Models\Wiki\Anime\AnimeSynonym;
+use App\Models\Wiki\Anime\AnimeTheme;
 use App\Models\Wiki\ExternalResource;
 use App\Models\Wiki\Image;
 use App\Models\Wiki\Series;
@@ -31,7 +33,7 @@ class AnimePolicy extends BasePolicy
      */
     public function addAnyAnimeSynonym(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Anime::class));
+        return $user->can(CrudPermission::UPDATE->format(AnimeSynonym::class));
     }
 
     /**
@@ -42,7 +44,7 @@ class AnimePolicy extends BasePolicy
      */
     public function addAnyAnimeTheme(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Anime::class));
+        return $user->can(CrudPermission::UPDATE->format(AnimeTheme::class));
     }
 
     /**
@@ -53,7 +55,7 @@ class AnimePolicy extends BasePolicy
      */
     public function attachAnySeries(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Anime::class));
+        return $user->can(CrudPermission::CREATE->format(Anime::class)) && $user->can(CrudPermission::CREATE->format(Series::class));
     }
 
     /**
@@ -71,7 +73,9 @@ class AnimePolicy extends BasePolicy
             ->where(AnimeSeries::ATTRIBUTE_SERIES, $series->getKey())
             ->exists();
 
-        return !$attached && $user->can(CrudPermission::UPDATE->format(Anime::class));
+        return !$attached
+            && $user->can(CrudPermission::CREATE->format(Anime::class))
+            && $user->can(CrudPermission::CREATE->format(Series::class));
     }
 
     /**
@@ -82,25 +86,7 @@ class AnimePolicy extends BasePolicy
      */
     public function detachAnySeries(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Anime::class));
-    }
-
-    /**
-     * Determine whether the user can detach a series from the anime.
-     *
-     * @param  User  $user
-     * @param  Anime  $anime
-     * @param  ExternalResource
-     * @return bool
-     */
-    public function detachSeries(User $user, Anime $anime, ExternalResource $resource): bool
-    {
-        $attached = AnimeSeries::query()
-            ->where(AnimeSeries::ATTRIBUTE_ANIME, $anime->getKey())
-            ->where(AnimeSeries::ATTRIBUTE_SERIES, $resource->getKey())
-            ->exists();
-
-        return $attached && $user->can(CrudPermission::UPDATE->format(Anime::class));
+        return $user->can(CrudPermission::DELETE->format(Anime::class)) && $user->can(CrudPermission::DELETE->format(Series::class));
     }
 
     /**
@@ -111,7 +97,7 @@ class AnimePolicy extends BasePolicy
      */
     public function attachAnyExternalResource(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Anime::class));
+        return $user->can(CrudPermission::CREATE->format(Anime::class)) && $user->can(CrudPermission::CREATE->format(ExternalResource::class));
     }
 
     /**
@@ -129,7 +115,9 @@ class AnimePolicy extends BasePolicy
             ->where(AnimeResource::ATTRIBUTE_RESOURCE, $resource->getKey())
             ->exists();
 
-        return !$attached && $user->can(CrudPermission::UPDATE->format(Anime::class));
+        return !$attached
+            && $user->can(CrudPermission::CREATE->format(Anime::class))
+            && $user->can(CrudPermission::CREATE->format(ExternalResource::class));
     }
 
     /**
@@ -140,25 +128,7 @@ class AnimePolicy extends BasePolicy
      */
     public function detachAnyExternalResource(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Anime::class));
-    }
-
-    /**
-     * Determine whether the user can detach a resource from the anime.
-     *
-     * @param  User  $user
-     * @param  Anime  $anime
-     * @param  ExternalResource  $resource
-     * @return bool
-     */
-    public function detachExternalResource(User $user, Anime $anime, ExternalResource $resource): bool
-    {
-        $attached = AnimeResource::query()
-            ->where(AnimeResource::ATTRIBUTE_ANIME, $anime->getKey())
-            ->where(AnimeResource::ATTRIBUTE_RESOURCE, $resource->getKey())
-            ->exists();
-
-        return $attached && $user->can(CrudPermission::UPDATE->format(Anime::class));
+        return $user->can(CrudPermission::DELETE->format(Anime::class)) && $user->can(CrudPermission::DELETE->format(ExternalResource::class));
     }
 
     /**
@@ -169,7 +139,7 @@ class AnimePolicy extends BasePolicy
      */
     public function attachAnyImage(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Anime::class));
+        return $user->can(CrudPermission::CREATE->format(Anime::class)) && $user->can(CrudPermission::CREATE->format(Image::class));
     }
 
     /**
@@ -187,7 +157,9 @@ class AnimePolicy extends BasePolicy
             ->where(AnimeImage::ATTRIBUTE_IMAGE, $image->getKey())
             ->exists();
 
-        return !$attached && $user->can(CrudPermission::UPDATE->format(Anime::class));
+        return !$attached
+            && $user->can(CrudPermission::CREATE->format(Anime::class))
+            && $user->can(CrudPermission::CREATE->format(Image::class));
     }
 
     /**
@@ -198,25 +170,7 @@ class AnimePolicy extends BasePolicy
      */
     public function detachAnyImage(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Anime::class));
-    }
-
-    /**
-     * Determine whether the user can detach an image from the anime.
-     *
-     * @param  User  $user
-     * @param  Anime  $anime
-     * @param  Image  $image
-     * @return bool
-     */
-    public function detachImage(User $user, Anime $anime, Image $image): bool
-    {
-        $attached = AnimeImage::query()
-            ->where(AnimeImage::ATTRIBUTE_ANIME, $anime->getKey())
-            ->where(AnimeImage::ATTRIBUTE_IMAGE, $image->getKey())
-            ->exists();
-
-        return $attached && $user->can(CrudPermission::UPDATE->format(Anime::class));
+        return $user->can(CrudPermission::DELETE->format(Anime::class)) && $user->can(CrudPermission::DELETE->format(Image::class));
     }
 
     /**
@@ -227,7 +181,7 @@ class AnimePolicy extends BasePolicy
      */
     public function attachAnyStudio(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Anime::class));
+        return $user->can(CrudPermission::CREATE->format(Anime::class)) && $user->can(CrudPermission::CREATE->format(Studio::class));
     }
 
     /**
@@ -245,7 +199,9 @@ class AnimePolicy extends BasePolicy
             ->where(AnimeStudio::ATTRIBUTE_STUDIO, $studio->getKey())
             ->exists();
 
-        return !$attached && $user->can(CrudPermission::UPDATE->format(Anime::class));
+        return !$attached
+            && $user->can(CrudPermission::CREATE->format(Anime::class))
+            && $user->can(CrudPermission::CREATE->format(Studio::class));
     }
 
     /**
@@ -256,29 +212,11 @@ class AnimePolicy extends BasePolicy
      */
     public function detachAnyStudio(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Anime::class));
+        return $user->can(CrudPermission::DELETE->format(Anime::class)) && $user->can(CrudPermission::DELETE->format(Studio::class));
     }
 
     /**
-     * Determine whether the user can detach a studio from the anime.
-     *
-     * @param  User  $user
-     * @param  Anime  $anime
-     * @param  Studio  $studio
-     * @return bool
-     */
-    public function detachStudio(User $user, Anime $anime, Studio $studio): bool
-    {
-        $attached = AnimeStudio::query()
-            ->where(AnimeStudio::ATTRIBUTE_ANIME, $anime->getKey())
-            ->where(AnimeStudio::ATTRIBUTE_STUDIO, $studio->getKey())
-            ->exists();
-
-        return $attached && $user->can(CrudPermission::UPDATE->format(Anime::class));
-    }
-
-    /**
-     * Determine whether the user can add a entry to the anime.
+     * Determine whether the user can add an entry to the anime.
      *
      * @param  User  $user
      * @return bool

--- a/app/Policies/Wiki/ArtistPolicy.php
+++ b/app/Policies/Wiki/ArtistPolicy.php
@@ -29,7 +29,7 @@ class ArtistPolicy extends BasePolicy
      */
     public function attachAnySong(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Artist::class));
+        return $user->can(CrudPermission::CREATE->format(Artist::class)) && $user->can(CrudPermission::CREATE->format(Song::class));
     }
 
     /**
@@ -47,7 +47,9 @@ class ArtistPolicy extends BasePolicy
             ->where(ArtistSong::ATTRIBUTE_SONG, $song->getKey())
             ->exists();
 
-        return !$attached && $user->can(CrudPermission::UPDATE->format(Artist::class));
+        return !$attached
+            && $user->can(CrudPermission::CREATE->format(Artist::class))
+            && $user->can(CrudPermission::CREATE->format(Song::class));
     }
 
     /**
@@ -58,18 +60,7 @@ class ArtistPolicy extends BasePolicy
      */
     public function detachAnySong(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Artist::class));
-    }
-
-    /**
-     * Determine whether the user can detach a song from the artist.
-     *
-     * @param  User  $user
-     * @return bool
-     */
-    public function detachSong(User $user): bool
-    {
-        return $user->can(CrudPermission::UPDATE->format(Artist::class));
+        return $user->can(CrudPermission::DELETE->format(Artist::class)) && $user->can(CrudPermission::DELETE->format(Song::class));
     }
 
     /**
@@ -80,7 +71,7 @@ class ArtistPolicy extends BasePolicy
      */
     public function attachAnyExternalResource(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Artist::class));
+        return $user->can(CrudPermission::CREATE->format(Artist::class)) && $user->can(CrudPermission::CREATE->format(ExternalResource::class));
     }
 
     /**
@@ -98,7 +89,9 @@ class ArtistPolicy extends BasePolicy
             ->where(ArtistResource::ATTRIBUTE_RESOURCE, $resource->getKey())
             ->exists();
 
-        return !$attached && $user->can(CrudPermission::UPDATE->format(Artist::class));
+        return !$attached
+            && $user->can(CrudPermission::CREATE->format(Artist::class))
+            && $user->can(CrudPermission::CREATE->format(ExternalResource::class));
     }
 
     /**
@@ -109,25 +102,7 @@ class ArtistPolicy extends BasePolicy
      */
     public function detachAnyExternalResource(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Artist::class));
-    }
-
-    /**
-     * Determine whether the user can detach any resource from the artist.
-     *
-     * @param  User  $user
-     * @param  Artist  $artist
-     * @param  ExternalResource  $resource
-     * @return bool
-     */
-    public function detachExternalResource(User $user, Artist $artist, ExternalResource $resource): bool
-    {
-        $attached = ArtistResource::query()
-            ->where(ArtistResource::ATTRIBUTE_ARTIST, $artist->getKey())
-            ->where(ArtistResource::ATTRIBUTE_RESOURCE, $resource->getKey())
-            ->exists();
-
-        return $attached && $user->can(CrudPermission::UPDATE->format(Artist::class));
+        return $user->can(CrudPermission::DELETE->format(Artist::class)) && $user->can(CrudPermission::DELETE->format(ExternalResource::class));
     }
 
     /**
@@ -138,7 +113,7 @@ class ArtistPolicy extends BasePolicy
      */
     public function attachAnyArtist(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Artist::class));
+        return $user->can(CrudPermission::CREATE->format(Artist::class));
     }
 
     /**
@@ -161,7 +136,7 @@ class ArtistPolicy extends BasePolicy
             ->where(ArtistMember::ATTRIBUTE_MEMBER, $artist2->getKey())
             ->exists();
 
-        return !$attached && $user->can(CrudPermission::UPDATE->format(Artist::class));
+        return !$attached && $user->can(CrudPermission::CREATE->format(Artist::class));
     }
 
     /**
@@ -172,25 +147,7 @@ class ArtistPolicy extends BasePolicy
      */
     public function detachAnyArtist(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Artist::class));
-    }
-
-    /**
-     * Determine whether the user can detach a group/member from the artist.
-     *
-     * @param  User  $user
-     * @param  Artist  $artist
-     * @param  Artist  $artist2
-     * @return bool
-     */
-    public function detachArtist(User $user, Artist $artist, Artist $artist2): bool
-    {
-        $attached = ArtistMember::query()
-            ->where(ArtistMember::ATTRIBUTE_ARTIST, $artist->getKey())
-            ->where(ArtistMember::ATTRIBUTE_MEMBER, $artist2->getKey())
-            ->exists();
-
-        return $attached && $user->can(CrudPermission::UPDATE->format(Artist::class));
+        return $user->can(CrudPermission::DELETE->format(Artist::class));
     }
 
     /**
@@ -201,7 +158,7 @@ class ArtistPolicy extends BasePolicy
      */
     public function attachAnyImage(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Artist::class));
+        return $user->can(CrudPermission::CREATE->format(Artist::class)) && $user->can(CrudPermission::CREATE->format(Image::class));
     }
 
     /**
@@ -219,7 +176,9 @@ class ArtistPolicy extends BasePolicy
             ->where(ArtistImage::ATTRIBUTE_IMAGE, $image->getKey())
             ->exists();
 
-        return !$attached && $user->can(CrudPermission::UPDATE->format(Artist::class));
+        return !$attached
+            && $user->can(CrudPermission::CREATE->format(Artist::class))
+            && $user->can(CrudPermission::CREATE->format(Image::class));
     }
 
     /**
@@ -230,24 +189,6 @@ class ArtistPolicy extends BasePolicy
      */
     public function detachAnyImage(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Artist::class));
-    }
-
-    /**
-     * Determine whether the user can detach an image from the artist.
-     *
-     * @param  User  $user
-     * @param  Artist  $artist
-     * @param  Image  $image
-     * @return bool
-     */
-    public function detachImage(User $user, Artist $artist, Image $image): bool
-    {
-        $attached = ArtistImage::query()
-            ->where(ArtistImage::ATTRIBUTE_ARTIST, $artist->getKey())
-            ->where(ArtistImage::ATTRIBUTE_IMAGE, $image->getKey())
-            ->exists();
-
-        return $attached && $user->can(CrudPermission::UPDATE->format(Artist::class));
+        return $user->can(CrudPermission::DELETE->format(Artist::class)) && $user->can(CrudPermission::DELETE->format(Image::class));
     }
 }

--- a/app/Policies/Wiki/ArtistPolicy.php
+++ b/app/Policies/Wiki/ArtistPolicy.php
@@ -7,8 +7,13 @@ namespace App\Policies\Wiki;
 use App\Enums\Auth\CrudPermission;
 use App\Models\Auth\User;
 use App\Models\Wiki\Artist;
+use App\Models\Wiki\ExternalResource;
 use App\Models\Wiki\Image;
+use App\Models\Wiki\Song;
 use App\Pivots\Wiki\ArtistImage;
+use App\Pivots\Wiki\ArtistMember;
+use App\Pivots\Wiki\ArtistResource;
+use App\Pivots\Wiki\ArtistSong;
 use App\Policies\BasePolicy;
 
 /**
@@ -16,6 +21,57 @@ use App\Policies\BasePolicy;
  */
 class ArtistPolicy extends BasePolicy
 {
+    /**
+     * Determine whether the user can attach any song to the artist.
+     *
+     * @param  User  $user
+     * @return bool
+     */
+    public function attachAnySong(User $user): bool
+    {
+        return $user->can(CrudPermission::UPDATE->format(Artist::class));
+    }
+
+    /**
+     * Determine whether the user can attach any song to the artist.
+     *
+     * @param  User  $user
+     * @param  Artist  $artist
+     * @param  Song  $song
+     * @return bool
+     */
+    public function attachSong(User $user, Artist $artist, Song $song): bool
+    {
+        $attached = ArtistSong::query()
+            ->where(ArtistSong::ATTRIBUTE_ARTIST, $artist->getKey())
+            ->where(ArtistSong::ATTRIBUTE_SONG, $song->getKey())
+            ->exists();
+
+        return !$attached && $user->can(CrudPermission::UPDATE->format(Artist::class));
+    }
+
+    /**
+     * Determine whether the user can detach any song from the artist.
+     *
+     * @param  User  $user
+     * @return bool
+     */
+    public function detachAnySong(User $user): bool
+    {
+        return $user->can(CrudPermission::UPDATE->format(Artist::class));
+    }
+
+    /**
+     * Determine whether the user can detach a song from the artist.
+     *
+     * @param  User  $user
+     * @return bool
+     */
+    public function detachSong(User $user): bool
+    {
+        return $user->can(CrudPermission::UPDATE->format(Artist::class));
+    }
+
     /**
      * Determine whether the user can attach any resource to the artist.
      *
@@ -31,11 +87,18 @@ class ArtistPolicy extends BasePolicy
      * Determine whether the user can attach a resource to the artist.
      *
      * @param  User  $user
+     * @param  Artist  $artist
+     * @param  ExternalResource  $resource
      * @return bool
      */
-    public function attachExternalResource(User $user): bool
+    public function attachExternalResource(User $user, Artist $artist, ExternalResource $resource): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Artist::class));
+        $attached = ArtistResource::query()
+            ->where(ArtistResource::ATTRIBUTE_ARTIST, $artist->getKey())
+            ->where(ArtistResource::ATTRIBUTE_RESOURCE, $resource->getKey())
+            ->exists();
+
+        return !$attached && $user->can(CrudPermission::UPDATE->format(Artist::class));
     }
 
     /**
@@ -44,42 +107,27 @@ class ArtistPolicy extends BasePolicy
      * @param  User  $user
      * @return bool
      */
-    public function detachExternalResource(User $user): bool
+    public function detachAnyExternalResource(User $user): bool
     {
         return $user->can(CrudPermission::UPDATE->format(Artist::class));
     }
 
     /**
-     * Determine whether the user can attach any song to the artist.
+     * Determine whether the user can detach any resource from the artist.
      *
      * @param  User  $user
+     * @param  Artist  $artist
+     * @param  ExternalResource  $resource
      * @return bool
      */
-    public function attachAnySong(User $user): bool
+    public function detachExternalResource(User $user, Artist $artist, ExternalResource $resource): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Artist::class));
-    }
+        $attached = ArtistResource::query()
+            ->where(ArtistResource::ATTRIBUTE_ARTIST, $artist->getKey())
+            ->where(ArtistResource::ATTRIBUTE_RESOURCE, $resource->getKey())
+            ->exists();
 
-    /**
-     * Determine whether the user can attach a song to the artist.
-     *
-     * @param  User  $user
-     * @return bool
-     */
-    public function attachSong(User $user): bool
-    {
-        return $user->can(CrudPermission::UPDATE->format(Artist::class));
-    }
-
-    /**
-     * Determine whether the user can detach a song from the artist.
-     *
-     * @param  User  $user
-     * @return bool
-     */
-    public function detachSong(User $user): bool
-    {
-        return $user->can(CrudPermission::UPDATE->format(Artist::class));
+        return $attached && $user->can(CrudPermission::UPDATE->format(Artist::class));
     }
 
     /**
@@ -97,9 +145,32 @@ class ArtistPolicy extends BasePolicy
      * Determine whether the user can attach a group/member to the artist.
      *
      * @param  User  $user
+     * @param  Artist  $artist
+     * @param  Artist  $artist2
      * @return bool
      */
-    public function attachArtist(User $user): bool
+    public function attachArtist(User $user, Artist $artist, Artist $artist2): bool
+    {
+        if ($artist->is($artist2)) {
+            // An artist cannot be a member/group of themselves
+            return false;
+        }
+
+        $attached = ArtistMember::query()
+            ->where(ArtistMember::ATTRIBUTE_ARTIST, $artist->getKey())
+            ->where(ArtistMember::ATTRIBUTE_MEMBER, $artist2->getKey())
+            ->exists();
+
+        return !$attached && $user->can(CrudPermission::UPDATE->format(Artist::class));
+    }
+
+    /**
+     * Determine whether the user can detach any group/member from the artist.
+     *
+     * @param  User  $user
+     * @return bool
+     */
+    public function detachAnyArtist(User $user): bool
     {
         return $user->can(CrudPermission::UPDATE->format(Artist::class));
     }
@@ -108,11 +179,18 @@ class ArtistPolicy extends BasePolicy
      * Determine whether the user can detach a group/member from the artist.
      *
      * @param  User  $user
+     * @param  Artist  $artist
+     * @param  Artist  $artist2
      * @return bool
      */
-    public function detachArtist(User $user): bool
+    public function detachArtist(User $user, Artist $artist, Artist $artist2): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Artist::class));
+        $attached = ArtistMember::query()
+            ->where(ArtistMember::ATTRIBUTE_ARTIST, $artist->getKey())
+            ->where(ArtistMember::ATTRIBUTE_MEMBER, $artist2->getKey())
+            ->exists();
+
+        return $attached && $user->can(CrudPermission::UPDATE->format(Artist::class));
     }
 
     /**
@@ -137,21 +215,39 @@ class ArtistPolicy extends BasePolicy
     public function attachImage(User $user, Artist $artist, Image $image): bool
     {
         $attached = ArtistImage::query()
-            ->where($artist->getKeyName(), $artist->getKey())
-            ->where($image->getKeyName(), $image->getKey())
+            ->where(ArtistImage::ATTRIBUTE_ARTIST, $artist->getKey())
+            ->where(ArtistImage::ATTRIBUTE_IMAGE, $image->getKey())
             ->exists();
 
         return !$attached && $user->can(CrudPermission::UPDATE->format(Artist::class));
     }
 
     /**
-     * Determine whether the user can detach an image from the artist.
+     * Determine whether the user can detach any image from the artist.
      *
      * @param  User  $user
      * @return bool
      */
-    public function detachImage(User $user): bool
+    public function detachAnyImage(User $user): bool
     {
         return $user->can(CrudPermission::UPDATE->format(Artist::class));
+    }
+
+    /**
+     * Determine whether the user can detach an image from the artist.
+     *
+     * @param  User  $user
+     * @param  Artist  $artist
+     * @param  Image  $image
+     * @return bool
+     */
+    public function detachImage(User $user, Artist $artist, Image $image): bool
+    {
+        $attached = ArtistImage::query()
+            ->where(ArtistImage::ATTRIBUTE_ARTIST, $artist->getKey())
+            ->where(ArtistImage::ATTRIBUTE_IMAGE, $image->getKey())
+            ->exists();
+
+        return $attached && $user->can(CrudPermission::UPDATE->format(Artist::class));
     }
 }

--- a/app/Policies/Wiki/AudioPolicy.php
+++ b/app/Policies/Wiki/AudioPolicy.php
@@ -6,7 +6,7 @@ namespace App\Policies\Wiki;
 
 use App\Enums\Auth\CrudPermission;
 use App\Models\Auth\User;
-use App\Models\Wiki\Audio;
+use App\Models\Wiki\Video;
 use App\Policies\BasePolicy;
 
 /**
@@ -22,6 +22,6 @@ class AudioPolicy extends BasePolicy
      */
     public function addVideo(User $user): bool
     {
-        return $user->can(CrudPermission::CREATE->format(Audio::class));
+        return $user->can(CrudPermission::CREATE->format(Video::class));
     }
 }

--- a/app/Policies/Wiki/ExternalResourcePolicy.php
+++ b/app/Policies/Wiki/ExternalResourcePolicy.php
@@ -6,7 +6,15 @@ namespace App\Policies\Wiki;
 
 use App\Enums\Auth\CrudPermission;
 use App\Models\Auth\User;
+use App\Models\Wiki\Anime;
+use App\Models\Wiki\Artist;
 use App\Models\Wiki\ExternalResource;
+use App\Models\Wiki\Song;
+use App\Models\Wiki\Studio;
+use App\Pivots\Wiki\AnimeResource;
+use App\Pivots\Wiki\ArtistResource;
+use App\Pivots\Wiki\SongResource;
+use App\Pivots\Wiki\StudioResource;
 use App\Policies\BasePolicy;
 
 /**
@@ -14,6 +22,64 @@ use App\Policies\BasePolicy;
  */
 class ExternalResourcePolicy extends BasePolicy
 {
+     /**
+     * Determine whether the user can attach any anime to the resource.
+     *
+     * @param  User  $user
+     * @return bool
+     */
+    public function attachAnyAnime(User $user): bool
+    {
+        return $user->can(CrudPermission::UPDATE->format(ExternalResource::class));
+    }
+
+     /**
+     * Determine whether the user can attach an anime to the resource.
+     *
+     * @param  User  $user
+     * @param  ExternalResource  $resource
+     * @param  Anime  $anime
+     * @return bool
+     */
+    public function attachAnime(User $user, ExternalResource $resource, Anime $anime): bool
+    {
+        $attached = AnimeResource::query()
+            ->where(AnimeResource::ATTRIBUTE_RESOURCE, $resource->getKey())
+            ->where(AnimeResource::ATTRIBUTE_ANIME, $anime->getKey())
+            ->exists();
+
+        return !$attached && $user->can(CrudPermission::UPDATE->format(ExternalResource::class));
+    }
+
+    /**
+     * Determine whether the user can detach any anime from the resource.
+     *
+     * @param  User  $user
+     * @return bool
+     */
+    public function detachAnyAnime(User $user): bool
+    {
+        return $user->can(CrudPermission::UPDATE->format(ExternalResource::class));
+    }
+
+    /**
+     * Determine whether the user can detach an anime from the resource.
+     *
+     * @param  User  $user
+     * @param  ExternalResource  $resource
+     * @param  Anime  $anime
+     * @return bool
+     */
+    public function detachAnime(User $user, ExternalResource $resource, Anime $anime): bool
+    {
+        $attached = AnimeResource::query()
+            ->where(AnimeResource::ATTRIBUTE_RESOURCE, $resource->getKey())
+            ->where(AnimeResource::ATTRIBUTE_ANIME, $anime->getKey())
+            ->exists();
+
+        return $attached && $user->can(CrudPermission::UPDATE->format(ExternalResource::class));
+    }
+
     /**
      * Determine whether the user can attach any artist to the resource.
      *
@@ -29,9 +95,27 @@ class ExternalResourcePolicy extends BasePolicy
      * Determine whether the user can attach an artist to the resource.
      *
      * @param  User  $user
+     * @param  ExternalResource  $resource
+     * @param  Artist  $artist
      * @return bool
      */
-    public function attachArtist(User $user): bool
+    public function attachArtist(User $user, ExternalResource $resource, Artist $artist): bool
+    {
+        $attached = ArtistResource::query()
+            ->where(ArtistResource::ATTRIBUTE_RESOURCE, $resource->getKey())
+            ->where(ArtistResource::ATTRIBUTE_ARTIST, $artist->getKey())
+            ->exists();
+
+        return !$attached && $user->can(CrudPermission::UPDATE->format(ExternalResource::class));
+    }
+
+    /**
+     * Determine whether the user can detach any artist from the resource.
+     *
+     * @param  User  $user
+     * @return bool
+     */
+    public function detachAnyArtist(User $user): bool
     {
         return $user->can(CrudPermission::UPDATE->format(ExternalResource::class));
     }
@@ -40,44 +124,76 @@ class ExternalResourcePolicy extends BasePolicy
      * Determine whether the user can detach an artist from the resource.
      *
      * @param  User  $user
+     * @param  ExternalResource  $resource
+     * @param  Artist  $artist
      * @return bool
      */
-    public function detachArtist(User $user): bool
+    public function detachArtist(User $user, ExternalResource $resource, Artist $artist): bool
+    {
+        $attached = ArtistResource::query()
+            ->where(ArtistResource::ATTRIBUTE_RESOURCE, $resource->getKey())
+            ->where(ArtistResource::ATTRIBUTE_ARTIST, $artist->getKey())
+            ->exists();
+
+        return $attached && $user->can(CrudPermission::UPDATE->format(ExternalResource::class));
+    }
+
+    /**
+     * Determine whether the user can attach any song to the resource.
+     *
+     * @param  User  $user
+     * @return bool
+     */
+    public function attachAnySong(User $user): bool
     {
         return $user->can(CrudPermission::UPDATE->format(ExternalResource::class));
     }
 
     /**
-     * Determine whether the user can attach any anime to the resource.
+     * Determine whether the user can attach a song to the resource.
+     *
+     * @param  User  $user
+     * @param  ExternalResource  $resource
+     * @param  Song  $song
+     * @return bool
+     */
+    public function attachSong(User $user, ExternalResource $resource, Song $song): bool
+    {
+        $attached = SongResource::query()
+            ->where(SongResource::ATTRIBUTE_RESOURCE, $resource->getKey())
+            ->where(SongResource::ATTRIBUTE_SONG, $song->getKey())
+            ->exists();
+
+        return !$attached && $user->can(CrudPermission::UPDATE->format(ExternalResource::class));
+    }
+
+    /**
+     * Determine whether the user can detach any song from the resource.
      *
      * @param  User  $user
      * @return bool
      */
-    public function attachAnyAnime(User $user): bool
+    public function detachAnySong(User $user): bool
     {
         return $user->can(CrudPermission::UPDATE->format(ExternalResource::class));
     }
 
     /**
-     * Determine whether the user can attach an anime to the resource.
+     * Determine whether the user can detach a song from the resource.
      *
      * @param  User  $user
+     * @param  ExternalResource  $resource
+     * @param  Song  $song
      * @return bool
      */
-    public function attachAnime(User $user): bool
+    public function detachSong(User $user, ExternalResource $resource, Song $song): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(ExternalResource::class));
-    }
+        $attached = SongResource::query()
+            ->where(SongResource::ATTRIBUTE_RESOURCE, $resource->getKey())
+            ->where(SongResource::ATTRIBUTE_SONG, $song->getKey())
+            ->exists();
 
-    /**
-     * Determine whether the user can detach an anime from the resource.
-     *
-     * @param  User  $user
-     * @return bool
-     */
-    public function detachAnime(User $user): bool
-    {
-        return $user->can(CrudPermission::UPDATE->format(ExternalResource::class));
+        return $attached && $user->can(CrudPermission::UPDATE->format(ExternalResource::class));
     }
 
     /**
@@ -95,9 +211,27 @@ class ExternalResourcePolicy extends BasePolicy
      * Determine whether the user can attach a studio to the resource.
      *
      * @param  User  $user
+     * @param  ExternalResource  $resource
+     * @param  Studio  $studio
      * @return bool
      */
-    public function attachStudio(User $user): bool
+    public function attachStudio(User $user, ExternalResource $resource, Studio $studio): bool
+    {
+        $attached = StudioResource::query()
+            ->where(StudioResource::ATTRIBUTE_RESOURCE, $resource->getKey())
+            ->where(StudioResource::ATTRIBUTE_STUDIO, $studio->getKey())
+            ->exists();
+
+        return !$attached && $user->can(CrudPermission::UPDATE->format(ExternalResource::class));
+    }
+
+    /**
+     * Determine whether the user can detach any studio from the resource.
+     *
+     * @param  User  $user
+     * @return bool
+     */
+    public function detachAnyStudio(User $user): bool
     {
         return $user->can(CrudPermission::UPDATE->format(ExternalResource::class));
     }
@@ -106,10 +240,17 @@ class ExternalResourcePolicy extends BasePolicy
      * Determine whether the user can detach a studio from the resource.
      *
      * @param  User  $user
+     * @param  ExternalResource  $resource
+     * @param  Studio  $studio
      * @return bool
      */
-    public function detachStudio(User $user): bool
+    public function detachStudio(User $user, ExternalResource $resource, Studio $studio): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(ExternalResource::class));
+        $attached = StudioResource::query()
+            ->where(StudioResource::ATTRIBUTE_RESOURCE, $resource->getKey())
+            ->where(StudioResource::ATTRIBUTE_STUDIO, $studio->getKey())
+            ->exists();
+
+        return $attached && $user->can(CrudPermission::UPDATE->format(ExternalResource::class));
     }
 }

--- a/app/Policies/Wiki/ExternalResourcePolicy.php
+++ b/app/Policies/Wiki/ExternalResourcePolicy.php
@@ -30,7 +30,7 @@ class ExternalResourcePolicy extends BasePolicy
      */
     public function attachAnyAnime(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(ExternalResource::class));
+        return $user->can(CrudPermission::CREATE->format(ExternalResource::class)) && $user->can(CrudPermission::CREATE->format(Anime::class));
     }
 
      /**
@@ -48,7 +48,9 @@ class ExternalResourcePolicy extends BasePolicy
             ->where(AnimeResource::ATTRIBUTE_ANIME, $anime->getKey())
             ->exists();
 
-        return !$attached && $user->can(CrudPermission::UPDATE->format(ExternalResource::class));
+        return !$attached
+            && $user->can(CrudPermission::CREATE->format(ExternalResource::class))
+            && $user->can(CrudPermission::CREATE->format(Anime::class));
     }
 
     /**
@@ -59,25 +61,7 @@ class ExternalResourcePolicy extends BasePolicy
      */
     public function detachAnyAnime(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(ExternalResource::class));
-    }
-
-    /**
-     * Determine whether the user can detach an anime from the resource.
-     *
-     * @param  User  $user
-     * @param  ExternalResource  $resource
-     * @param  Anime  $anime
-     * @return bool
-     */
-    public function detachAnime(User $user, ExternalResource $resource, Anime $anime): bool
-    {
-        $attached = AnimeResource::query()
-            ->where(AnimeResource::ATTRIBUTE_RESOURCE, $resource->getKey())
-            ->where(AnimeResource::ATTRIBUTE_ANIME, $anime->getKey())
-            ->exists();
-
-        return $attached && $user->can(CrudPermission::UPDATE->format(ExternalResource::class));
+        return $user->can(CrudPermission::DELETE->format(ExternalResource::class)) && $user->can(CrudPermission::DELETE->format(Anime::class));
     }
 
     /**
@@ -88,7 +72,7 @@ class ExternalResourcePolicy extends BasePolicy
      */
     public function attachAnyArtist(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(ExternalResource::class));
+        return $user->can(CrudPermission::CREATE->format(ExternalResource::class)) && $user->can(CrudPermission::CREATE->format(Artist::class));
     }
 
     /**
@@ -106,7 +90,9 @@ class ExternalResourcePolicy extends BasePolicy
             ->where(ArtistResource::ATTRIBUTE_ARTIST, $artist->getKey())
             ->exists();
 
-        return !$attached && $user->can(CrudPermission::UPDATE->format(ExternalResource::class));
+            return !$attached
+            && $user->can(CrudPermission::CREATE->format(ExternalResource::class))
+            && $user->can(CrudPermission::CREATE->format(Artist::class));
     }
 
     /**
@@ -117,25 +103,7 @@ class ExternalResourcePolicy extends BasePolicy
      */
     public function detachAnyArtist(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(ExternalResource::class));
-    }
-
-    /**
-     * Determine whether the user can detach an artist from the resource.
-     *
-     * @param  User  $user
-     * @param  ExternalResource  $resource
-     * @param  Artist  $artist
-     * @return bool
-     */
-    public function detachArtist(User $user, ExternalResource $resource, Artist $artist): bool
-    {
-        $attached = ArtistResource::query()
-            ->where(ArtistResource::ATTRIBUTE_RESOURCE, $resource->getKey())
-            ->where(ArtistResource::ATTRIBUTE_ARTIST, $artist->getKey())
-            ->exists();
-
-        return $attached && $user->can(CrudPermission::UPDATE->format(ExternalResource::class));
+        return $user->can(CrudPermission::DELETE->format(ExternalResource::class)) && $user->can(CrudPermission::DELETE->format(Artist::class));
     }
 
     /**
@@ -146,7 +114,7 @@ class ExternalResourcePolicy extends BasePolicy
      */
     public function attachAnySong(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(ExternalResource::class));
+        return $user->can(CrudPermission::CREATE->format(ExternalResource::class)) && $user->can(CrudPermission::CREATE->format(Song::class));
     }
 
     /**
@@ -164,7 +132,9 @@ class ExternalResourcePolicy extends BasePolicy
             ->where(SongResource::ATTRIBUTE_SONG, $song->getKey())
             ->exists();
 
-        return !$attached && $user->can(CrudPermission::UPDATE->format(ExternalResource::class));
+        return !$attached
+            && $user->can(CrudPermission::CREATE->format(ExternalResource::class))
+            && $user->can(CrudPermission::CREATE->format(Song::class));
     }
 
     /**
@@ -175,25 +145,7 @@ class ExternalResourcePolicy extends BasePolicy
      */
     public function detachAnySong(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(ExternalResource::class));
-    }
-
-    /**
-     * Determine whether the user can detach a song from the resource.
-     *
-     * @param  User  $user
-     * @param  ExternalResource  $resource
-     * @param  Song  $song
-     * @return bool
-     */
-    public function detachSong(User $user, ExternalResource $resource, Song $song): bool
-    {
-        $attached = SongResource::query()
-            ->where(SongResource::ATTRIBUTE_RESOURCE, $resource->getKey())
-            ->where(SongResource::ATTRIBUTE_SONG, $song->getKey())
-            ->exists();
-
-        return $attached && $user->can(CrudPermission::UPDATE->format(ExternalResource::class));
+        return $user->can(CrudPermission::DELETE->format(ExternalResource::class)) && $user->can(CrudPermission::DELETE->format(Song::class));
     }
 
     /**
@@ -204,7 +156,7 @@ class ExternalResourcePolicy extends BasePolicy
      */
     public function attachAnyStudio(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(ExternalResource::class));
+        return $user->can(CrudPermission::CREATE->format(ExternalResource::class)) && $user->can(CrudPermission::CREATE->format(Studio::class));
     }
 
     /**
@@ -222,7 +174,9 @@ class ExternalResourcePolicy extends BasePolicy
             ->where(StudioResource::ATTRIBUTE_STUDIO, $studio->getKey())
             ->exists();
 
-        return !$attached && $user->can(CrudPermission::UPDATE->format(ExternalResource::class));
+        return !$attached
+            && $user->can(CrudPermission::CREATE->format(ExternalResource::class))
+            && $user->can(CrudPermission::CREATE->format(Studio::class));
     }
 
     /**
@@ -233,24 +187,6 @@ class ExternalResourcePolicy extends BasePolicy
      */
     public function detachAnyStudio(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(ExternalResource::class));
-    }
-
-    /**
-     * Determine whether the user can detach a studio from the resource.
-     *
-     * @param  User  $user
-     * @param  ExternalResource  $resource
-     * @param  Studio  $studio
-     * @return bool
-     */
-    public function detachStudio(User $user, ExternalResource $resource, Studio $studio): bool
-    {
-        $attached = StudioResource::query()
-            ->where(StudioResource::ATTRIBUTE_RESOURCE, $resource->getKey())
-            ->where(StudioResource::ATTRIBUTE_STUDIO, $studio->getKey())
-            ->exists();
-
-        return $attached && $user->can(CrudPermission::UPDATE->format(ExternalResource::class));
+        return $user->can(CrudPermission::DELETE->format(ExternalResource::class)) && $user->can(CrudPermission::DELETE->format(Studio::class));
     }
 }

--- a/app/Policies/Wiki/GroupPolicy.php
+++ b/app/Policies/Wiki/GroupPolicy.php
@@ -6,7 +6,7 @@ namespace App\Policies\Wiki;
 
 use App\Enums\Auth\CrudPermission;
 use App\Models\Auth\User;
-use App\Models\Wiki\Group;
+use App\Models\Wiki\Anime\AnimeTheme;
 use App\Policies\BasePolicy;
 
 /**
@@ -22,6 +22,6 @@ class GroupPolicy extends BasePolicy
      */
     public function addAnimeTheme(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Group::class));
+        return $user->can(CrudPermission::UPDATE->format(AnimeTheme::class));
     }
 }

--- a/app/Policies/Wiki/ImagePolicy.php
+++ b/app/Policies/Wiki/ImagePolicy.php
@@ -7,12 +7,10 @@ namespace App\Policies\Wiki;
 use App\Enums\Auth\CrudPermission;
 use App\Enums\Auth\Role as RoleEnum;
 use App\Models\Auth\User;
-use App\Models\List\Playlist;
 use App\Models\Wiki\Anime;
 use App\Models\Wiki\Artist;
 use App\Models\Wiki\Image;
 use App\Models\Wiki\Studio;
-use App\Pivots\List\PlaylistImage;
 use App\Pivots\Wiki\AnimeImage;
 use App\Pivots\Wiki\ArtistImage;
 use App\Pivots\Wiki\StudioImage;
@@ -45,22 +43,40 @@ class ImagePolicy extends BasePolicy
     public function attachArtist(User $user, Image $image, Artist $artist): bool
     {
         $attached = ArtistImage::query()
-            ->where($artist->getKeyName(), $artist->getKey())
-            ->where($image->getKeyName(), $image->getKey())
+            ->where(ArtistImage::ATTRIBUTE_IMAGE, $image->getKey())
+            ->where(ArtistImage::ATTRIBUTE_ARTIST, $artist->getKey())
             ->exists();
 
         return !$attached && $user->can(CrudPermission::UPDATE->format(Image::class));
     }
 
     /**
-     * Determine whether the user can detach an artist from the image.
+     * Determine whether the user can detach any artist from the image.
      *
      * @param  User  $user
      * @return bool
      */
-    public function detachArtist(User $user): bool
+    public function detachAnyArtist(User $user): bool
     {
         return $user->can(CrudPermission::UPDATE->format(Image::class));
+    }
+
+    /**
+     * Determine whether the user can detach an artist from the image.
+     *
+     * @param  User  $user
+     * @param  Image  $image
+     * @param  Artist  $artist
+     * @return bool
+     */
+    public function detachArtist(User $user, Image $image, Artist $artist): bool
+    {
+        $attached = ArtistImage::query()
+            ->where(ArtistImage::ATTRIBUTE_IMAGE, $image->getKey())
+            ->where(ArtistImage::ATTRIBUTE_ARTIST, $artist->getKey())
+            ->exists();
+
+        return $attached && $user->can(CrudPermission::UPDATE->format(Image::class));
     }
 
     /**
@@ -85,11 +101,22 @@ class ImagePolicy extends BasePolicy
     public function attachAnime(User $user, Image $image, Anime $anime): bool
     {
         $attached = AnimeImage::query()
-            ->where($anime->getKeyName(), $anime->getKey())
-            ->where($image->getKeyName(), $image->getKey())
+            ->where(AnimeImage::ATTRIBUTE_IMAGE, $image->getKey())
+            ->where(AnimeImage::ATTRIBUTE_ANIME, $anime->getKey())
             ->exists();
 
         return !$attached && $user->can(CrudPermission::UPDATE->format(Image::class));
+    }
+
+    /**
+     * Determine whether the user can detach any anime from the image.
+     *
+     * @param  User  $user
+     * @return bool
+     */
+    public function detachAnyAnime(User $user): bool
+    {
+        return $user->can(CrudPermission::UPDATE->format(Image::class));
     }
 
     /**
@@ -98,9 +125,14 @@ class ImagePolicy extends BasePolicy
      * @param  User  $user
      * @return bool
      */
-    public function detachAnime(User $user): bool
+    public function detachAnime(User $user, Image $image, Anime $anime): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Image::class));
+        $attached = AnimeImage::query()
+            ->where(AnimeImage::ATTRIBUTE_IMAGE, $image->getKey())
+            ->where(AnimeImage::ATTRIBUTE_ANIME, $anime->getKey())
+            ->exists();
+
+        return $attached && $user->can(CrudPermission::UPDATE->format(Image::class));
     }
 
     /**
@@ -125,22 +157,40 @@ class ImagePolicy extends BasePolicy
     public function attachStudio(User $user, Image $image, Studio $studio): bool
     {
         $attached = StudioImage::query()
-            ->where($image->getKeyName(), $image->getKey())
-            ->where($studio->getKeyName(), $studio->getKey())
+            ->where(StudioImage::ATTRIBUTE_IMAGE, $image->getKey())
+            ->where(StudioImage::ATTRIBUTE_STUDIO, $studio->getKey())
             ->exists();
 
         return !$attached && $user->can(CrudPermission::UPDATE->format(Image::class));
     }
 
     /**
-     * Determine whether the user can detach a studio from the image.
+     * Determine whether the user can detach any studio from the image.
      *
      * @param  User  $user
      * @return bool
      */
-    public function detachStudio(User $user): bool
+    public function detachAnyStudio(User $user): bool
     {
         return $user->can(CrudPermission::UPDATE->format(Image::class));
+    }
+
+    /**
+     * Determine whether the user can detach a studio from the image.
+     *
+     * @param  User  $user
+     * @param  Image  $image
+     * @param  Studio  $studio
+     * @return bool
+     */
+    public function detachStudio(User $user, Image $image, Studio $studio): bool
+    {
+        $attached = StudioImage::query()
+            ->where(StudioImage::ATTRIBUTE_IMAGE, $image->getKey())
+            ->where(StudioImage::ATTRIBUTE_STUDIO, $studio->getKey())
+            ->exists();
+
+        return $attached && $user->can(CrudPermission::UPDATE->format(Image::class));
     }
 
     /**
@@ -158,18 +208,22 @@ class ImagePolicy extends BasePolicy
      * Determine whether the user can attach a playlist to the image.
      *
      * @param  User  $user
-     * @param  Image  $image
-     * @param  Playlist  $playlist
      * @return bool
      */
-    public function attachPlaylist(User $user, Image $image, Playlist $playlist): bool
+    public function attachPlaylist(User $user): bool
     {
-        $attached = PlaylistImage::query()
-            ->where($image->getKeyName(), $image->getKey())
-            ->where($playlist->getKeyName(), $playlist->getKey())
-            ->exists();
+        return $user->hasRole(RoleEnum::ADMIN->value);
+    }
 
-        return !$attached && $user->hasRole(RoleEnum::ADMIN->value);
+    /**
+     * Determine whether the user can detach any playlist from the image.
+     *
+     * @param  User  $user
+     * @return bool
+     */
+    public function detachAnyPlaylist(User $user): bool
+    {
+        return $user->hasRole(RoleEnum::ADMIN->value);
     }
 
     /**

--- a/app/Policies/Wiki/ImagePolicy.php
+++ b/app/Policies/Wiki/ImagePolicy.php
@@ -29,7 +29,7 @@ class ImagePolicy extends BasePolicy
      */
     public function attachAnyArtist(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Image::class));
+        return $user->can(CrudPermission::CREATE->format(Image::class)) && $user->can(CrudPermission::CREATE->format(Artist::class));
     }
 
     /**
@@ -47,7 +47,9 @@ class ImagePolicy extends BasePolicy
             ->where(ArtistImage::ATTRIBUTE_ARTIST, $artist->getKey())
             ->exists();
 
-        return !$attached && $user->can(CrudPermission::UPDATE->format(Image::class));
+        return !$attached
+            && $user->can(CrudPermission::CREATE->format(Image::class))
+            && $user->can(CrudPermission::CREATE->format(Artist::class));
     }
 
     /**
@@ -58,25 +60,7 @@ class ImagePolicy extends BasePolicy
      */
     public function detachAnyArtist(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Image::class));
-    }
-
-    /**
-     * Determine whether the user can detach an artist from the image.
-     *
-     * @param  User  $user
-     * @param  Image  $image
-     * @param  Artist  $artist
-     * @return bool
-     */
-    public function detachArtist(User $user, Image $image, Artist $artist): bool
-    {
-        $attached = ArtistImage::query()
-            ->where(ArtistImage::ATTRIBUTE_IMAGE, $image->getKey())
-            ->where(ArtistImage::ATTRIBUTE_ARTIST, $artist->getKey())
-            ->exists();
-
-        return $attached && $user->can(CrudPermission::UPDATE->format(Image::class));
+        return $user->can(CrudPermission::DELETE->format(Image::class)) && $user->can(CrudPermission::DELETE->format(Artist::class));
     }
 
     /**
@@ -87,7 +71,7 @@ class ImagePolicy extends BasePolicy
      */
     public function attachAnyAnime(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Image::class));
+        return $user->can(CrudPermission::CREATE->format(Image::class)) && $user->can(CrudPermission::CREATE->format(Anime::class));
     }
 
     /**
@@ -105,7 +89,9 @@ class ImagePolicy extends BasePolicy
             ->where(AnimeImage::ATTRIBUTE_ANIME, $anime->getKey())
             ->exists();
 
-        return !$attached && $user->can(CrudPermission::UPDATE->format(Image::class));
+        return !$attached
+            && $user->can(CrudPermission::CREATE->format(Image::class))
+            && $user->can(CrudPermission::CREATE->format(Anime::class));
     }
 
     /**
@@ -116,23 +102,7 @@ class ImagePolicy extends BasePolicy
      */
     public function detachAnyAnime(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Image::class));
-    }
-
-    /**
-     * Determine whether the user can detach an anime from the image.
-     *
-     * @param  User  $user
-     * @return bool
-     */
-    public function detachAnime(User $user, Image $image, Anime $anime): bool
-    {
-        $attached = AnimeImage::query()
-            ->where(AnimeImage::ATTRIBUTE_IMAGE, $image->getKey())
-            ->where(AnimeImage::ATTRIBUTE_ANIME, $anime->getKey())
-            ->exists();
-
-        return $attached && $user->can(CrudPermission::UPDATE->format(Image::class));
+        return $user->can(CrudPermission::DELETE->format(Image::class)) && $user->can(CrudPermission::DELETE->format(Anime::class));
     }
 
     /**
@@ -143,7 +113,7 @@ class ImagePolicy extends BasePolicy
      */
     public function attachAnyStudio(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Image::class));
+        return $user->can(CrudPermission::CREATE->format(Image::class)) && $user->can(CrudPermission::CREATE->format(Studio::class));
     }
 
     /**
@@ -161,7 +131,9 @@ class ImagePolicy extends BasePolicy
             ->where(StudioImage::ATTRIBUTE_STUDIO, $studio->getKey())
             ->exists();
 
-        return !$attached && $user->can(CrudPermission::UPDATE->format(Image::class));
+        return !$attached
+            && $user->can(CrudPermission::CREATE->format(Image::class))
+            && $user->can(CrudPermission::CREATE->format(Studio::class));
     }
 
     /**
@@ -172,25 +144,7 @@ class ImagePolicy extends BasePolicy
      */
     public function detachAnyStudio(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Image::class));
-    }
-
-    /**
-     * Determine whether the user can detach a studio from the image.
-     *
-     * @param  User  $user
-     * @param  Image  $image
-     * @param  Studio  $studio
-     * @return bool
-     */
-    public function detachStudio(User $user, Image $image, Studio $studio): bool
-    {
-        $attached = StudioImage::query()
-            ->where(StudioImage::ATTRIBUTE_IMAGE, $image->getKey())
-            ->where(StudioImage::ATTRIBUTE_STUDIO, $studio->getKey())
-            ->exists();
-
-        return $attached && $user->can(CrudPermission::UPDATE->format(Image::class));
+        return $user->can(CrudPermission::DELETE->format(Image::class)) && $user->can(CrudPermission::DELETE->format(Studio::class));
     }
 
     /**
@@ -222,17 +176,6 @@ class ImagePolicy extends BasePolicy
      * @return bool
      */
     public function detachAnyPlaylist(User $user): bool
-    {
-        return $user->hasRole(RoleEnum::ADMIN->value);
-    }
-
-    /**
-     * Determine whether the user can detach a playlist from the image.
-     *
-     * @param  User  $user
-     * @return bool
-     */
-    public function detachPlaylist(User $user): bool
     {
         return $user->hasRole(RoleEnum::ADMIN->value);
     }

--- a/app/Policies/Wiki/SeriesPolicy.php
+++ b/app/Policies/Wiki/SeriesPolicy.php
@@ -24,7 +24,7 @@ class SeriesPolicy extends BasePolicy
      */
     public function attachAnyAnime(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Series::class));
+        return $user->can(CrudPermission::CREATE->format(Series::class)) && $user->can(CrudPermission::CREATE->format(Anime::class));
     }
 
     /**
@@ -42,7 +42,9 @@ class SeriesPolicy extends BasePolicy
             ->where(AnimeSeries::ATTRIBUTE_ANIME, $anime->getKey())
             ->exists();
 
-        return !$attached && $user->can(CrudPermission::UPDATE->format(Series::class));
+        return !$attached
+            && $user->can(CrudPermission::CREATE->format(Series::class))
+            && $user->can(CrudPermission::CREATE->format(Anime::class));
     }
 
     /**
@@ -53,24 +55,6 @@ class SeriesPolicy extends BasePolicy
      */
     public function detachAnyAnime(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Series::class));
-    }
-
-    /**
-     * Determine whether the user can detach an anime from the series.
-     *
-     * @param  User  $user
-     * @param  Series  $series
-     * @param  Anime  $anime
-     * @return bool
-     */
-    public function detachAnime(User $user, Series $series, Anime $anime): bool
-    {
-        $attached = AnimeSeries::query()
-            ->where(AnimeSeries::ATTRIBUTE_SERIES, $series->getKey())
-            ->where(AnimeSeries::ATTRIBUTE_ANIME, $anime->getKey())
-            ->exists();
-
-        return $attached && $user->can(CrudPermission::UPDATE->format(Series::class));
+        return $user->can(CrudPermission::DELETE->format(Series::class)) && $user->can(CrudPermission::DELETE->format(Anime::class));
     }
 }

--- a/app/Policies/Wiki/SeriesPolicy.php
+++ b/app/Policies/Wiki/SeriesPolicy.php
@@ -38,21 +38,39 @@ class SeriesPolicy extends BasePolicy
     public function attachAnime(User $user, Series $series, Anime $anime): bool
     {
         $attached = AnimeSeries::query()
-            ->where($anime->getKeyName(), $anime->getKey())
-            ->where($series->getKeyName(), $series->getKey())
+            ->where(AnimeSeries::ATTRIBUTE_SERIES, $series->getKey())
+            ->where(AnimeSeries::ATTRIBUTE_ANIME, $anime->getKey())
             ->exists();
 
         return !$attached && $user->can(CrudPermission::UPDATE->format(Series::class));
     }
 
     /**
-     * Determine whether the user can detach an anime from the series.
+     * Determine whether the user can detach any anime from the series.
      *
      * @param  User  $user
      * @return bool
      */
-    public function detachAnime(User $user): bool
+    public function detachAnyAnime(User $user): bool
     {
         return $user->can(CrudPermission::UPDATE->format(Series::class));
+    }
+
+    /**
+     * Determine whether the user can detach an anime from the series.
+     *
+     * @param  User  $user
+     * @param  Series  $series
+     * @param  Anime  $anime
+     * @return bool
+     */
+    public function detachAnime(User $user, Series $series, Anime $anime): bool
+    {
+        $attached = AnimeSeries::query()
+            ->where(AnimeSeries::ATTRIBUTE_SERIES, $series->getKey())
+            ->where(AnimeSeries::ATTRIBUTE_ANIME, $anime->getKey())
+            ->exists();
+
+        return $attached && $user->can(CrudPermission::UPDATE->format(Series::class));
     }
 }

--- a/app/Policies/Wiki/SongPolicy.php
+++ b/app/Policies/Wiki/SongPolicy.php
@@ -6,7 +6,11 @@ namespace App\Policies\Wiki;
 
 use App\Enums\Auth\CrudPermission;
 use App\Models\Auth\User;
+use App\Models\Wiki\Artist;
+use App\Models\Wiki\ExternalResource;
 use App\Models\Wiki\Song;
+use App\Pivots\Wiki\ArtistSong;
+use App\Pivots\Wiki\SongResource;
 use App\Policies\BasePolicy;
 
 /**
@@ -14,17 +18,6 @@ use App\Policies\BasePolicy;
  */
 class SongPolicy extends BasePolicy
 {
-    /**
-     * Determine whether the user can add a theme to the song.
-     *
-     * @param  User  $user
-     * @return bool
-     */
-    public function addAnimeTheme(User $user): bool
-    {
-        return $user->can(CrudPermission::UPDATE->format(Song::class));
-    }
-
     /**
      * Determine whether the user can attach any artist to the song.
      *
@@ -40,9 +33,27 @@ class SongPolicy extends BasePolicy
      * Determine whether the user can attach an artist to the song.
      *
      * @param  User  $user
+     * @param  Song  $song
+     * @param  Artist  $artist
      * @return bool
      */
-    public function attachArtist(User $user): bool
+    public function attachArtist(User $user, Song $song, Artist $artist): bool
+    {
+        $attached = ArtistSong::query()
+            ->where(ArtistSong::ATTRIBUTE_SONG, $song->getKey())
+            ->where(ArtistSong::ATTRIBUTE_ARTIST, $artist->getKey())
+            ->exists();
+
+        return !$attached && $user->can(CrudPermission::UPDATE->format(Song::class));
+    }
+
+    /**
+     * Determine whether the user can detach any artist from the song.
+     *
+     * @param  User  $user
+     * @return bool
+     */
+    public function detachAnyArtist(User $user): bool
     {
         return $user->can(CrudPermission::UPDATE->format(Song::class));
     }
@@ -51,9 +62,27 @@ class SongPolicy extends BasePolicy
      * Determine whether the user can detach an artist from the song.
      *
      * @param  User  $user
+     * @param  Song  $song
+     * @param  Artist  $artist
      * @return bool
      */
-    public function detachArtist(User $user): bool
+    public function detachArtist(User $user, Song $song, Artist $artist): bool
+    {
+        $attached = ArtistSong::query()
+            ->where(ArtistSong::ATTRIBUTE_SONG, $song->getKey())
+            ->where(ArtistSong::ATTRIBUTE_ARTIST, $artist->getKey())
+            ->exists();
+
+        return $attached && $user->can(CrudPermission::UPDATE->format(Song::class));
+    }
+
+    /**
+     * Determine whether the user can add a theme to the song.
+     *
+     * @param  User  $user
+     * @return bool
+     */
+    public function addAnimeTheme(User $user): bool
     {
         return $user->can(CrudPermission::UPDATE->format(Song::class));
     }
@@ -73,9 +102,27 @@ class SongPolicy extends BasePolicy
      * Determine whether the user can attach a resource to the song.
      *
      * @param  User  $user
+     * @param  Song  $song
+     * @param  ExternalResource  $resource
      * @return bool
      */
-    public function attachExternalResource(User $user): bool
+    public function attachExternalResource(User $user, Song $song, ExternalResource $resource): bool
+    {
+        $attached = SongResource::query()
+            ->where(SongResource::ATTRIBUTE_SONG, $song->getKey())
+            ->where(SongResource::ATTRIBUTE_RESOURCE, $resource->getKey())
+            ->exists();
+
+        return !$attached && $user->can(CrudPermission::UPDATE->format(Song::class));
+    }
+
+    /**
+     * Determine whether the user can detach any resource from the song.
+     *
+     * @param  User  $user
+     * @return bool
+     */
+    public function detachAnyExternalResource(User $user): bool
     {
         return $user->can(CrudPermission::UPDATE->format(Song::class));
     }
@@ -84,10 +131,17 @@ class SongPolicy extends BasePolicy
      * Determine whether the user can detach a resource from the song.
      *
      * @param  User  $user
+     * @param  Song  $song
+     * @param  ExternalResource  $resource
      * @return bool
      */
-    public function detachExternalResource(User $user): bool
+    public function detachExternalResource(User $user, Song $song, ExternalResource $resource): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Song::class));
+        $attached = SongResource::query()
+            ->where(SongResource::ATTRIBUTE_SONG, $song->getKey())
+            ->where(SongResource::ATTRIBUTE_RESOURCE, $resource->getKey())
+            ->exists();
+
+        return $attached && $user->can(CrudPermission::UPDATE->format(Song::class));
     }
 }

--- a/app/Policies/Wiki/SongPolicy.php
+++ b/app/Policies/Wiki/SongPolicy.php
@@ -6,6 +6,7 @@ namespace App\Policies\Wiki;
 
 use App\Enums\Auth\CrudPermission;
 use App\Models\Auth\User;
+use App\Models\Wiki\Anime\AnimeTheme;
 use App\Models\Wiki\Artist;
 use App\Models\Wiki\ExternalResource;
 use App\Models\Wiki\Song;
@@ -26,7 +27,7 @@ class SongPolicy extends BasePolicy
      */
     public function attachAnyArtist(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Song::class));
+        return $user->can(CrudPermission::CREATE->format(Song::class)) && $user->can(CrudPermission::CREATE->format(Artist::class));
     }
 
     /**
@@ -44,7 +45,9 @@ class SongPolicy extends BasePolicy
             ->where(ArtistSong::ATTRIBUTE_ARTIST, $artist->getKey())
             ->exists();
 
-        return !$attached && $user->can(CrudPermission::UPDATE->format(Song::class));
+        return !$attached
+            && $user->can(CrudPermission::CREATE->format(Song::class))
+            && $user->can(CrudPermission::CREATE->format(Artist::class));
     }
 
     /**
@@ -55,25 +58,7 @@ class SongPolicy extends BasePolicy
      */
     public function detachAnyArtist(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Song::class));
-    }
-
-    /**
-     * Determine whether the user can detach an artist from the song.
-     *
-     * @param  User  $user
-     * @param  Song  $song
-     * @param  Artist  $artist
-     * @return bool
-     */
-    public function detachArtist(User $user, Song $song, Artist $artist): bool
-    {
-        $attached = ArtistSong::query()
-            ->where(ArtistSong::ATTRIBUTE_SONG, $song->getKey())
-            ->where(ArtistSong::ATTRIBUTE_ARTIST, $artist->getKey())
-            ->exists();
-
-        return $attached && $user->can(CrudPermission::UPDATE->format(Song::class));
+        return $user->can(CrudPermission::DELETE->format(Song::class)) && $user->can(CrudPermission::DELETE->format(Artist::class));
     }
 
     /**
@@ -84,7 +69,7 @@ class SongPolicy extends BasePolicy
      */
     public function addAnimeTheme(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Song::class));
+        return $user->can(CrudPermission::UPDATE->format(AnimeTheme::class));
     }
 
     /**
@@ -95,7 +80,7 @@ class SongPolicy extends BasePolicy
      */
     public function attachAnyExternalResource(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Song::class));
+        return $user->can(CrudPermission::CREATE->format(Song::class)) && $user->can(CrudPermission::CREATE->format(ExternalResource::class));
     }
 
     /**
@@ -113,7 +98,9 @@ class SongPolicy extends BasePolicy
             ->where(SongResource::ATTRIBUTE_RESOURCE, $resource->getKey())
             ->exists();
 
-        return !$attached && $user->can(CrudPermission::UPDATE->format(Song::class));
+        return !$attached
+            && $user->can(CrudPermission::CREATE->format(Song::class))
+            && $user->can(CrudPermission::CREATE->format(ExternalResource::class));
     }
 
     /**
@@ -124,24 +111,6 @@ class SongPolicy extends BasePolicy
      */
     public function detachAnyExternalResource(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Song::class));
-    }
-
-    /**
-     * Determine whether the user can detach a resource from the song.
-     *
-     * @param  User  $user
-     * @param  Song  $song
-     * @param  ExternalResource  $resource
-     * @return bool
-     */
-    public function detachExternalResource(User $user, Song $song, ExternalResource $resource): bool
-    {
-        $attached = SongResource::query()
-            ->where(SongResource::ATTRIBUTE_SONG, $song->getKey())
-            ->where(SongResource::ATTRIBUTE_RESOURCE, $resource->getKey())
-            ->exists();
-
-        return $attached && $user->can(CrudPermission::UPDATE->format(Song::class));
+        return $user->can(CrudPermission::DELETE->format(Song::class)) && $user->can(CrudPermission::DELETE->format(ExternalResource::class));
     }
 }

--- a/app/Policies/Wiki/StudioPolicy.php
+++ b/app/Policies/Wiki/StudioPolicy.php
@@ -28,7 +28,7 @@ class StudioPolicy extends BasePolicy
      */
     public function attachAnyAnime(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Studio::class));
+        return $user->can(CrudPermission::CREATE->format(Studio::class)) && $user->can(CrudPermission::CREATE->format(Anime::class));
     }
 
     /**
@@ -46,7 +46,9 @@ class StudioPolicy extends BasePolicy
             ->where(AnimeStudio::ATTRIBUTE_ANIME, $anime->getKey())
             ->exists();
 
-        return !$attached && $user->can(CrudPermission::UPDATE->format(Studio::class));
+        return !$attached
+            && $user->can(CrudPermission::CREATE->format(Studio::class))
+            && $user->can(CrudPermission::CREATE->format(Anime::class));
     }
 
     /**
@@ -57,25 +59,7 @@ class StudioPolicy extends BasePolicy
      */
     public function detachAnyAnime(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Studio::class));
-    }
-
-    /**
-     * Determine whether the user can detach an anime from the studio.
-     *
-     * @param  User  $user
-     * @param  Studio  $studio
-     * @param  Anime  $anime
-     * @return bool
-     */
-    public function detachAnime(User $user, Studio $studio, Anime $anime): bool
-    {
-        $attached = AnimeStudio::query()
-            ->where(AnimeStudio::ATTRIBUTE_STUDIO, $studio->getKey())
-            ->where(AnimeStudio::ATTRIBUTE_ANIME, $anime->getKey())
-            ->exists();
-
-        return $attached && $user->can(CrudPermission::UPDATE->format(Studio::class));
+        return $user->can(CrudPermission::DELETE->format(Studio::class)) && $user->can(CrudPermission::DELETE->format(Anime::class));
     }
 
     /**
@@ -86,7 +70,7 @@ class StudioPolicy extends BasePolicy
      */
     public function attachAnyExternalResource(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Studio::class));
+        return $user->can(CrudPermission::CREATE->format(Studio::class)) && $user->can(CrudPermission::CREATE->format(ExternalResource::class));
     }
 
     /**
@@ -104,7 +88,9 @@ class StudioPolicy extends BasePolicy
             ->where(StudioResource::ATTRIBUTE_RESOURCE, $resource->getKey())
             ->exists();
 
-        return !$attached && $user->can(CrudPermission::UPDATE->format(Studio::class));
+        return !$attached
+            && $user->can(CrudPermission::CREATE->format(Studio::class))
+            && $user->can(CrudPermission::CREATE->format(ExternalResource::class));
     }
 
     /**
@@ -115,25 +101,7 @@ class StudioPolicy extends BasePolicy
      */
     public function detachAnyExternalResource(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Studio::class));
-    }
-
-    /**
-     * Determine whether the user can detach a resource from the studio.
-     *
-     * @param  User  $user
-     * @param  Studio  $studio
-     * @param  ExternalResource  $resource
-     * @return bool
-     */
-    public function detachExternalResource(User $user, Studio $studio, ExternalResource $resource): bool
-    {
-        $attached = StudioResource::query()
-            ->where(StudioResource::ATTRIBUTE_STUDIO, $studio->getKey())
-            ->where(StudioResource::ATTRIBUTE_RESOURCE, $resource->getKey())
-            ->exists();
-
-        return $attached && $user->can(CrudPermission::UPDATE->format(Studio::class));
+        return $user->can(CrudPermission::DELETE->format(Studio::class)) && $user->can(CrudPermission::DELETE->format(ExternalResource::class));
     }
 
     /**
@@ -144,7 +112,7 @@ class StudioPolicy extends BasePolicy
      */
     public function attachAnyImage(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Studio::class));
+        return $user->can(CrudPermission::CREATE->format(Studio::class)) && $user->can(CrudPermission::CREATE->format(Image::class));
     }
 
     /**
@@ -162,7 +130,9 @@ class StudioPolicy extends BasePolicy
             ->where(StudioImage::ATTRIBUTE_IMAGE, $image->getKey())
             ->exists();
 
-        return !$attached && $user->can(CrudPermission::UPDATE->format(Studio::class));
+        return !$attached
+            && $user->can(CrudPermission::CREATE->format(Studio::class))
+            && $user->can(CrudPermission::CREATE->format(Image::class));
     }
 
     /**
@@ -173,24 +143,6 @@ class StudioPolicy extends BasePolicy
      */
     public function detachAnyImage(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Studio::class));
-    }
-
-    /**
-     * Determine whether the user can detach an image from the studio.
-     *
-     * @param  User  $user
-     * @param  Studio  $studio
-     * @param  Image  $image
-     * @return bool
-     */
-    public function detachImage(User $user, Studio $studio, Image $image): bool
-    {
-        $attached = StudioImage::query()
-            ->where(StudioImage::ATTRIBUTE_STUDIO, $studio->getKey())
-            ->where(StudioImage::ATTRIBUTE_IMAGE, $image->getKey())
-            ->exists();
-
-        return $attached && $user->can(CrudPermission::UPDATE->format(Studio::class));
+        return $user->can(CrudPermission::DELETE->format(Studio::class)) && $user->can(CrudPermission::DELETE->format(Image::class));
     }
 }

--- a/app/Policies/Wiki/StudioPolicy.php
+++ b/app/Policies/Wiki/StudioPolicy.php
@@ -7,10 +7,12 @@ namespace App\Policies\Wiki;
 use App\Enums\Auth\CrudPermission;
 use App\Models\Auth\User;
 use App\Models\Wiki\Anime;
+use App\Models\Wiki\ExternalResource;
 use App\Models\Wiki\Image;
 use App\Models\Wiki\Studio;
 use App\Pivots\Wiki\AnimeStudio;
 use App\Pivots\Wiki\StudioImage;
+use App\Pivots\Wiki\StudioResource;
 use App\Policies\BasePolicy;
 
 /**
@@ -40,22 +42,40 @@ class StudioPolicy extends BasePolicy
     public function attachAnime(User $user, Studio $studio, Anime $anime): bool
     {
         $attached = AnimeStudio::query()
-            ->where($anime->getKeyName(), $anime->getKey())
-            ->where($studio->getKeyName(), $studio->getKey())
+            ->where(AnimeStudio::ATTRIBUTE_STUDIO, $studio->getKey())
+            ->where(AnimeStudio::ATTRIBUTE_ANIME, $anime->getKey())
             ->exists();
 
         return !$attached && $user->can(CrudPermission::UPDATE->format(Studio::class));
     }
 
     /**
-     * Determine whether the user can detach an anime from the studio.
+     * Determine whether the user can detach any anime from the studio.
      *
      * @param  User  $user
      * @return bool
      */
-    public function detachAnime(User $user): bool
+    public function detachAnyAnime(User $user): bool
     {
         return $user->can(CrudPermission::UPDATE->format(Studio::class));
+    }
+
+    /**
+     * Determine whether the user can detach an anime from the studio.
+     *
+     * @param  User  $user
+     * @param  Studio  $studio
+     * @param  Anime  $anime
+     * @return bool
+     */
+    public function detachAnime(User $user, Studio $studio, Anime $anime): bool
+    {
+        $attached = AnimeStudio::query()
+            ->where(AnimeStudio::ATTRIBUTE_STUDIO, $studio->getKey())
+            ->where(AnimeStudio::ATTRIBUTE_ANIME, $anime->getKey())
+            ->exists();
+
+        return $attached && $user->can(CrudPermission::UPDATE->format(Studio::class));
     }
 
     /**
@@ -73,9 +93,27 @@ class StudioPolicy extends BasePolicy
      * Determine whether the user can attach a resource to the studio.
      *
      * @param  User  $user
+     * @param  Studio  $studio
+     * @param  ExternalResource  $resource
      * @return bool
      */
-    public function attachExternalResource(User $user): bool
+    public function attachExternalResource(User $user, Studio $studio, ExternalResource $resource): bool
+    {
+        $attached = StudioResource::query()
+            ->where(StudioResource::ATTRIBUTE_STUDIO, $studio->getKey())
+            ->where(StudioResource::ATTRIBUTE_RESOURCE, $resource->getKey())
+            ->exists();
+
+        return !$attached && $user->can(CrudPermission::UPDATE->format(Studio::class));
+    }
+
+    /**
+     * Determine whether the user can detach any resource from the studio.
+     *
+     * @param  User  $user
+     * @return bool
+     */
+    public function detachAnyExternalResource(User $user): bool
     {
         return $user->can(CrudPermission::UPDATE->format(Studio::class));
     }
@@ -84,11 +122,18 @@ class StudioPolicy extends BasePolicy
      * Determine whether the user can detach a resource from the studio.
      *
      * @param  User  $user
+     * @param  Studio  $studio
+     * @param  ExternalResource  $resource
      * @return bool
      */
-    public function detachExternalResource(User $user): bool
+    public function detachExternalResource(User $user, Studio $studio, ExternalResource $resource): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Studio::class));
+        $attached = StudioResource::query()
+            ->where(StudioResource::ATTRIBUTE_STUDIO, $studio->getKey())
+            ->where(StudioResource::ATTRIBUTE_RESOURCE, $resource->getKey())
+            ->exists();
+
+        return $attached && $user->can(CrudPermission::UPDATE->format(Studio::class));
     }
 
     /**
@@ -113,21 +158,39 @@ class StudioPolicy extends BasePolicy
     public function attachImage(User $user, Studio $studio, Image $image): bool
     {
         $attached = StudioImage::query()
-            ->where($studio->getKeyName(), $studio->getKey())
-            ->where($image->getKeyName(), $image->getKey())
+            ->where(StudioImage::ATTRIBUTE_STUDIO, $studio->getKey())
+            ->where(StudioImage::ATTRIBUTE_IMAGE, $image->getKey())
             ->exists();
 
         return !$attached && $user->can(CrudPermission::UPDATE->format(Studio::class));
     }
 
     /**
-     * Determine whether the user can detach an image from the studio.
+     * Determine whether the user can detach any image from the studio.
      *
      * @param  User  $user
      * @return bool
      */
-    public function detachImage(User $user): bool
+    public function detachAnyImage(User $user): bool
     {
         return $user->can(CrudPermission::UPDATE->format(Studio::class));
+    }
+
+    /**
+     * Determine whether the user can detach an image from the studio.
+     *
+     * @param  User  $user
+     * @param  Studio  $studio
+     * @param  Image  $image
+     * @return bool
+     */
+    public function detachImage(User $user, Studio $studio, Image $image): bool
+    {
+        $attached = StudioImage::query()
+            ->where(StudioImage::ATTRIBUTE_STUDIO, $studio->getKey())
+            ->where(StudioImage::ATTRIBUTE_IMAGE, $image->getKey())
+            ->exists();
+
+        return $attached && $user->can(CrudPermission::UPDATE->format(Studio::class));
     }
 }

--- a/app/Policies/Wiki/VideoPolicy.php
+++ b/app/Policies/Wiki/VideoPolicy.php
@@ -25,7 +25,7 @@ class VideoPolicy extends BasePolicy
      */
     public function attachAnyAnimeThemeEntry(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Video::class));
+        return $user->can(CrudPermission::CREATE->format(Video::class)) && $user->can(CrudPermission::CREATE->format(AnimeThemeEntry::class));
     }
 
     /**
@@ -43,36 +43,20 @@ class VideoPolicy extends BasePolicy
             ->where(AnimeThemeEntryVideo::ATTRIBUTE_ENTRY, $entry->getKey())
             ->exists();
 
-        return !$attached && $user->can(CrudPermission::UPDATE->format(Video::class));
+        return !$attached
+            && $user->can(CrudPermission::CREATE->format(Video::class))
+            && $user->can(CrudPermission::CREATE->format(AnimeThemeEntry::class));
     }
 
     /**
-     * Determine whether the user can detach an entry from a video.
+     * Determine whether the user can detach any entry from a video.
      *
      * @param  User  $user
      * @return bool
      */
     public function detachAnyAnimeThemeEntry(User $user): bool
     {
-        return $user->can(CrudPermission::UPDATE->format(Video::class));
-    }
-
-    /**
-     * Determine whether the user can detach an entry from a video.
-     *
-     * @param  User  $user
-     * @param  Video  $video
-     * @param  AnimeThemeEntry  $entry
-     * @return bool
-     */
-    public function detachAnimeThemeEntry(User $user, Video $video, AnimeThemeEntry $entry): bool
-    {
-        $attached = AnimeThemeEntryVideo::query()
-            ->where(AnimeThemeEntryVideo::ATTRIBUTE_VIDEO, $video->getKey())
-            ->where(AnimeThemeEntryVideo::ATTRIBUTE_ENTRY, $entry->getKey())
-            ->exists();
-
-        return $attached && $user->can(CrudPermission::UPDATE->format(Video::class));
+        return $user->can(CrudPermission::DELETE->format(Video::class)) && $user->can(CrudPermission::DELETE->format(AnimeThemeEntry::class));
     }
 
     /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -160,7 +160,7 @@ if (! function_exists('apiResourceUri')) {
                 ->append('}');
         }
 
-        return $uri->toString();
+        return $uri->__toString();
     }
 }
 
@@ -218,7 +218,7 @@ if (! function_exists('apiPivotResourceUri')) {
             ->append('}/{')
             ->append($foreign)
             ->append('}')
-            ->toString();
+            ->__toString();
     }
 }
 

--- a/tests/Feature/Http/Api/Pivot/List/PlaylistImage/PlaylistImageStoreTest.php
+++ b/tests/Feature/Http/Api/Pivot/List/PlaylistImage/PlaylistImageStoreTest.php
@@ -107,7 +107,6 @@ class PlaylistImageStoreTest extends TestCase
 
         Feature::activate(AllowPlaylistManagement::class);
 
-        $playlist = Playlist::factory()->createOne();
         $image = Image::factory()->createOne();
 
         $user = User::factory()
@@ -115,6 +114,10 @@ class PlaylistImageStoreTest extends TestCase
                 CrudPermission::CREATE->format(Playlist::class),
                 CrudPermission::CREATE->format(Image::class)
             )
+            ->createOne();
+
+        $playlist = Playlist::factory()
+            ->for($user)
             ->createOne();
 
         Sanctum::actingAs($user);
@@ -137,7 +140,6 @@ class PlaylistImageStoreTest extends TestCase
 
         Feature::activate(AllowPlaylistManagement::class, $this->faker->boolean());
 
-        $playlist = Playlist::factory()->createOne();
         $image = Image::factory()->createOne();
 
         $user = User::factory()
@@ -146,6 +148,10 @@ class PlaylistImageStoreTest extends TestCase
                 CrudPermission::CREATE->format(Image::class),
                 SpecialPermission::BYPASS_FEATURE_FLAGS->value
             )
+            ->createOne();
+
+        $playlist = Playlist::factory()
+            ->for($user)
             ->createOne();
 
         Sanctum::actingAs($user);


### PR DESCRIPTION
Filament and API now use the same policies methods to validate pivot management. This way, the pivot validation is more customizable than just checking foreign and related policies.