### PR TITLE
chore!: database changes part 2

### DIFF
--- a/app/Filament/Actions/Storage/Wiki/Video/UploadVideoAction.php
+++ b/app/Filament/Actions/Storage/Wiki/Video/UploadVideoAction.php
@@ -122,8 +122,7 @@ class UploadVideoAction extends UploadAction
                                         Select::make(Video::ATTRIBUTE_SOURCE)
                                             ->label(__('filament.fields.video.source.name'))
                                             ->helperText(__('filament.fields.video.source.help'))
-                                            ->options(VideoSource::class)
-                                            ->required(),
+                                            ->options(VideoSource::class),
                                     ]),
 
                                 Section::make(__('filament.resources.singularLabel.video_script'))

--- a/app/Filament/Resources/Wiki/Anime/Theme/Entry.php
+++ b/app/Filament/Resources/Wiki/Anime/Theme/Entry.php
@@ -137,7 +137,9 @@ class Entry extends BaseResource
                 TextInput::make(EntryModel::ATTRIBUTE_VERSION)
                     ->label(__('filament.fields.anime_theme_entry.version.name'))
                     ->helperText(__('filament.fields.anime_theme_entry.version.help'))
-                    ->integer(),
+                    ->default(1)
+                    ->integer()
+                    ->required(),
 
                 TextInput::make(EntryModel::ATTRIBUTE_EPISODES)
                     ->label(__('filament.fields.anime_theme_entry.episodes.name'))

--- a/app/Filament/Resources/Wiki/Video.php
+++ b/app/Filament/Resources/Wiki/Video.php
@@ -113,13 +113,13 @@ class Video extends BaseResource
                 Select::make(VideoModel::ATTRIBUTE_OVERLAP)
                     ->label(__('filament.fields.video.overlap.name'))
                     ->helperText(__('filament.fields.video.overlap.help'))
-                    ->options(VideoOverlap::class),
+                    ->options(VideoOverlap::class)
+                    ->required(),
 
                 Select::make(VideoModel::ATTRIBUTE_SOURCE)
                     ->label(__('filament.fields.video.source.name'))
                     ->helperText(__('filament.fields.video.source.help'))
-                    ->options(VideoSource::class)
-                    ->required(),
+                    ->options(VideoSource::class),
 
                 Select::make(VideoModel::ATTRIBUTE_AUDIO)
                     ->label(__('filament.resources.singularLabel.audio'))

--- a/app/GraphQL/Schema/Fields/Wiki/Anime/Theme/Entry/AnimeThemeEntryVersionField.php
+++ b/app/GraphQL/Schema/Fields/Wiki/Anime/Theme/Entry/AnimeThemeEntryVersionField.php
@@ -27,7 +27,6 @@ class AnimeThemeEntryVersionField extends IntField implements CreatableField, Up
     public function getCreationRules(array $args): array
     {
         return [
-            'sometimes',
             'required',
             'integer',
             'min:0',

--- a/app/Http/Api/Field/Admin/Announcement/AnnouncementEndAtField.php
+++ b/app/Http/Api/Field/Admin/Announcement/AnnouncementEndAtField.php
@@ -11,7 +11,6 @@ use App\Http\Api\Field\DateField;
 use App\Http\Api\Query\Query;
 use App\Http\Api\Schema\Schema;
 use App\Models\Admin\Announcement;
-use App\Models\Admin\FeaturedTheme;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 

--- a/app/Http/Api/Field/List/ExternalProfile/ExternalProfileVisibilityField.php
+++ b/app/Http/Api/Field/List/ExternalProfile/ExternalProfileVisibilityField.php
@@ -23,7 +23,6 @@ class ExternalProfileVisibilityField extends EnumField implements CreatableField
     public function getCreationRules(Request $request): array
     {
         return [
-            'sometimes',
             'required',
             new Enum(ExternalProfileVisibility::class),
         ];

--- a/app/Http/Api/Field/Wiki/Anime/Theme/Entry/EntryVersionField.php
+++ b/app/Http/Api/Field/Wiki/Anime/Theme/Entry/EntryVersionField.php
@@ -21,7 +21,6 @@ class EntryVersionField extends IntField implements CreatableField, UpdatableFie
     public function getCreationRules(Request $request): array
     {
         return [
-            'sometimes',
             'required',
             'integer',
             'min:0',

--- a/app/Models/Auth/Role.php
+++ b/app/Models/Auth/Role.php
@@ -36,15 +36,6 @@ class Role extends BaseRole implements Nameable
     final public const string RELATION_USERS = 'users';
 
     /**
-     * The model's default values for attributes.
-     *
-     * @var array<string, mixed>
-     */
-    protected $attributes = [
-        Role::ATTRIBUTE_PRIORITY => 0,
-    ];
-
-    /**
      * Get the attributes that should be cast.
      *
      * @return array<string, string>

--- a/app/Models/Wiki/Anime/AnimeSynonym.php
+++ b/app/Models/Wiki/Anime/AnimeSynonym.php
@@ -75,15 +75,6 @@ class AnimeSynonym extends BaseModel implements Auditable, SoftDeletable
     ];
 
     /**
-     * The model's default values for attributes.
-     *
-     * @var array<string, mixed>
-     */
-    protected $attributes = [
-        AnimeSynonym::ATTRIBUTE_TYPE => AnimeSynonymType::OTHER->value,
-    ];
-
-    /**
      * The event map for the model.
      *
      * Allows for object-based events for native Eloquent events.

--- a/app/Models/Wiki/Anime/Theme/AnimeThemeEntry.php
+++ b/app/Models/Wiki/Anime/Theme/AnimeThemeEntry.php
@@ -138,15 +138,6 @@ class AnimeThemeEntry extends BaseModel implements Auditable, HasAggregateLikes,
     ];
 
     /**
-     * The model's default values for attributes.
-     *
-     * @var array<string, mixed>
-     */
-    protected $attributes = [
-        AnimeThemeEntry::ATTRIBUTE_VERSION => 1,
-    ];
-
-    /**
      * Get the attributes that should be cast.
      *
      * @return array<string, string>

--- a/app/Models/Wiki/Song/Performance.php
+++ b/app/Models/Wiki/Song/Performance.php
@@ -100,15 +100,6 @@ class Performance extends BaseModel implements Auditable, SoftDeletable
         Performance::ATTRIBUTE_RELEVANCE,
     ];
 
-    /**
-     * The model's default values for attributes.
-     *
-     * @var array<string, mixed>
-     */
-    protected $attributes = [
-        Performance::ATTRIBUTE_RELEVANCE => 1,
-    ];
-
     public function getName(): string
     {
         return strval($this->getKey());

--- a/app/Models/Wiki/Video.php
+++ b/app/Models/Wiki/Video.php
@@ -160,15 +160,6 @@ class Video extends BaseModel implements Auditable, HasAggregateViews, SoftDelet
     ];
 
     /**
-     * The model's default values for attributes.
-     *
-     * @var array<string, mixed>
-     */
-    protected $attributes = [
-        Video::ATTRIBUTE_OVERLAP => VideoOverlap::NONE->value,
-    ];
-
-    /**
      * Get the attributes that should be cast.
      *
      * @return array<string, string>

--- a/app/Pivots/Morph/Imageable.php
+++ b/app/Pivots/Morph/Imageable.php
@@ -87,15 +87,6 @@ class Imageable extends BaseMorphPivot
     ];
 
     /**
-     * The model's default values for attributes.
-     *
-     * @var array<string, mixed>
-     */
-    protected $attributes = [
-        Imageable::ATTRIBUTE_DEPTH => 1,
-    ];
-
-    /**
      * Get the attributes that should be cast.
      *
      * @return array<string, string>

--- a/app/Pivots/Wiki/ArtistMember.php
+++ b/app/Pivots/Wiki/ArtistMember.php
@@ -73,15 +73,6 @@ class ArtistMember extends BasePivot
     ];
 
     /**
-     * The model's default values for attributes.
-     *
-     * @var array<string, mixed>
-     */
-    protected $attributes = [
-        ArtistMember::ATTRIBUTE_RELEVANCE => 1,
-    ];
-
-    /**
      * Get the composite primary key for the pivot.
      *
      * @return string[]

--- a/database/migrations/2022_05_09_032230_create_permission_tables.php
+++ b/database/migrations/2022_05_09_032230_create_permission_tables.php
@@ -49,7 +49,7 @@ return new class extends Migration
             $table->string('guard_name'); // For MyISAM use string('guard_name', 25);
             $table->boolean('default')->default(false);
             $table->string('color')->nullable();
-            $table->integer('priority');
+            $table->integer('priority')->default(0);
             $table->timestamps();
             if ($teams || config('permission.testing')) {
                 $table->unique([$columnNames['team_foreign_key'], 'name', 'guard_name']);

--- a/database/migrations/2025_08_16_025830_create_imageables_table.php
+++ b/database/migrations/2025_08_16_025830_create_imageables_table.php
@@ -19,7 +19,7 @@ return new class extends Migration
                 $table->foreign('image_id')->references('image_id')->on('images')->cascadeOnDelete();
 
                 $table->morphs('imageable');
-                $table->integer('depth');
+                $table->integer('depth')->default(1);
 
                 $table->timestamps(6);
 

--- a/database/migrations/2025_10_25_033138_add_relevance_to_performances.php
+++ b/database/migrations/2025_10_25_033138_add_relevance_to_performances.php
@@ -15,7 +15,7 @@ return new class extends Migration
     {
         if (! Schema::hasColumn('performances', 'relevance')) {
             Schema::table('performances', function (Blueprint $table) {
-                $table->integer('relevance')->after('as');
+                $table->integer('relevance')->default(1)->after('as');
             });
         }
     }

--- a/database/migrations/2025_10_30_204112_add_relevance_to_artist_members_table.php
+++ b/database/migrations/2025_10_30_204112_add_relevance_to_artist_members_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
     {
         if (! Schema::hasColumn('artist_member', 'relevance')) {
             Schema::table('artist_member', function (Blueprint $table) {
-                $table->integer('relevance')->nullable();
+                $table->integer('relevance')->default(1)->nullable();
             });
         }
     }

--- a/lang/en/filament.php
+++ b/lang/en/filament.php
@@ -562,7 +562,7 @@ return [
                 'name' => 'Spoiler',
             ],
             'version' => [
-                'help' => 'The Version number of the Theme. Can be left blank if there is only one version. Version is only required if there exist at least 2 in the sequence.',
+                'help' => 'The Version number of the Theme.',
                 'name' => 'Version',
             ],
             'youtube' => [


### PR DESCRIPTION
## Database changes:
* `roles.priority` remove default in code, default to 0 on database level
* `external_profiles.visibility` remove default in code, should explicitly choose the value instead
* `anime_synonyms.type` remove default in code, should explicitly choose the value instead
* `anime_theme_entries.version` remove default in code, should explicitly choose the value instead, default to 1 in admin panel
* `imageables.depth` remove default in code, default to 1 on database level
* `performances.relevance` remove default in code, default to 1 on database level
* `artist_member.relevance` remove default in code, default to 1 on database level
* `videos.overlap` remove default in code, should explicitly choose the value instead